### PR TITLE
Move README links to new MatterMiners repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/tardis-resourcemanager/tardis.svg?branch=master)](https://travis-ci.org/tardis-resourcemanager/tardis)
-[![codecov](https://codecov.io/gh/tardis-resourcemanager/tardis/branch/master/graph/badge.svg)](https://codecov.io/gh/tardis-resourcemanager/tardis)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/giffels/tardis/blob/master/LICENSE.txt)
+[![Build Status](https://travis-ci.org/MaterMiners/tardis.svg?branch=master)](https://travis-ci.org/MatterMiners/tardis)
+[![codecov](https://codecov.io/gh/MaterMiners/tardis/branch/master/graph/badge.svg)](https://codecov.io/gh/MatterMiners/tardis)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MatterMiners/tardis/blob/master/LICENSE.txt)
 [![DOI](https://zenodo.org/badge/132791417.svg)](https://zenodo.org/badge/latestdoi/132791417)
 
 # TARDIS Resourcemanager


### PR DESCRIPTION
We moved the repository to the MatterMiners organization. This pull request closes #52.