### PR TITLE
Enable HTCondor JDL templates and send JDL via stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/MatterMiners/tardis.svg?branch=master)](https://travis-ci.org/MatterMiners/tardis)
 [![codecov](https://codecov.io/gh/MatterMiners/tardis/branch/master/graph/badge.svg)](https://codecov.io/gh/MatterMiners/tardis)
+[![PyPI version](https://badge.fury.io/py/cobald-tardis.svg)](https://badge.fury.io/py/cobald-tardis)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MatterMiners/tardis/blob/master/LICENSE.txt)
 [![DOI](https://zenodo.org/badge/132791417.svg)](https://zenodo.org/badge/latestdoi/132791417)
 

--- a/tests/data/submit.jdl
+++ b/tests/data/submit.jdl
@@ -1,0 +1,15 @@
+executable = start_pilot.sh
+transfer_input_files = setup_pilot.sh
+output = logs/$$(cluster).$$(process).out
+error = logs/$$(cluster).$$(process).err
+log = logs/cluster.log
+
+accounting_group=tardis
+
+environment=${Environment}
+
+request_cpus=${Cores}
+request_memory=${Memory}
+request_disk=${Disk}
+
+queue 1


### PR DESCRIPTION
This pull request addresses #58. 

- HTCondor JDL is now templated using `string.Templates`. Values for request_cpu, request_memory, request_disk and environment are replaces during the `deploy_resource` by the corresponding machine meta data
- HTCondor JDL is send via stdin to the `condor_submit` call.