### PR TITLE
Adapt openstack adapter unittest to new aiohttp version

### DIFF
--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -115,7 +115,7 @@ class TestOpenStackAdapter(TestCase):
 
         matrix = [(asyncio.TimeoutError(), TardisTimeout),
                   (AuthError(message="Test_Error", response="Not Allowed"), TardisAuthError),
-                  (ContentTypeError(request_info="Test", history="Test"), TardisResourceStatusUpdateFailed),
+                  (ContentTypeError(request_info=AttributeDict(real_url="Test"), history="Test"), TardisResourceStatusUpdateFailed),
                   (ClientError(message="Test_Error", response="Internal Server Error"), TardisDroneCrashed),
                   (ClientConnectionError(), TardisResourceStatusUpdateFailed),
                   (Exception, TardisError)]


### PR DESCRIPTION
The unittest of the OpenStackAdapter is failing for a aiohttp 3.6.1. This pull request adjust the according unittest. 