### PR TITLE
Retire AsyncRunCommandFailure exception and retry condor_status calls on failure

### DIFF
--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -1,5 +1,5 @@
 from ...configuration.configuration import Configuration
-from ...exceptions.tardisexceptions import AsyncRunCommandFailure
+from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
 from ...utilities.utils import async_run_command
@@ -53,9 +53,9 @@ async def htcondor_status_updater(options: AttributeDict,
             status_key = row['TardisDroneUuid'] or row['Machine'].split('.')[0]
             htcondor_status[status_key] = row
 
-    except AsyncRunCommandFailure as ex:
+    except CommandExecutionFailure as cef:
         logging.error("condor_status could not be executed!")
-        logging.error(str(ex))
+        logging.error(str(cef))
     else:
         logging.debug("HTCondor status update finished.")
         return htcondor_status
@@ -125,16 +125,16 @@ class HTCondorAdapter(BatchSystemAdapter):
 
         try:
             return await async_run_command(cmd)
-        except AsyncRunCommandFailure as ex:
-            if ex.error_code == 1:
+        except CommandExecutionFailure as cef:
+            if cef.exit_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp  # noqa: B950
                 logging.debug(
-                    f"Draining failed with message: {ex.error_message} {str(ex)}")
+                    f"Draining failed with message: {cef.message} {str(cef)}")
                 logging.debug(
                     f"Probably drone {drone_uuid} is not available or already drained.")
                 return
-            raise ex
+            raise cef
 
     async def integrate_machine(self, drone_uuid: str) -> None:
         """

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -56,6 +56,7 @@ async def htcondor_status_updater(options: AttributeDict,
     except CommandExecutionFailure as cef:
         logging.error("condor_status could not be executed!")
         logging.error(str(cef))
+        raise
     else:
         logging.debug("HTCondor status update finished.")
         return htcondor_status

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -131,7 +131,7 @@ class HTCondorAdapter(BatchSystemAdapter):
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp  # noqa: B950
                 logging.debug(
-                    f"Draining failed with message: {cef.message} {str(cef)}")
+                    f"Draining failed with: {str(cef)}")
                 logging.debug(
                     f"Probably drone {drone_uuid} is not available or already drained.")
                 return

--- a/tardis/exceptions/tardisexceptions.py
+++ b/tardis/exceptions/tardisexceptions.py
@@ -1,14 +1,3 @@
-class AsyncRunCommandFailure(Exception):
-    def __init__(self, message: str, error_code: str = None, error_message: str = None):
-        self.message = message
-        self.error_code = error_code
-        self.error_message = error_message
-
-    def __str__(self):
-        return f"(message={self.message}, error_code={self.error_code}, " \
-               f"error_message={self.error_message})"
-
-
 class TardisAuthError(Exception):
     pass
 

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -1,5 +1,4 @@
 from .executors.shellexecutor import ShellExecutor
-from ..exceptions.tardisexceptions import AsyncRunCommandFailure
 from ..exceptions.executorexceptions import CommandExecutionFailure
 
 from io import StringIO
@@ -18,11 +17,7 @@ async def async_run_command(cmd, shell_executor=ShellExecutor()):
 
         if ef.exit_code == 255:
             return ef.stdout
-        raise AsyncRunCommandFailure(
-            message=ef.stdout,
-            error_code=ef.exit_code,
-            error_message=ef.stderr
-        ) from ef
+        raise
     else:
         return response.stdout
 

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -3,7 +3,7 @@ from tests.utilities.utilities import run_async
 from tardis.adapters.batchsystems.htcondor import HTCondorAdapter
 from tardis.adapters.batchsystems.htcondor import htcondor_status_updater
 from tardis.interfaces.batchsystemadapter import MachineStatus
-from tardis.exceptions.tardisexceptions import AsyncRunCommandFailure
+from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from functools import partial
 from shlex import quote
@@ -69,15 +69,15 @@ class TestHTCondorAdapter(TestCase):
         run_async(self.htcondor_adapter.drain_machine, drone_uuid='test')
         self.mock_async_run_command.assert_called_with('condor_drain -pool my-htcondor.local -test -graceful test')
         self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists"))
-        self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Does not exists",
-                                                                         error_code=1,
-                                                                         error_message="Does not exists")
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Does not exists",
+                                                                          exit_code=1,
+                                                                          stderr="Does not exists")
         self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
 
-        self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Unhandled error",
-                                                                         error_code=2,
-                                                                         error_message="Unhandled error")
-        with self.assertRaises(AsyncRunCommandFailure):
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Unhandled error",
+                                                                          exit_code=2,
+                                                                          stderr="Unhandled error")
+        with self.assertRaises(CommandExecutionFailure):
             self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
 
         self.mock_async_run_command.side_effect = None
@@ -136,8 +136,8 @@ class TestHTCondorAdapter(TestCase):
                          MachineStatus.Available)
         self.mock_async_run_command.reset_mock()
 
-        self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Test", error_code=123,
-                                                                         error_message="Test")
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Test", exit_code=123,
+                                                                          stderr="Test")
         with self.assertLogs(level='ERROR'):
             attributes = dict(Machine='Machine', State='State', Activity='Activity', TardisDroneUuid='TardisDroneUuid')
             # Escape htcondor expressions and add them to attributes

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -139,12 +139,16 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Test", exit_code=123,
                                                                           stderr="Test")
         with self.assertLogs(level='ERROR'):
-            attributes = dict(Machine='Machine', State='State', Activity='Activity', TardisDroneUuid='TardisDroneUuid')
-            # Escape htcondor expressions and add them to attributes
-            attributes.update({key: quote(value) for key, value in self.config.BatchSystem.ratios.items()})
-
-            run_async(partial(htcondor_status_updater, self.config.BatchSystem.options, attributes))
-            self.mock_async_run_command.assert_called_with(self.command)
+            with self.assertRaises(CommandExecutionFailure):
+                attributes = dict(Machine='Machine', State='State', Activity='Activity',
+                                  TardisDroneUuid='TardisDroneUuid')
+                # Escape htcondor expressions and add them to attributes
+                attributes.update({key: quote(value) for key, value in
+                                   self.config.BatchSystem.ratios.items()})
+                run_async(
+                    partial(htcondor_status_updater, self.config.BatchSystem.options,
+                            attributes))
+                self.mock_async_run_command.assert_called_with(self.command)
         self.mock_async_run_command.side_effect = None
 
     def test_get_utilization(self):

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -140,8 +140,9 @@ class TestHTCondorAdapter(TestCase):
                                                                           stderr="Test")
         with self.assertLogs(level='ERROR'):
             with self.assertRaises(CommandExecutionFailure):
-                attributes = dict(Machine='Machine', State='State', Activity='Activity',
-                                  TardisDroneUuid='TardisDroneUuid')
+                attributes = {"Machine": "Machine", "State": "State",
+                              "Activity": "Activity",
+                              "TardisDroneUuid": "TardisDroneUuid"}
                 # Escape htcondor expressions and add them to attributes
                 attributes.update({key: quote(value) for key, value in
                                    self.config.BatchSystem.ratios.items()})

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,7 +1,7 @@
 from tardis.utilities.utils import async_run_command
 from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import htcondor_csv_parser
-from tardis.exceptions.tardisexceptions import AsyncRunCommandFailure
+from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from ..utilities.utilities import run_async
 
@@ -13,7 +13,7 @@ class TestAsyncRunCommand(TestCase):
         run_async(async_run_command, 'exit 0')
         run_async(async_run_command,'exit 255')
 
-        with self.assertRaises(AsyncRunCommandFailure):
+        with self.assertRaises(CommandExecutionFailure):
             run_async(async_run_command, 'exit 1')
 
         self.assertEqual(run_async(async_run_command, 'echo "Test"'), "Test")


### PR DESCRIPTION
During debugging I found out that we have actually redundent exceptions for failing subprocess calls. `AsyncRunCommandFailure` is almost the same as `CommandExecutionFailure`. 
https://github.com/MatterMiners/tardis/blob/1ac93e153d4a139428bcffac64646d7e62d46b9c/tardis/exceptions/executorexceptions.py#L1-L12
and 
https://github.com/MatterMiners/tardis/blob/1ac93e153d4a139428bcffac64646d7e62d46b9c/tardis/exceptions/tardisexceptions.py#L1-L9
The latter was introduced when switching to use executors and is actually superseding `AsyncRunCommandFailure`, since it providers more information about the problem. Therefore, this pull request is going to retire `AsyncRunCommandFailure`.

The bug reported in #103 that a temporary failure of the `condor_status` call in the HTCondor batch system adapter leads to crash of tardis, can be prevented by re-raising the `CommandExecutionFailure` exception in https://github.com/MatterMiners/tardis/blob/1ac93e153d4a139428bcffac64646d7e62d46b9c/tardis/adapters/batchsystems/htcondor.py#L56-L58. This will lead to a retry of the `condor_status` command by the`self._update_coroutine()` call in the `AsyncCacheMap` during the next call of  https://github.com/MatterMiners/tardis/blob/1ac93e153d4a139428bcffac64646d7e62d46b9c/tardis/utilities/asynccachemap.py#L31-L45
Currently, `self._data` in the `AsyncCacheMap` is set to `None`, since the failing command is simply ignored, just logged and `None` is returned in https://github.com/MatterMiners/tardis/blob/1ac93e153d4a139428bcffac64646d7e62d46b9c/tardis/adapters/batchsystems/htcondor.py#L56-L61, which leads to the crash reported in #103.

This pull request fixes the bug reported in #103.