### PR TITLE
 Handle termination of vanished resources

### DIFF
--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -46,13 +46,15 @@ async def htcondor_queue_updater(executor):
         return htcondor_queue
 
 
-htcondor_status_codes = {'0': ResourceStatus.Error,
-                         '1': ResourceStatus.Booting,
+# According to https://htcondor.readthedocs.io/en/latest/classad-attributes/
+# job-classad-attributes.html
+htcondor_status_codes = {'1': ResourceStatus.Booting,
                          '2': ResourceStatus.Running,
-                         '3': ResourceStatus.Stopped,
+                         '3': ResourceStatus.Running,
                          '4': ResourceStatus.Deleted,
                          '5': ResourceStatus.Error,
-                         '6': ResourceStatus.Error}
+                         '6': ResourceStatus.Running,
+                         '7': ResourceStatus.Stopped}
 
 htcondor_translate_resources_prefix = {'Cores': 1,
                                        'Memory': 1024,

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,5 +1,6 @@
 from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
+from ...exceptions.tardisexceptions import TardisDroneCrashed
 from ...exceptions.tardisexceptions import TardisError
 from ...exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from ...interfaces.siteadapter import SiteAdapter
@@ -168,10 +169,9 @@ class HTCondorAdapter(SiteAdapter):
             response = await self._executor.run_command(terminate_command)
         except CommandExecutionFailure as cef:
             if cef.exit_code == 1 and "Couldn't find/remove" in cef.stderr:
-                # Happens if condor_rm is called in the moment the drone is shutting
-                # down itself. Repeat the procedure until resource has vanished
-                # from condor_status call
-                raise TardisResourceStatusUpdateFailed from cef
+                # Happens if condor_rm is called once the resource has shut
+                # down itself. Consider the resource as crashed
+                raise TardisDroneCrashed from cef
             raise
         pattern = re.compile(r"^.*?(?P<ClusterId>\d+).*$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -253,9 +253,6 @@ class CleanupState(State):
                 logging.warning(
                     f"Calling terminate_resource failed for drone "
                     f"{drone.resource_attributes.drone_uuid}. Will retry later!")
-                new_state = CleanupState()
-            else:
-                new_state = CleanupState()
 
         await drone.set_state(new_state)  # static state transition
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -17,13 +17,13 @@ import logging
 CONDOR_SUBMIT_OUTPUT = """Submitting job(s).
 1 job(s) submitted to cluster 1351043."""
 
-CONDOR_Q_OUTPUT_UNEXANPANDED = "test\t0\t1351043\t0"
 CONDOR_Q_OUTPUT_IDLE = "test\t1\t1351043\t0"
 CONDOR_Q_OUTPUT_RUN = "test\t2\t1351043\t0"
-CONDOR_Q_OUTPUT_REMOVED = "test\t3\t1351043\t0"
+CONDOR_Q_OUTPUT_REMOVING = "test\t3\t1351043\t0"
 CONDOR_Q_OUTPUT_COMPLETED = "test\t4\t1351043\t0"
 CONDOR_Q_OUTPUT_HELD = "test\t5\t1351043\t0"
-CONDOR_Q_OUTPUT_SUBMISSION_ERR = "test\t6\t1351043\t0"
+CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT = "test\t6\t1351043\t0"
+CONDOR_Q_OUTPUT_SUSPENDED = "test\t7\t1351043\t0"
 
 CONDOR_RM_OUTPUT = """All jobs in cluster 1351043 have been marked for removal"""
 CONDOR_RM_FAILED_OUTPUT = """Couldn't find/remove all jobs in cluster 1351043"""
@@ -107,11 +107,6 @@ class TestHTCondorSiteAdapter(TestCase):
     def test_site_name(self):
         self.assertEqual(self.adapter.site_name, 'TestSite')
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_UNEXANPANDED)
-    def test_resource_status_unexpanded(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
-        self.assertEqual(response.resource_status, ResourceStatus.Error)
-
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
     def test_resource_status_idle(self):
         response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
@@ -120,6 +115,12 @@ class TestHTCondorSiteAdapter(TestCase):
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
     def test_resource_status_run(self):
         response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        self.assertEqual(response.resource_status, ResourceStatus.Running)
+
+    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_REMOVING)
+    def test_resource_status_idle(self):
+        response = run_async(self.adapter.resource_status,
+                             AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
@@ -132,10 +133,16 @@ class TestHTCondorSiteAdapter(TestCase):
         response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUBMISSION_ERR)
+    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT)
     def test_resource_status_idle(self):
         response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
-        self.assertEqual(response.resource_status, ResourceStatus.Error)
+        self.assertEqual(response.resource_status, ResourceStatus.Running)
+
+    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUSPENDED)
+    def test_resource_status_unexpanded(self):
+        response = run_async(self.adapter.resource_status,
+                             AttributeDict(remote_resource_uuid="1351043"))
+        self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
                                                                                   stderr="Failed", exit_code=2))

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -1,6 +1,5 @@
 from tardis.adapters.sites.htcondor import HTCondorAdapter
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
-from tardis.exceptions.tardisexceptions import TardisDroneCrashed
 from tardis.exceptions.tardisexceptions import TardisError
 from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.interfaces.siteadapter import ResourceStatus
@@ -169,19 +168,13 @@ class TestHTCondorSiteAdapter(TestCase):
         response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
         self.assertEqual(response.remote_resource_uuid, "1351043")
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(
-        message=CONDOR_RM_FAILED_MESSAGE,
-        exit_code=1,
-        stderr=CONDOR_RM_FAILED_OUTPUT,
-        stdout="", stdin=""))
-    def test_terminate_resource_failed(self):
-        # avoid execution of htcondor_queue_updater
-        now = datetime.now()
-        self.adapter._htcondor_queue._last_update = now
-        with self.assertRaises(TardisDroneCrashed):
-            run_async(self.adapter.terminate_resource,
-                      AttributeDict(remote_resource_uuid="1351043",
-                                    created=now))
+    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
+                                                                                  exit_code=1,
+                                                                                  stderr=CONDOR_RM_FAILED_OUTPUT,
+                                                                                  stdout="", stdin=""))
+    def test_terminate_resource_failed_redo(self):
+        with self.assertRaises(TardisResourceStatusUpdateFailed):
+            run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
 
     @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
                                                                                   exit_code=2,


### PR DESCRIPTION
Resources that shut down itself while being idle for 20 minutes remain in `CleanUpState` forever, since the `teminate_resource` call keeps raising `TardisResourceStatusUpdateFailed`, which will lead to infinte retries of the `terminate_resource` call. 
https://github.com/MatterMiners/tardis/blob/e771903419ba37a45d40cee7828a179d9e0f441c/tardis/adapters/sites/htcondor.py#L132

See #84 for the corresponding bug report.

There are currently several problems addressed by this pull request related to bug report.

1. The mapping between HTCondor status codes and the internal `ResourceStatus` relied on a very old HTCondor documentation http://pages.cs.wisc.edu/~adesmet/status.html. HTCondor adjusted the status codes in the past. The HTCondor status code "3" translates into "Removing", not into "Removed" as before. So, the corresponding `ResouceStatus` is not `Stopped` anymore, but `Running` instead. This addresses the reason why those jobs end up in the CleanupState. In case the resource shuts down itself, the HTCondor status will be "Removing" for a short time. Is a `condor_q` executed during this period, the resource will end up in the CleanupState.
In same the way other HTCondor status code translations have been changed according to https://htcondor.readthedocs.io/en/latest/classad-attributes/job-classad-attributes.html.

2. Because the support of cloud computing providers using VMs, we need to support stoping and terminating machines. In case of the HTCondor site adapter, both states triggered a `condor_rm`, which is more corresponding to terminating a machine. Executing `condor_rm` twice on a job will trigger an error on the second call, which will trigger a `TardisResourceStatusUpdateFailed` to be raised. The right way to go is that stopping a machine should translate into a `condor_suspend`call, while terminating a machine is translated into a `condor_rm` call. This is as well addressed in this pull request.

3. The last part of this pull request addresses the infinte loop in `CleanupState`. In case the HTCondor commands `condor_suspend` and `condor_rm` cannot find the corresponding job a update failure is assumed and the system is going to retry the corresponding command until the job has vanished from HTCondor. This was already assumed by the original code. However, now the `CleanupState` is checking the resource status and will move the resource into `DownState` once it is not available in HTCondor anymore. This part was missing before.