### PR TITLE
Fix transistion within the CleanupState of a resource

### DIFF
--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -229,7 +229,8 @@ class ShuttingDownState(State):
 
 
 class CleanupState(State):
-    transition = {ResourceStatus.Stopped: lambda: CleanupState(),
+    transition = {ResourceStatus.Booting: lambda: CleanupState(),
+                  ResourceStatus.Stopped: lambda: CleanupState(),
                   ResourceStatus.Deleted: lambda: DownState(),
                   ResourceStatus.Error: lambda: CleanupState()}
     processing_pipeline = [resource_status]

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -230,6 +230,7 @@ class ShuttingDownState(State):
 
 class CleanupState(State):
     transition = {ResourceStatus.Booting: lambda: CleanupState(),
+                  ResourceStatus.Running: lambda: DrainState(),
                   ResourceStatus.Stopped: lambda: CleanupState(),
                   ResourceStatus.Deleted: lambda: DownState(),
                   ResourceStatus.Error: lambda: CleanupState()}

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -213,6 +213,7 @@ class TestDroneStates(TestCase):
 
     def test_cleanup_state(self):
         matrix = [(ResourceStatus.Booting, None, CleanupState),
+                  (ResourceStatus.Running, None, DrainState),
                   (ResourceStatus.Stopped, None, CleanupState),
                   (ResourceStatus.Deleted, None, DownState),
                   (ResourceStatus.Error, None, CleanupState)]

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -212,7 +212,8 @@ class TestDroneStates(TestCase):
         self.run_the_matrix(matrix, initial_state=ShuttingDownState)
 
     def test_cleanup_state(self):
-        matrix = [(ResourceStatus.Stopped, None, CleanupState),
+        matrix = [(ResourceStatus.Booting, None, CleanupState),
+                  (ResourceStatus.Stopped, None, CleanupState),
                   (ResourceStatus.Deleted, None, DownState),
                   (ResourceStatus.Error, None, CleanupState)]
 


### PR DESCRIPTION
As introduced in #96. The CleanupState is now taking into account the status of the resource. Unfortunately, two possible state transitions are missing the transition dictionary, which are added in this pull request.

In case a resource is in BootingState and COBalD decides to set the demand of the resource to zero, the resource can directly go into the CleanupState. https://github.com/MatterMiners/tardis/blob/699171a2b58479fd976c456ba500ed19077d4cde/tardis/resources/dronestates.py#L29-L37

However, there is currently no transition for `ResourceStatus.Booting` available in https://github.com/MatterMiners/tardis/blob/699171a2b58479fd976c456ba500ed19077d4cde/tardis/resources/dronestates.py#L231-L234. This pull request adds a transition for `ResourceStatus.Booting` to `CleanupState`. This will execute `condor_rm` and removes that job from the system as desired by setting its demand to zero.

In addition, in the unlikely but possible case a resource in BootingState is transfered to CleanupState by https://github.com/MatterMiners/tardis/blob/699171a2b58479fd976c456ba500ed19077d4cde/tardis/resources/dronestates.py#L29-L37, it can happen that the resource (HTCondor job) starts running before the `run` function of the `CleanupState` has been executed. In that case a transition from `ResourceStatus.Running`is missing in  https://github.com/MatterMiners/tardis/blob/699171a2b58479fd976c456ba500ed19077d4cde/tardis/resources/dronestates.py#L231-L234 as well. This pull request adds a transition for `ResourceStatus.Running` to `DrainState`. The reason is that once the resource starts running in the system, it will accept jobs and the current policy is to drain resources first before removing them from the system.

Both cases did already occur on our TOPAS installation.