### PR TITLE
Fix condor_drain call in HTCondor Batch System Adapter

### DIFF
--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -22,6 +22,13 @@ async def async_run_command(cmd, shell_executor=ShellExecutor()):
         return response.stdout
 
 
+def htcondor_cmd_option_formatter(options):
+    options = (f"-{name} {value}" if value is not None else f"-{name}"
+               for name, value in options.items())
+
+    return " ".join(options)
+
+
 def htcondor_csv_parser(htcondor_input, fieldnames, delimiter='\t', replacements=None):
     replacements = replacements or {}
     with StringIO(htcondor_input) as csv_input:

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,4 +1,5 @@
 from tardis.utilities.utils import async_run_command
+from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import htcondor_csv_parser
 from tardis.exceptions.tardisexceptions import AsyncRunCommandFailure
 
@@ -16,6 +17,15 @@ class TestAsyncRunCommand(TestCase):
             run_async(async_run_command, 'exit 1')
 
         self.assertEqual(run_async(async_run_command, 'echo "Test"'), "Test")
+
+
+class TestHTCondorCMDOptionFormatter(TestCase):
+    def test_htcondor_cmd_option_formatter(self):
+        options = {'pool': 'my-htcondor.local',
+                   'test': None}
+        options_string = htcondor_cmd_option_formatter(options)
+
+        self.assertEqual(options_string, "-pool my-htcondor.local -test")
 
 
 class TestHTCondorCSVParser(TestCase):


### PR DESCRIPTION
condor_drain does currently not take into account additional options like `-pool htcondor.local`, this will be fixed by this pull request.