### PR TITLE
Bug fix htcondor site adapter

### DIFF
--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -74,7 +74,7 @@ class HTCondorAdapter(SiteAdapter):
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())
-        response.update(self.update_timestamps())
+        response.update(self.create_timestamps())
         return self.handle_response(response)
 
     @property
@@ -112,11 +112,10 @@ class HTCondorAdapter(SiteAdapter):
         response = await self._executor.run_command(terminate_command)
         pattern = re.compile(r"^.*?(?P<ClusterId>\d+).*$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())
-        response.update(self.update_timestamps())
         return self.handle_response(response)
 
     @staticmethod
-    def update_timestamps():
+    def create_timestamps():
         now = datetime.now()
         return AttributeDict(created=now, updated=now)
 

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -32,7 +32,7 @@ async def htcondor_queue_updater(executor):
     else:
         for row in htcondor_csv_parser(htcondor_input=condor_queue.stdout, fieldnames=tuple(attributes.keys()),
                                        delimiter='\t', replacements=dict(undefined=None)):
-            htcondor_queue[int(row['ClusterId'])] = row
+            htcondor_queue[row['ClusterId']] = row
         return htcondor_queue
 
 
@@ -57,8 +57,7 @@ class HTCondorAdapter(SiteAdapter):
 
         # HTCondor uses digits to indicate job states and digit as variable names are not allowed in Python, therefore
         # the trick using an expanded htcondor_status_code dictionary is necessary. Somehow ugly.
-        translator_functions = StaticMapping(ClusterId=lambda x: int(x),
-                                             JobStatus=lambda x, translator=StaticMapping(**htcondor_status_codes):
+        translator_functions = StaticMapping(JobStatus=lambda x, translator=StaticMapping(**htcondor_status_codes):
                                              translator[x])
 
         self.handle_response = partial(self.handle_response, key_translator=key_translator,

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -65,7 +65,7 @@ class TestHTCondorSiteAdapter(TestCase):
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
         response = run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
-        self.assertEqual(response.remote_resource_uuid, 1351043)
+        self.assertEqual(response.remote_resource_uuid, "1351043")
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
@@ -84,32 +84,32 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_UNEXANPANDED)
     def test_resource_status_unexpanded(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
     def test_resource_status_run(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_HELD)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUBMISSION_ERR)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
@@ -118,7 +118,7 @@ class TestHTCondorSiteAdapter(TestCase):
         future_timestamp = datetime.now() + timedelta(minutes=1)
         with self.assertRaises(TardisResourceStatusUpdateFailed):
             with self.assertLogs(logging.getLogger(), logging.ERROR):
-                run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043,
+                run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043",
                                                                       created=future_timestamp))
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
@@ -129,19 +129,19 @@ class TestHTCondorSiteAdapter(TestCase):
         past_timestamp = datetime.now() - timedelta(minutes=12)
         self.adapter._htcondor_queue._last_update = datetime.now() - timedelta(minutes=11)
         with self.assertLogs(logging.getLogger(), logging.ERROR):
-            response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043,
+            response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043",
                                                                              created=past_timestamp))
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_stop_resource(self):
-        response = run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid=1351043))
-        self.assertEqual(response.remote_resource_uuid, 1351043)
+        response = run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043"))
+        self.assertEqual(response.remote_resource_uuid, "1351043")
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
-        response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid=1351043))
-        self.assertEqual(response.remote_resource_uuid, 1351043)
+        response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
+        self.assertEqual(response.remote_resource_uuid, "1351043")
 
     def test_exception_handling(self):
         def test_exception_handling(raise_it, catch_it):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -137,15 +137,11 @@ class TestHTCondorSiteAdapter(TestCase):
     def test_stop_resource(self):
         response = run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.remote_resource_uuid, 1351043)
-        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
-        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
         response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.remote_resource_uuid, 1351043)
-        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
-        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
     def test_exception_handling(self):
         def test_exception_handling(raise_it, catch_it):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -65,7 +65,7 @@ class TestHTCondorSiteAdapter(TestCase):
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
         response = run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
-        self.assertEqual(response.resource_id, 1351043)
+        self.assertEqual(response.remote_resource_uuid, 1351043)
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
@@ -84,32 +84,32 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_UNEXANPANDED)
     def test_resource_status_unexpanded(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
     def test_resource_status_run(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_HELD)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUBMISSION_ERR)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
@@ -118,7 +118,7 @@ class TestHTCondorSiteAdapter(TestCase):
         future_timestamp = datetime.now() + timedelta(minutes=1)
         with self.assertRaises(TardisResourceStatusUpdateFailed):
             with self.assertLogs(logging.getLogger(), logging.ERROR):
-                run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043,
+                run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043,
                                                                       created=future_timestamp))
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
@@ -129,21 +129,21 @@ class TestHTCondorSiteAdapter(TestCase):
         past_timestamp = datetime.now() - timedelta(minutes=12)
         self.adapter._htcondor_queue._last_update = datetime.now() - timedelta(minutes=11)
         with self.assertLogs(logging.getLogger(), logging.ERROR):
-            response = run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043,
+            response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid=1351043,
                                                                              created=past_timestamp))
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_stop_resource(self):
-        response = run_async(self.adapter.stop_resource, AttributeDict(resource_id=1351043))
-        self.assertEqual(response.resource_id, 1351043)
+        response = run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid=1351043))
+        self.assertEqual(response.remote_resource_uuid, 1351043)
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
-        response = run_async(self.adapter.terminate_resource, AttributeDict(resource_id=1351043))
-        self.assertEqual(response.resource_id, 1351043)
+        response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid=1351043))
+        self.assertEqual(response.remote_resource_uuid, 1351043)
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 


### PR DESCRIPTION
This pull fixes the following bugs, which led to crashes in case state is restored from persistent drone registry #59:
- Change `resource_id` to `remote_resource_uuid`, since `resource_id` has been deprecated recently.
- Handle `remote_resource_uuid` as a string instead of a int

In addition, the following problem was fixed as well
- Do not update created timestamp after deployment of a resource
