### PR TITLE
Adaptation of readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,5 @@
+version: 2
+
 python:
    version: 3
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,7 @@
 python:
    version: 3
-   setup_py_install: true
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+           - docs


### PR DESCRIPTION
The current build of documentation did not find some of the required packages defined in setup.py. Therefore, this PR adapts the current `readthedocs.yml` to explicitly include docs as extra.

In summary, this PR fixes

* [x] build of documentation