### PR TITLE
Telegraf config update

### DIFF
--- a/docs/source/plugins/plugins.rst
+++ b/docs/source/plugins/plugins.rst
@@ -2,7 +2,7 @@
 Plugins
 =======
 
-All plugins are configured within the `plugins` section of the TARDIS configuration. Using multiple plugins is```
+All plugins are configured within the `plugins` section of the TARDIS configuration. Using multiple plugins is
 supported by using a separate MappingNode per plugin.
 
 .. code-block:: yaml
@@ -41,6 +41,10 @@ Telegraf Monitoring
 -------------------
 The :py:class:`~tardis.plugins.telegrafmonitoring.TelegrafMonitoring` implements an interface to monitor state changes
 of the Drones in a telegraf service running a UDP input module.
+
+.. Note::
+    By default the machine name of the host running tardis is added as default tag. It can be overwritten by adding
+    `tardis_machine_name: 'something_else'` as `default_tag` in the configuration.
 
 Available configuration options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tardis/plugins/telegrafmonitoring.py
+++ b/tardis/plugins/telegrafmonitoring.py
@@ -6,6 +6,7 @@ from ..utilities.attributedict import AttributeDict
 import aiotelegraf
 from datetime import datetime
 import logging
+import platform
 
 
 class TelegrafMonitoring(Plugin):
@@ -20,7 +21,8 @@ class TelegrafMonitoring(Plugin):
 
         host = config.host
         port = config.port
-        default_tags = getattr(config, 'default_tags', None)
+        default_tags = dict(tardis_machine_name=platform.node())
+        default_tags.update(getattr(config, 'default_tags', {}))
         self.metric = getattr(config, 'metric', 'tardis_data')
 
         self.client = aiotelegraf.Client(host=host, port=port, tags=default_tags)


### PR DESCRIPTION
This pull request adds the machine name of the host running tardis as a default tag in the telegraf monitoring plugin. 
The node name can be overwritten by adding `tardis_machine_name: 'someting_else'` as `default_tag` in the telegraf plugin configuration.

This pull request closes #73.