### PR TITLE
Add construction of requested resources from drone meta-data in htcondor site-adapter

### DIFF
--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -48,6 +48,7 @@ htcondor_translate_resources = {'Cores': 'request_cpus',
                                 'Memory': 'request_memory',
                                 'Disk': 'request_disk'}
 
+
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type, site_name):
         self.configuration = getattr(Configuration(), site_name)

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -48,6 +48,10 @@ htcondor_translate_resources = {'Cores': 'request_cpus',
                                 'Memory': 'request_memory',
                                 'Disk': 'request_disk'}
 
+htcondor_translate_prefix_resources = {'Cores': 1,
+                                       'Memory': 1024,
+                                       'Disk': 1024}
+
 
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type, site_name):
@@ -72,19 +76,19 @@ class HTCondorAdapter(SiteAdapter):
 
     async def deploy_resource(self, resource_attributes):
         submit_jdl = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
-        drone_resources = ";".join(
-            [f'TardisDrone{resource}={self.machine_meta_data[resource]}' for resource in self.machine_meta_data])
         submit_resources_args = ''
+        drone_resources = ''
         for resource in self.machine_meta_data:
             try:
-                submit_resources_args += \
-                    f'-a "{htcondor_translate_resources[resource]} = {self.machine_meta_data[resource]}" '
+                drone_resource_value = self.machine_meta_data[resource] * htcondor_translate_prefix_resources[resource]
+                drone_resources += f';TardisDrone{resource}={drone_resource_value}'
+                submit_resources_args += f'-a "{htcondor_translate_resources[resource]} = {drone_resource_value}" '
             except KeyError as e:
                 logging.error(f"deploy_resource failed: no translation known for {e}")
                 raise
         submit_command = (
             f'condor_submit '
-            f'-append "environment = TardisDroneUuid={resource_attributes.drone_uuid};{drone_resources}"'
+            f'-append "environment = TardisDroneUuid={resource_attributes.drone_uuid}{drone_resources}"'
             f' {submit_resources_args}{submit_jdl}')
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -72,8 +72,8 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32"'
-            ' -a "request_cpus = 8" -a "request_memory = 32" submit.jdl')
+            'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32768"'
+            ' -a "request_cpus = 8" -a "request_memory = 32768" submit.jdl')
         self.mock_executor.reset()
 
     def test_translate_resources_raises_logs(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -70,7 +70,8 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32" submit.jdl')
+            'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32"'
+            ' -a "request_cpus = 8" -a "request_memory = 32" submit.jdl')
         self.mock_executor.reset()
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -56,8 +56,8 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=8, Memory='32'),
-                             testunkownresource=AttributeDict(Cores=8, Memory='32', Foo='3'))
+        return AttributeDict(test2large=AttributeDict(Cores=8, Memory=32),
+                             testunkownresource=AttributeDict(Cores=8, Memory=32, Foo=3))
 
     @property
     def machine_type_configuration(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -56,11 +56,13 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=8, Memory='32'))
+        return AttributeDict(test2large=AttributeDict(Cores=8, Memory='32'),
+                             testunkownresource=AttributeDict(Cores=8, Memory='32', Foo='3'))
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict(jdl='submit.jdl'))
+        return AttributeDict(test2large=AttributeDict(jdl='submit.jdl'),
+                             testunkownresource=AttributeDict(jdl='submit.jdl'))
 
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
@@ -73,6 +75,12 @@ class TestHTCondorSiteAdapter(TestCase):
             'condor_submit -append "environment = TardisDroneUuid=test-123;TardisDroneCores=8;TardisDroneMemory=32"'
             ' -a "request_cpus = 8" -a "request_memory = 32" submit.jdl')
         self.mock_executor.reset()
+
+    def test_translate_resources_raises_logs(self):
+        self.adapter = HTCondorAdapter(machine_type='testunkownresource', site_name='TestSite')
+        with self.assertLogs(logging.getLogger(), logging.ERROR):
+            with self.assertRaises(KeyError):
+                run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
 
     def test_machine_meta_data(self):
         self.assertEqual(self.adapter.machine_meta_data, self.machine_meta_data.test2large)


### PR DESCRIPTION
This pull request adds the functionality to the htcondor site-adapter to set the requested resources based on the machine_meta_data of the drone. Currently only the three meta-data "Cores", "Memory" and "Disk" are supported. In case not yet considered meta-data entries are found an error is logged and a KeyError is raised.

This contribution addresses part of #58 . It should be adapted to modify the jdl provided to condor_submit instead of using the append arguments in the context of providing the jdl via stdin.