### PR TITLE
Enabling stdin for executors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,17 @@ ENV/
 
 # test database
 tests/plugins_t/test.db
+
+# test scripts
+test_scripts/
+
+# Ignore drone registry
+*.db
+
+# Ignore configurations
+cobald.yml
+faketardis.yml
+tardis.yml
+
+#Ignore cloudinit files
+cloudinit/

--- a/tardis/exceptions/executorexceptions.py
+++ b/tardis/exceptions/executorexceptions.py
@@ -1,9 +1,11 @@
 class CommandExecutionFailure(Exception):
-    def __init__(self, message: str, exit_code: int = None, stdout: str = None, stderr: str = None):
+    def __init__(self, message: str, exit_code: int = None, stdout: str = None, stderr: str = None, stdin: str = None):
         self.message = message
         self.exit_code = exit_code
         self.stdout = stdout
         self.stderr = stderr
+        self.stdin = stdin
 
     def __str__(self):
-        return f"(message={self.message}, exit_code={self.exit_code}, stdout={self.stdout}, stderr= {self.stderr})"
+        return f"(message={self.message}, exit_code={self.exit_code}, stdout={self.stdout}, " \
+            f"stderr={self.stderr}, stdin={self.stdin})"

--- a/tardis/utilities/executors/shellexecutor.py
+++ b/tardis/utilities/executors/shellexecutor.py
@@ -11,16 +11,21 @@ class ShellExecutor(Executor):
     def __init__(self, *args, **kwargs):
         pass
 
-    async def run_command(self, command):
-        sub_process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE,
+    async def run_command(self, command, stdin_input=None):
+        sub_process = await asyncio.create_subprocess_shell(command,
+                                                            stdin=stdin_input and asyncio.subprocess.PIPE,
+                                                            stdout=asyncio.subprocess.PIPE,
                                                             stderr=asyncio.subprocess.PIPE)
 
-        stdout, stderr = await sub_process.communicate()
+        stdout, stderr = await sub_process.communicate(stdin_input and stdin_input.encode())
         exit_code = sub_process.returncode
 
         if exit_code:
             raise CommandExecutionFailure(message=f"Run command {command} via ShellExecutor failed",
-                                          exit_code=exit_code, stdout=stdout, stderr=stderr)
+                                          exit_code=exit_code,
+                                          stdout=stdout.decode().strip(),
+                                          stderr=stderr.decode().strip(),
+                                          stdin=stdin_input)
 
         return AttributeDict(stdout=stdout.decode().strip(), stderr=stderr.decode().strip(),
                              exit_code=exit_code)

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -11,12 +11,15 @@ class SSHExecutor(Executor):
     def __init__(self, **parameters):
         self._parameters = parameters
 
-    async def run_command(self, command):
+    async def run_command(self, command, stdin_input=None):
         async with asyncssh.connect(**self._parameters) as conn:
             try:
-                response = await conn.run(command, check=True)
+                response = await conn.run(command, check=True, input=stdin_input and stdin_input.encode())
             except asyncssh.ProcessError as pe:
                 raise CommandExecutionFailure(message=f"Run command {command} via SSHExecutor failed",
-                                              exit_code=pe.exit_status, stdout=pe.stdout, stderr=pe.stderr) from pe
+                                              exit_code=pe.exit_status,
+                                              stdin=stdin_input,
+                                              stdout=pe.stdout,
+                                              stderr=pe.stderr) from pe
             else:
                 return AttributeDict(stdout=response.stdout, stderr=response.stderr, exit_code=response.exit_status)

--- a/tests/utilities_t/executors_t/test_shellexecutor.py
+++ b/tests/utilities_t/executors_t/test_shellexecutor.py
@@ -23,6 +23,9 @@ class TestAsyncRunCommand(TestCase):
 
         self.assertEqual(run_async(self.executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test")
 
+        self.assertEqual(run_async(self.executor.run_command, 'read test; echo $test',
+                                   stdin_input="Test").stdout, "Test")
+
     def test_construction_by_yaml(self):
         executor = yaml.safe_load("""
                       !ShellExecutor

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -1,6 +1,9 @@
 from tests.utilities.utilities import run_async
 from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.executors.sshexecutor import SSHExecutor
+from tardis.exceptions.executorexceptions import CommandExecutionFailure
+
+from asyncssh import ProcessError
 
 try:
     from contextlib import asynccontextmanager
@@ -13,20 +16,19 @@ from unittest.mock import patch
 import yaml
 
 
-def generate_connect(response):
+def generate_connect(response, exception=None):
     @asynccontextmanager
     async def connect(*args, **kwargs):
         class Connection(object):
-            async def run(self, *args, **kwargs):
+            async def run(self, *args, input, **kwargs):
+                if exception:
+                    raise exception
+                self.stdout = input and input.decode()
                 return self
 
             @property
             def exit_status(self):
                 return response.exit_status
-
-            @property
-            def stdout(self):
-                return response.stdout
 
             @property
             def stderr(self):
@@ -40,26 +42,52 @@ class TestSSHExecutor(TestCase):
     def setUpClass(cls):
         cls.mock_asyncssh_patcher = patch('tardis.utilities.executors.sshexecutor.asyncssh')
         cls.mock_asyncssh = cls.mock_asyncssh_patcher.start()
+        cls.mock_asyncssh.ProcessError = ProcessError
 
     @classmethod
     def tearDownClass(cls):
         cls.mock_asyncssh.stop()
 
+    def setUp(self) -> None:
+        self.response = AttributeDict(stderr="", exit_status=0)
+        self.mock_asyncssh.connect.side_effect = generate_connect(self.response)
+        self.mock_asyncssh.reset_mock()
+
     def test_run_command(self):
-        response = AttributeDict(stdout="Test", stderr="", exit_status=0)
         executor = SSHExecutor(host="test_host", username="test", client_keys=["TestKey"])
-        self.mock_asyncssh.connect.side_effect = generate_connect(response)
-        self.assertEqual(run_async(executor.run_command, command="Test").stdout, "Test")
+        self.assertIsNone(run_async(executor.run_command, command="Test").stdout)
         self.mock_asyncssh.connect.assert_called_with(host="test_host", username="test",
                                                       client_keys=["TestKey"])
         self.mock_asyncssh.reset_mock()
 
         executor = SSHExecutor(host="test_host", username="test", client_keys=("TestKey",))
-        self.assertEqual(run_async(executor.run_command, command="Test").stdout, "Test")
+        self.assertIsNone(run_async(executor.run_command, command="Test").stdout)
         self.mock_asyncssh.connect.assert_called_with(host="test_host", username="test",
                                                       client_keys=("TestKey",))
-        self.mock_asyncssh.connect.side_effect = None
+
         self.mock_asyncssh.reset_mock()
+
+        executor = SSHExecutor(host="test_host", username="test", client_keys=("TestKey",))
+        self.assertEqual(run_async(executor.run_command, command="Test", stdin_input="Test").stdout, "Test")
+        self.mock_asyncssh.connect.assert_called_with(host="test_host", username="test",
+                                                      client_keys=("TestKey",))
+
+    def test_run_raises_process_error(self):
+        test_exception = ProcessError(env="Test",
+                                      command="Test",
+                                      subsystem="Test",
+                                      exit_status=1,
+                                      exit_signal=None,
+                                      returncode=1,
+                                      stdout="TestError",
+                                      stderr="TestError")
+
+        self.mock_asyncssh.connect.side_effect = generate_connect(self.response, exception=test_exception)
+
+        executor = SSHExecutor(host="test_host", username="test", client_keys=("TestKey",))
+
+        with self.assertRaises(CommandExecutionFailure):
+            run_async(executor.run_command, command="Test", stdin_input="Test")
 
     def test_construction_by_yaml(self):
         executor = yaml.safe_load("""
@@ -69,10 +97,10 @@ class TestSSHExecutor(TestCase):
                    client_keys:
                     - TestKey
                    """)
-        response = AttributeDict(stdout="Test", stderr="", exit_status=0)
+        response = AttributeDict(stderr="", exit_status=0)
 
         self.mock_asyncssh.connect.side_effect = generate_connect(response)
-        self.assertEqual(run_async(executor.run_command, command="Test").stdout, "Test")
+        self.assertEqual(run_async(executor.run_command, command="Test", stdin_input="Test").stdout, "Test")
         self.mock_asyncssh.connect.assert_called_with(host="test_host", username="test",
                                                       client_keys=["TestKey"])
         self.mock_asyncssh.connect.side_effect = None


### PR DESCRIPTION
Enable input via stdin for executors. Addresses part of #58 