### PR TITLE
Corrected type hints for helper functions in dronestates

### DIFF
--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from typing import TYPE_CHECKING
+from typing import Type
 
 from ..exceptions.tardisexceptions import TardisAuthError
 from ..exceptions.tardisexceptions import TardisDroneCrashed
@@ -19,13 +20,14 @@ if TYPE_CHECKING:
 
 
 async def batchsystem_machine_status(state_transition, drone: "Drone",
-                                     current_state: State):
+                                     current_state: Type[State]):
     machine_status = await drone.batch_system_agent.get_machine_status(
         drone_uuid=drone.resource_attributes['drone_uuid'])
     return state_transition[machine_status]()
 
 
-async def check_demand(state_transition, drone: "Drone", current_state: State):
+async def check_demand(state_transition, drone: "Drone",
+                       current_state: Type[State]):
     if not drone.demand:
         drone._supply = 0.0
         if current_state in (BootingState,):
@@ -35,7 +37,8 @@ async def check_demand(state_transition, drone: "Drone", current_state: State):
     return state_transition
 
 
-async def resource_status(state_transition, drone: "Drone", current_state: State):
+async def resource_status(state_transition, drone: "Drone",
+                          current_state: Type[State]):
     try:
         drone.resource_attributes.update(
             await drone.site_agent.resource_status(drone.resource_attributes))


### PR DESCRIPTION
This pull request addresses wrong type hints for helper functions in dronestates.

https://github.com/MatterMiners/tardis/blob/63e186576c658c0e3c9f4fe38e065aeebb16228b/tardis/resources/dronestates.py#L21-L22
https://github.com/MatterMiners/tardis/blob/63e186576c658c0e3c9f4fe38e065aeebb16228b/tardis/resources/dronestates.py#L28
and
https://github.com/MatterMiners/tardis/blob/63e186576c658c0e3c9f4fe38e065aeebb16228b/tardis/resources/dronestates.py#L38
sliped through the review. Instead of instances of `State`, the functions requires the class object itself. So the type hint should be `Type[State]`, instead of `State`.

See #97  for the issue!