### PR TITLE
Keep drone in shutdown state if stop_resource call fails

### DIFF
--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -169,9 +169,12 @@ class ShutDownState(State):
         logging.info(f'Stopping VM with ID {drone.resource_attributes.remote_resource_uuid}')
 
         new_state = await cls.run_processing_pipeline(drone)
-
         if isinstance(new_state, ShuttingDownState):
-            await drone.site_agent.stop_resource(drone.resource_attributes)
+            try:
+                await drone.site_agent.stop_resource(drone.resource_attributes)
+            except TardisResourceStatusUpdateFailed:
+                logging.warning(f"Calling stop_resource failed for drone {drone.resource_attributes.drone_uuid}")
+                new_state = ShutDownState()
         await drone.set_state(new_state)
 
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -158,8 +158,16 @@ class TestHTCondorSiteAdapter(TestCase):
                                                                                   exit_code=1,
                                                                                   stderr=CONDOR_RM_FAILED_OUTPUT,
                                                                                   stdout="", stdin=""))
-    def test_terminate_resource_failed(self):
+    def test_terminate_resource_failed_redo(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
+            run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
+
+    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
+                                                                                  exit_code=2,
+                                                                                  stderr=CONDOR_RM_FAILED_OUTPUT,
+                                                                                  stdout="", stdin=""))
+    def test_terminate_resource_failed_raise(self):
+        with self.assertRaises(CommandExecutionFailure):
             run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
 
     def test_exception_handling(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -26,6 +26,8 @@ CONDOR_Q_OUTPUT_HELD = "test\t5\t1351043\t0"
 CONDOR_Q_OUTPUT_SUBMISSION_ERR = "test\t6\t1351043\t0"
 
 CONDOR_RM_OUTPUT = """All jobs in cluster 1351043 have been marked for removal"""
+CONDOR_RM_FAILED_OUTPUT = """Couldn't find/remove all jobs in cluster 1351043"""
+CONDOR_RM_FAILED_MESSAGE = """Run command condor_rm 1351043 via ShellExecutor failed"""
 
 
 class TestHTCondorSiteAdapter(TestCase):
@@ -151,6 +153,14 @@ class TestHTCondorSiteAdapter(TestCase):
     def test_terminate_resource(self):
         response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.remote_resource_uuid, "1351043")
+
+    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
+                                                                                  exit_code=1,
+                                                                                  stderr=CONDOR_RM_FAILED_OUTPUT,
+                                                                                  stdout="", stdin=""))
+    def test_terminate_resource_failed(self):
+        with self.assertRaises(TardisResourceStatusUpdateFailed):
+            run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
 
     def test_exception_handling(self):
         def test_exception_handling(raise_it, catch_it):


### PR DESCRIPTION
This can happens if condor_rm is called in the moment the drone is shutting down itself. This pull request changes the behaviour of drone to repeat the procedure until resource has vanished from `condor_status` call and the resource is gone.