### PR TITLE
Added all drone meta data as environment variables for the condor submit

### DIFF
--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -68,9 +68,11 @@ class HTCondorAdapter(SiteAdapter):
 
     async def deploy_resource(self, resource_attributes):
         submit_jdl = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
-        drone_resources = ";".join([f'TardisDrone{resource}={self.machine_meta_data[resource]}' for resource in self.machine_meta_data])
-        submit_command = \
-            f'condor_submit -append "environment = TardisDroneUuid={resource_attributes.drone_uuid};{drone_resources}" {submit_jdl}'
+        drone_resources = ";".join(
+            [f'TardisDrone{resource}={self.machine_meta_data[resource]}' for resource in self.machine_meta_data])
+        submit_command = (
+            f'condor_submit '
+            f'-append "environment = TardisDroneUuid={resource_attributes.drone_uuid};{drone_resources}" {submit_jdl}')
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -68,8 +68,9 @@ class HTCondorAdapter(SiteAdapter):
 
     async def deploy_resource(self, resource_attributes):
         submit_jdl = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
+        drone_resources = ";".join([f'TardisDrone{resource}={self.machine_meta_data[resource]}' for resource in self.machine_meta_data])
         submit_command = \
-            f'condor_submit -append "environment = TardisDroneUuid={resource_attributes.drone_uuid}" {submit_jdl}'
+            f'condor_submit -append "environment = TardisDroneUuid={resource_attributes.drone_uuid};{drone_resources}" {submit_jdl}'
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -70,7 +70,7 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            'condor_submit -append "environment = TardisDroneUuid=test-123" submit.jdl')
+            'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32" submit.jdl')
         self.mock_executor.reset()
 
     def test_machine_meta_data(self):


### PR DESCRIPTION
This commit adds environment variables for all values provided as the MachineMetaData to the condor submission in the htcondor site-adapter. The Environment variables follow the pattern "TardisDrone{Resource}".
This pull request addresses issue #61 