### PR TITLE
Allow removal of booting drones if demand drops to zero

### DIFF
--- a/docs/source/api/tardis.adapters.batchsystems.fakebatchsystem.rst
+++ b/docs/source/api/tardis.adapters.batchsystems.fakebatchsystem.rst
@@ -2,6 +2,6 @@ tardis.adapters.batchsystems.fakebatchsystem module
 ===================================================
 
 .. automodule:: tardis.adapters.batchsystems.fakebatchsystem
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.batchsystems.htcondor.rst
+++ b/docs/source/api/tardis.adapters.batchsystems.htcondor.rst
@@ -2,6 +2,6 @@ tardis.adapters.batchsystems.htcondor module
 ============================================
 
 .. automodule:: tardis.adapters.batchsystems.htcondor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.batchsystems.rst
+++ b/docs/source/api/tardis.adapters.batchsystems.rst
@@ -2,9 +2,9 @@ tardis.adapters.batchsystems package
 ====================================
 
 .. automodule:: tardis.adapters.batchsystems
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.adapters.batchsystems.fakebatchsystem
    tardis.adapters.batchsystems.htcondor
-

--- a/docs/source/api/tardis.adapters.rst
+++ b/docs/source/api/tardis.adapters.rst
@@ -2,15 +2,14 @@ tardis.adapters package
 =======================
 
 .. automodule:: tardis.adapters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Subpackages
 -----------
 
 .. toctree::
 
-    tardis.adapters.batchsystems
-    tardis.adapters.sites
-
+   tardis.adapters.batchsystems
+   tardis.adapters.sites

--- a/docs/source/api/tardis.adapters.sites.cloudstack.rst
+++ b/docs/source/api/tardis.adapters.sites.cloudstack.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.cloudstack module
 =======================================
 
 .. automodule:: tardis.adapters.sites.cloudstack
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.fakesite.rst
+++ b/docs/source/api/tardis.adapters.sites.fakesite.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.fakesite module
 =====================================
 
 .. automodule:: tardis.adapters.sites.fakesite
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.htcondor.rst
+++ b/docs/source/api/tardis.adapters.sites.htcondor.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.htcondor module
 =====================================
 
 .. automodule:: tardis.adapters.sites.htcondor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.moab.rst
+++ b/docs/source/api/tardis.adapters.sites.moab.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.moab module
 =================================
 
 .. automodule:: tardis.adapters.sites.moab
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.openstack.rst
+++ b/docs/source/api/tardis.adapters.sites.openstack.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.openstack module
 ======================================
 
 .. automodule:: tardis.adapters.sites.openstack
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.rst
+++ b/docs/source/api/tardis.adapters.sites.rst
@@ -2,9 +2,9 @@ tardis.adapters.sites package
 =============================
 
 .. automodule:: tardis.adapters.sites
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Submodules
    tardis.adapters.sites.moab
    tardis.adapters.sites.openstack
    tardis.adapters.sites.slurm
-

--- a/docs/source/api/tardis.adapters.sites.slurm.rst
+++ b/docs/source/api/tardis.adapters.sites.slurm.rst
@@ -2,6 +2,6 @@ tardis.adapters.sites.slurm module
 ==================================
 
 .. automodule:: tardis.adapters.sites.slurm
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.agents.batchsystemagent.rst
+++ b/docs/source/api/tardis.agents.batchsystemagent.rst
@@ -2,6 +2,6 @@ tardis.agents.batchsystemagent module
 =====================================
 
 .. automodule:: tardis.agents.batchsystemagent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.agents.rst
+++ b/docs/source/api/tardis.agents.rst
@@ -2,9 +2,9 @@ tardis.agents package
 =====================
 
 .. automodule:: tardis.agents
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.agents.batchsystemagent
    tardis.agents.siteagent
-

--- a/docs/source/api/tardis.agents.siteagent.rst
+++ b/docs/source/api/tardis.agents.siteagent.rst
@@ -2,6 +2,6 @@ tardis.agents.siteagent module
 ==============================
 
 .. automodule:: tardis.agents.siteagent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.configuration.configuration.rst
+++ b/docs/source/api/tardis.configuration.configuration.rst
@@ -2,6 +2,6 @@ tardis.configuration.configuration module
 =========================================
 
 .. automodule:: tardis.configuration.configuration
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.configuration.rst
+++ b/docs/source/api/tardis.configuration.rst
@@ -2,9 +2,9 @@ tardis.configuration package
 ============================
 
 .. automodule:: tardis.configuration
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.configuration.configuration
    tardis.configuration.utilities
-

--- a/docs/source/api/tardis.configuration.utilities.rst
+++ b/docs/source/api/tardis.configuration.utilities.rst
@@ -2,6 +2,6 @@ tardis.configuration.utilities module
 =====================================
 
 .. automodule:: tardis.configuration.utilities
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.exceptions.executorexceptions.rst
+++ b/docs/source/api/tardis.exceptions.executorexceptions.rst
@@ -2,6 +2,6 @@ tardis.exceptions.executorexceptions module
 ===========================================
 
 .. automodule:: tardis.exceptions.executorexceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.exceptions.rst
+++ b/docs/source/api/tardis.exceptions.rst
@@ -2,9 +2,9 @@ tardis.exceptions package
 =========================
 
 .. automodule:: tardis.exceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.exceptions.executorexceptions
    tardis.exceptions.tardisexceptions
-

--- a/docs/source/api/tardis.exceptions.tardisexceptions.rst
+++ b/docs/source/api/tardis.exceptions.tardisexceptions.rst
@@ -2,6 +2,6 @@ tardis.exceptions.tardisexceptions module
 =========================================
 
 .. automodule:: tardis.exceptions.tardisexceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.batchsystemadapter.rst
+++ b/docs/source/api/tardis.interfaces.batchsystemadapter.rst
@@ -2,6 +2,6 @@ tardis.interfaces.batchsystemadapter module
 ===========================================
 
 .. automodule:: tardis.interfaces.batchsystemadapter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.borg.rst
+++ b/docs/source/api/tardis.interfaces.borg.rst
@@ -2,6 +2,6 @@ tardis.interfaces.borg module
 =============================
 
 .. automodule:: tardis.interfaces.borg
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.executor.rst
+++ b/docs/source/api/tardis.interfaces.executor.rst
@@ -2,6 +2,6 @@ tardis.interfaces.executor module
 =================================
 
 .. automodule:: tardis.interfaces.executor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.plugin.rst
+++ b/docs/source/api/tardis.interfaces.plugin.rst
@@ -2,6 +2,6 @@ tardis.interfaces.plugin module
 ===============================
 
 .. automodule:: tardis.interfaces.plugin
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.rst
+++ b/docs/source/api/tardis.interfaces.rst
@@ -2,9 +2,9 @@ tardis.interfaces package
 =========================
 
 .. automodule:: tardis.interfaces
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -18,4 +18,3 @@ Submodules
    tardis.interfaces.simulator
    tardis.interfaces.siteadapter
    tardis.interfaces.state
-

--- a/docs/source/api/tardis.interfaces.simulator.rst
+++ b/docs/source/api/tardis.interfaces.simulator.rst
@@ -2,6 +2,6 @@ tardis.interfaces.simulator module
 ==================================
 
 .. automodule:: tardis.interfaces.simulator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.siteadapter.rst
+++ b/docs/source/api/tardis.interfaces.siteadapter.rst
@@ -2,6 +2,6 @@ tardis.interfaces.siteadapter module
 ====================================
 
 .. automodule:: tardis.interfaces.siteadapter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.interfaces.state.rst
+++ b/docs/source/api/tardis.interfaces.state.rst
@@ -2,6 +2,6 @@ tardis.interfaces.state module
 ==============================
 
 .. automodule:: tardis.interfaces.state
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.plugins.rst
+++ b/docs/source/api/tardis.plugins.rst
@@ -2,9 +2,9 @@ tardis.plugins package
 ======================
 
 .. automodule:: tardis.plugins
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.plugins.sqliteregistry
    tardis.plugins.telegrafmonitoring
-

--- a/docs/source/api/tardis.plugins.sqliteregistry.rst
+++ b/docs/source/api/tardis.plugins.sqliteregistry.rst
@@ -2,6 +2,6 @@ tardis.plugins.sqliteregistry module
 ====================================
 
 .. automodule:: tardis.plugins.sqliteregistry
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.plugins.telegrafmonitoring.rst
+++ b/docs/source/api/tardis.plugins.telegrafmonitoring.rst
@@ -2,6 +2,6 @@ tardis.plugins.telegrafmonitoring module
 ========================================
 
 .. automodule:: tardis.plugins.telegrafmonitoring
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.resources.drone.rst
+++ b/docs/source/api/tardis.resources.drone.rst
@@ -2,6 +2,6 @@ tardis.resources.drone module
 =============================
 
 .. automodule:: tardis.resources.drone
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.resources.dronestates.rst
+++ b/docs/source/api/tardis.resources.dronestates.rst
@@ -2,6 +2,6 @@ tardis.resources.dronestates module
 ===================================
 
 .. automodule:: tardis.resources.dronestates
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.resources.poolfactory.rst
+++ b/docs/source/api/tardis.resources.poolfactory.rst
@@ -2,6 +2,6 @@ tardis.resources.poolfactory module
 ===================================
 
 .. automodule:: tardis.resources.poolfactory
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.resources.rst
+++ b/docs/source/api/tardis.resources.rst
@@ -2,9 +2,9 @@ tardis.resources package
 ========================
 
 .. automodule:: tardis.resources
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -14,4 +14,3 @@ Submodules
    tardis.resources.drone
    tardis.resources.dronestates
    tardis.resources.poolfactory
-

--- a/docs/source/api/tardis.rst
+++ b/docs/source/api/tardis.rst
@@ -2,21 +2,20 @@ tardis package
 ==============
 
 .. automodule:: tardis
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Subpackages
 -----------
 
 .. toctree::
 
-    tardis.adapters
-    tardis.agents
-    tardis.configuration
-    tardis.exceptions
-    tardis.interfaces
-    tardis.plugins
-    tardis.resources
-    tardis.utilities
-
+   tardis.adapters
+   tardis.agents
+   tardis.configuration
+   tardis.exceptions
+   tardis.interfaces
+   tardis.plugins
+   tardis.resources
+   tardis.utilities

--- a/docs/source/api/tardis.utilities.asynccachemap.rst
+++ b/docs/source/api/tardis.utilities.asynccachemap.rst
@@ -2,6 +2,6 @@ tardis.utilities.asynccachemap module
 =====================================
 
 .. automodule:: tardis.utilities.asynccachemap
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.attributedict.rst
+++ b/docs/source/api/tardis.utilities.attributedict.rst
@@ -2,6 +2,6 @@ tardis.utilities.attributedict module
 =====================================
 
 .. automodule:: tardis.utilities.attributedict
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.executors.rst
+++ b/docs/source/api/tardis.utilities.executors.rst
@@ -2,9 +2,9 @@ tardis.utilities.executors package
 ==================================
 
 .. automodule:: tardis.utilities.executors
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.utilities.executors.shellexecutor
    tardis.utilities.executors.sshexecutor
-

--- a/docs/source/api/tardis.utilities.executors.shellexecutor.rst
+++ b/docs/source/api/tardis.utilities.executors.shellexecutor.rst
@@ -2,6 +2,6 @@ tardis.utilities.executors.shellexecutor module
 ===============================================
 
 .. automodule:: tardis.utilities.executors.shellexecutor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.executors.sshexecutor.rst
+++ b/docs/source/api/tardis.utilities.executors.sshexecutor.rst
@@ -2,6 +2,6 @@ tardis.utilities.executors.sshexecutor module
 =============================================
 
 .. automodule:: tardis.utilities.executors.sshexecutor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.pipeline.rst
+++ b/docs/source/api/tardis.utilities.pipeline.rst
@@ -2,6 +2,6 @@ tardis.utilities.pipeline module
 ================================
 
 .. automodule:: tardis.utilities.pipeline
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.rst
+++ b/docs/source/api/tardis.utilities.rst
@@ -2,17 +2,17 @@ tardis.utilities package
 ========================
 
 .. automodule:: tardis.utilities
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Subpackages
 -----------
 
 .. toctree::
 
-    tardis.utilities.executors
-    tardis.utilities.simulators
+   tardis.utilities.executors
+   tardis.utilities.simulators
 
 Submodules
 ----------
@@ -24,4 +24,3 @@ Submodules
    tardis.utilities.pipeline
    tardis.utilities.staticmapping
    tardis.utilities.utils
-

--- a/docs/source/api/tardis.utilities.simulators.periodicvalue.rst
+++ b/docs/source/api/tardis.utilities.simulators.periodicvalue.rst
@@ -2,6 +2,6 @@ tardis.utilities.simulators.periodicvalue module
 ================================================
 
 .. automodule:: tardis.utilities.simulators.periodicvalue
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.simulators.randomgauss.rst
+++ b/docs/source/api/tardis.utilities.simulators.randomgauss.rst
@@ -2,6 +2,6 @@ tardis.utilities.simulators.randomgauss module
 ==============================================
 
 .. automodule:: tardis.utilities.simulators.randomgauss
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.simulators.rst
+++ b/docs/source/api/tardis.utilities.simulators.rst
@@ -2,9 +2,9 @@ tardis.utilities.simulators package
 ===================================
 
 .. automodule:: tardis.utilities.simulators
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,4 +13,3 @@ Submodules
 
    tardis.utilities.simulators.periodicvalue
    tardis.utilities.simulators.randomgauss
-

--- a/docs/source/api/tardis.utilities.staticmapping.rst
+++ b/docs/source/api/tardis.utilities.staticmapping.rst
@@ -2,6 +2,6 @@ tardis.utilities.staticmapping module
 =====================================
 
 .. automodule:: tardis.utilities.staticmapping
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.utilities.utils.rst
+++ b/docs/source/api/tardis.utilities.utils.rst
@@ -2,6 +2,6 @@ tardis.utilities.utils module
 =============================
 
 .. automodule:: tardis.utilities.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -112,7 +112,8 @@ class HTCondorAdapter(BatchSystemAdapter):
             if ex.error_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp
-                logging.debug("Drone %s is not available or already drained." % drone_uuid)
+                logging.debug(f"Draining failed with message: {ex.error_message} {ex.message}")
+                logging.debug(f"Probably drone {drone_uuid} is not available or already drained.")
                 return
             raise ex
 

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -112,7 +112,7 @@ class HTCondorAdapter(BatchSystemAdapter):
             if ex.error_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp
-                logging.debug("Drone %s is not in HTCondor anymore." % drone_uuid)
+                logging.debug("Drone %s is not available or already drained." % drone_uuid)
                 return
             raise ex
 

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -109,6 +109,13 @@ class TestDroneStates(TestCase):
         self.run_side_effects(BootingState(), self.drone.site_agent.resource_status,
                               (TardisDroneCrashed,), CleanupState)
 
+        # Test draining procedure if cobald sets drone demand to zero
+        self.drone.demand = 0.0
+        self.drone.state.return_value = BootingState()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, CleanupState)
+        self.assertEqual(self.drone._supply, 0.0)
+
     def test_integrate_state(self):
         self.drone.state.return_value = IntegrateState
         run_async(self.drone.state.return_value.run, self.drone)
@@ -159,7 +166,7 @@ class TestDroneStates(TestCase):
 
     def test_draining_state(self):
         matrix = [(ResourceStatus.Running, MachineStatus.Draining, DrainingState),
-                  (ResourceStatus.Running, MachineStatus.Available, DrainingState),
+                  (ResourceStatus.Running, MachineStatus.Available, DrainState),
                   (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
                   (ResourceStatus.Running, MachineStatus.NotAvailable, ShutDownState),
                   (ResourceStatus.Deleted, MachineStatus.NotAvailable, DownState),


### PR DESCRIPTION
Currently only drones in AvailableState can be drained once the demand is set to zero by COBalD. This works fine for cloud provides, but is a problem if drones are deployed via a batch system, since the boot times can be quite large.

This pull request enables a deletion of drones (batch jobs) already during the booting phase.
