### PR TITLE
Move to black formatter to ensure an uniform code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
     - python: 3.7
       name: Style
       dist: xenial
-      script: python setup.py flake8
+      script:
+        - python setup.py flake8
+        - python -m black --target-version py36 --check tardis/ tests/
   fast_finish: true
 
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,10 +59,3 @@ the more likely and faster we can include your contribution.
 * The TARDIS code base is following the [PEP8](https://pep8.org/) code style.
 * To ensure a uniform code style and line breaking we enforce to use the 
   [``black``](https://black.readthedocs.io/en/stable/) code formatter
-* Departing from the standards outlined in the [PEP8](https://pep8.org/) guide line, 
-  we have the following additional code style:
-  * Each `import`should be written in a single line:
-  ```python
-  from tardis.resources.dronestates import RequestState
-  from tardis.resources.dronestates import BootingState
-  ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,15 +51,16 @@ the more likely and faster we can include your contribution.
     Include references to all related issues and pull requests.
 * Stand by while we review and inspect your contribution
   * A contribution MUST pass the continuous integration inspection.
-    This runs ``flake8`` on the code and unit tests.
+    This runs ``flake8`` and ``black`` on the code and unit tests.
   * A contribution MUST include unit tests if it adds new features.
     It SHOULD NOT decrease the unit test coverage.
 
 ## Code Style
 * The TARDIS code base is following the [PEP8](https://pep8.org/) code style.
+* To ensure a uniform code style and line breaking we enforce to use the 
+  [``black``](https://black.readthedocs.io/en/stable/) code formatter
 * Departing from the standards outlined in the [PEP8](https://pep8.org/) guide line, 
-  we have the following additional code styles:
-  * Line lengths should stay within 80 characters, however can be exceeded by 10% if needed.
+  we have the following additional code style:
   * Each `import`should be written in a single line:
   ```python
   from tardis.resources.dronestates import RequestState

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cobald-tardis.svg?style=flat-square)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MatterMiners/tardis/blob/master/LICENSE.txt)
 [![DOI](https://zenodo.org/badge/132791417.svg)](https://zenodo.org/badge/latestdoi/132791417)
+[![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 # TARDIS Resourcemanager
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     extras_require={
         'docs': ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-contentui"],
         'test': TESTS_REQUIRE,
-        'contrib': ['flake8', 'flake8-bugbear'] + TESTS_REQUIRE,
+        'contrib': ['flake8', 'flake8-bugbear', 'black'] + TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,
     zip_safe=False,

--- a/tardis/__about__.py
+++ b/tardis/__about__.py
@@ -1,10 +1,10 @@
-__title__ = 'tardis'
-__package__ = 'cobald-tardis'
-__summary__ = 'Transparent Adaptive Resource Dynamic Integration System'
-__url__ = 'https://github.com/matterminers/tardis'
+__title__ = "tardis"
+__package__ = "cobald-tardis"
+__summary__ = "Transparent Adaptive Resource Dynamic Integration System"
+__url__ = "https://github.com/matterminers/tardis"
 
-__version__ = '0.2.0'
-__author__ = 'Manuel Giffels, Matthias Schnepf'
-__email__ = 'giffels@gmail.com'
-__copyright__ = '2019 %s' % __author__
-__keywords__ = 'asyncio tardis cloud scheduler'
+__version__ = "0.2.0"
+__author__ = "Manuel Giffels, Matthias Schnepf"
+__email__ = "giffels@gmail.com"
+__copyright__ = "2019 %s" % __author__
+__keywords__ = "asyncio tardis cloud scheduler"

--- a/tardis/adapters/batchsystems/fakebatchsystem.py
+++ b/tardis/adapters/batchsystems/fakebatchsystem.py
@@ -13,6 +13,7 @@ class FakeBatchSystemAdapter(BatchSystemAdapter):
     The mocked response to the :py:meth:`~.get_utilization`, :py:meth:`~.get_allocation`
     and :py:meth:`~.get_machine_status` API calls is configurable statically.
     """
+
     def __init__(self):
         config = Configuration()
         self.fake_config = config.BatchSystem

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -23,23 +23,24 @@ class FakeSiteAdapter(SiteAdapter):
         self._resource_boot_time = self.configuration.resource_boot_time
 
         key_translator = StaticMapping(
-            remote_resource_uuid='remote_resource_uuid',
-            resource_status='resource_status',
-            created='created',
-            updated='updated',
-            resource_boot_time='resource_boot_time'
+            remote_resource_uuid="remote_resource_uuid",
+            resource_status="resource_status",
+            created="created",
+            updated="updated",
+            resource_boot_time="resource_boot_time",
         )
 
         self.handle_response = partial(
             self.handle_response,
             key_translator=key_translator,
-            translator_functions=StaticMapping()
+            translator_functions=StaticMapping(),
         )
 
         self._stopped_n_terminated_resources = {}
 
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         await asyncio.sleep(self._api_response_delay.get_value())
         now = datetime.now()
         response = AttributeDict(
@@ -47,7 +48,7 @@ class FakeSiteAdapter(SiteAdapter):
             resource_status=ResourceStatus.Booting,
             created=now,
             updated=now,
-            resource_boot_time=self._resource_boot_time.get_value()
+            resource_boot_time=self._resource_boot_time.get_value(),
         )
         return self.handle_response(response)
 
@@ -56,8 +57,9 @@ class FakeSiteAdapter(SiteAdapter):
             return resource_attributes.resource_boot_time
         except AttributeError:
             # In case tardis is restarted, resource_boot_time is not set, so re-set
-            resource_boot_time = resource_attributes["resource_boot_time"] = \
-                self._resource_boot_time.get_value()
+            resource_boot_time = resource_attributes[
+                "resource_boot_time"
+            ] = self._resource_boot_time.get_value()
             return resource_boot_time
 
     @property
@@ -73,39 +75,45 @@ class FakeSiteAdapter(SiteAdapter):
         return self._site_name
 
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         await asyncio.sleep(self._api_response_delay.get_value())
         try:  # check if resource has been stopped or terminated
             resource_status = self._stopped_n_terminated_resources[
-                resource_attributes.drone_uuid]
+                resource_attributes.drone_uuid
+            ]
         except KeyError:
             pass
         else:
-            return self.handle_response(AttributeDict(
-                resource_status=resource_status))
+            return self.handle_response(AttributeDict(resource_status=resource_status))
 
         created_time = resource_attributes.created
 
         resource_boot_time = self.get_resource_boot_time(resource_attributes)
         # check if resource is already running
         if (datetime.now() - created_time) > timedelta(seconds=resource_boot_time):
-            return self.handle_response(AttributeDict(
-                resource_status=ResourceStatus.Running))
+            return self.handle_response(
+                AttributeDict(resource_status=ResourceStatus.Running)
+            )
         return self.handle_response(resource_attributes)
 
     async def stop_resource(self, resource_attributes: AttributeDict):
         await asyncio.sleep(self._api_response_delay.get_value())
-        self._stopped_n_terminated_resources[resource_attributes.drone_uuid] = \
-            ResourceStatus.Stopped
-        return self.handle_response(AttributeDict(
-            resource_status=ResourceStatus.Stopped))
+        self._stopped_n_terminated_resources[
+            resource_attributes.drone_uuid
+        ] = ResourceStatus.Stopped
+        return self.handle_response(
+            AttributeDict(resource_status=ResourceStatus.Stopped)
+        )
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         await asyncio.sleep(self._api_response_delay.get_value())
-        self._stopped_n_terminated_resources[resource_attributes.drone_uuid] = \
-            ResourceStatus.Deleted
-        return self.handle_response(AttributeDict(
-            resource_status=ResourceStatus.Deleted))
+        self._stopped_n_terminated_resources[
+            resource_attributes.drone_uuid
+        ] = ResourceStatus.Deleted
+        return self.handle_response(
+            AttributeDict(resource_status=ResourceStatus.Deleted)
+        )
 
     @contextmanager
     def handle_exceptions(self) -> None:

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -28,16 +28,17 @@ async def moab_status_updater(executor):
     response = await executor.run_command(cmd)
     # combine two XML outputs to one
     xml_output = minidom.parseString(
-        response["stdout"].replace('\n', '').replace("</Data><Data>", ""))
-    xml_jobs_list = xml_output.getElementsByTagName('queue')
+        response["stdout"].replace("\n", "").replace("</Data><Data>", "")
+    )
+    xml_jobs_list = xml_output.getElementsByTagName("queue")
     # parse XML output
     moab_resource_status = {}
     for queue in xml_jobs_list:
-        queue_jobs_list = queue.getElementsByTagName('job')
+        queue_jobs_list = queue.getElementsByTagName("job")
         for line in queue_jobs_list:
-            moab_resource_status[line.attributes['JobID'].value] = {
-                'JobID': line.attributes['JobID'].value,
-                'State': line.attributes['State'].value
+            moab_resource_status[line.attributes["JobID"].value] = {
+                "JobID": line.attributes["JobID"].value,
+                "State": line.attributes["State"].value,
             }
     logging.debug("Moab status update completed")
     return moab_resource_status
@@ -50,15 +51,14 @@ class MoabAdapter(SiteAdapter):
         self._site_name = site_name
         self._startup_command = self.configuration.StartupCommand
 
-        self._executor = getattr(self.configuration, 'executor', ShellExecutor())
+        self._executor = getattr(self.configuration, "executor", ShellExecutor())
 
         self._moab_status = AsyncCacheMap(
             update_coroutine=partial(moab_status_updater, self._executor),
-            max_age=self.configuration.StatusUpdate * 60
+            max_age=self.configuration.StatusUpdate * 60,
         )
         key_translator = StaticMapping(
-            remote_resource_uuid='JobID',
-            resource_status='State'
+            remote_resource_uuid="JobID", resource_status="State"
         )
 
         translator_functions = StaticMapping(
@@ -67,25 +67,30 @@ class MoabAdapter(SiteAdapter):
                 Running=ResourceStatus.Running,
                 Completed=ResourceStatus.Deleted,
                 Canceling=ResourceStatus.Running,
-                Vacated=ResourceStatus.Stopped):
-            translator[x], JobID=lambda x: int(x)
+                Vacated=ResourceStatus.Stopped,
+            ): translator[x],
+            JobID=lambda x: int(x),
         )
 
         self.handle_response = partial(
             self.handle_response,
             key_translator=key_translator,
-            translator_functions=translator_functions
+            translator_functions=translator_functions,
         )
 
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         machine_configuration = self.configuration.MachineTypeConfiguration[
-            self._machine_type]
-        request_command = f'msub -j oe -m p -l ' \
-                          f'walltime={machine_configuration.Walltime},' \
-                          f'mem={self.machine_meta_data.Memory}gb,' \
-                          f'nodes={machine_configuration.NodeType} ' \
-                          f'{self._startup_command}'
+            self._machine_type
+        ]
+        request_command = (
+            f"msub -j oe -m p -l "
+            f"walltime={machine_configuration.Walltime},"
+            f"mem={self.machine_meta_data.Memory}gb,"
+            f"nodes={machine_configuration.NodeType} "
+            f"{self._startup_command}"
+        )
         result = await self._executor.run_command(request_command)
         logging.debug(f"{self.site_name} servers create returned {result}")
 
@@ -95,7 +100,7 @@ class MoabAdapter(SiteAdapter):
             created=datetime.now(),
             updated=datetime.now(),
             drone_uuid=self.drone_uuid(remote_resource_uuid),
-            resource_status=ResourceStatus.Booting
+            resource_status=ResourceStatus.Booting,
         )
         return resource_attributes
 
@@ -117,16 +122,17 @@ class MoabAdapter(SiteAdapter):
         remote_resource_uuid = int(pattern.findall(response)[0])
         if remote_resource_uuid != int(resource_attributes.remote_resource_uuid):
             raise TardisError(
-                f'Failed to terminate {resource_attributes.remote_resource_uuid}.')
+                f"Failed to terminate {resource_attributes.remote_resource_uuid}."
+            )
         else:
             resource_attributes.update(
-                resource_status=ResourceStatus.Stopped,
-                updated=datetime.now()
+                resource_status=ResourceStatus.Stopped, updated=datetime.now()
             )
         return remote_resource_uuid
 
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         await self._moab_status.update_status()
         # In case the created timestamp is after last update timestamp of the
         # asynccachemap, no decision about the current state can be given,
@@ -135,20 +141,20 @@ class MoabAdapter(SiteAdapter):
             resource_uuid = resource_attributes.remote_resource_uuid
             resource_status = self._moab_status[str(resource_uuid)]
         except KeyError:
-            if (self._moab_status._last_update - resource_attributes.created)\
-                    .total_seconds() < 0:
+            if (
+                self._moab_status._last_update - resource_attributes.created
+            ).total_seconds() < 0:
                 raise TardisResourceStatusUpdateFailed
             else:
                 resource_status = {
                     "JobID": resource_attributes.remote_resource_uuid,
-                    "State": "Completed"
+                    "State": "Completed",
                 }
-        logging.debug(f'{self.site_name} has status {resource_status}.')
+        logging.debug(f"{self.site_name} has status {resource_status}.")
         resource_attributes.update(updated=datetime.now())
-        return convert_to_attribute_dict({
-            **resource_attributes,
-            **self.handle_response(resource_status)
-        })
+        return convert_to_attribute_dict(
+            {**resource_attributes, **self.handle_response(resource_status)}
+        )
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         request_command = f"canceljob {resource_attributes.remote_resource_uuid}"
@@ -157,28 +163,27 @@ class MoabAdapter(SiteAdapter):
         except CommandExecutionFailure as cf:
             if cf.exit_code == 1:
                 logging.debug(
-                    f"{self.site_name} servers terminate returned {cf.stdout}")
+                    f"{self.site_name} servers terminate returned {cf.stdout}"
+                )
                 remote_resource_uuid = self.check_remote_resource_uuid(
                     resource_attributes,
-                    r'ERROR:  invalid job specified \((\d*)\)',
-                    cf.stderr
+                    r"ERROR:  invalid job specified \((\d*)\)",
+                    cf.stderr,
                 )
             else:
                 raise cf
         else:
             logging.debug(f"{self.site_name} servers terminate returned {response}")
             remote_resource_uuid = self.check_remote_resource_uuid(
-                resource_attributes,
-                r'^job \'(\d*)\' cancelled',
-                response.stdout
+                resource_attributes, r"^job \'(\d*)\' cancelled", response.stdout
             )
 
-        return self.handle_response({
-            'SystemJID': remote_resource_uuid
-        }, **resource_attributes)
+        return self.handle_response(
+            {"SystemJID": remote_resource_uuid}, **resource_attributes
+        )
 
     async def stop_resource(self, resource_attributes: AttributeDict):
-        logging.debug('MOAB jobs cannot be stopped gracefully. Terminating instead.')
+        logging.debug("MOAB jobs cannot be stopped gracefully. Terminating instead.")
         return await self.terminate_resource(resource_attributes)
 
     @contextmanager
@@ -188,7 +193,7 @@ class MoabAdapter(SiteAdapter):
         except TimeoutError as te:
             raise TardisTimeout from te
         except asyncssh.Error as exc:
-            logging.info('SSH connection failed: ' + str(exc))
+            logging.info("SSH connection failed: " + str(exc))
             raise TardisResourceStatusUpdateFailed
         except IndexError as ide:
             raise TardisResourceStatusUpdateFailed from ide

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -29,19 +29,19 @@ class OpenStackAdapter(SiteAdapter):
         self._machine_type = machine_type
         self._site_name = site_name
 
-        auth = AuthPassword(auth_url=self.configuration.auth_url,
-                            username=self.configuration.username,
-                            password=self.configuration.password,
-                            project_name=self.configuration.project_name,
-                            user_domain_name=self.configuration.user_domain_name,
-                            project_domain_name=self.configuration.project_domain_name)
+        auth = AuthPassword(
+            auth_url=self.configuration.auth_url,
+            username=self.configuration.username,
+            password=self.configuration.password,
+            project_name=self.configuration.project_name,
+            user_domain_name=self.configuration.user_domain_name,
+            project_domain_name=self.configuration.project_domain_name,
+        )
 
         self.nova = NovaClient(session=auth)
 
         key_translator = StaticMapping(
-            remote_resource_uuid='id',
-            drone_uuid='name',
-            resource_status='status'
+            remote_resource_uuid="id", drone_uuid="name", resource_status="status"
         )
 
         translator_functions = StaticMapping(
@@ -51,24 +51,25 @@ class OpenStackAdapter(SiteAdapter):
                 BUILD=ResourceStatus.Booting,
                 ACTIVE=ResourceStatus.Running,
                 SHUTOFF=ResourceStatus.Stopped,
-                ERROR=ResourceStatus.Error):
-            translator[x]
+                ERROR=ResourceStatus.Error,
+            ): translator[x],
         )
 
         self.handle_response = partial(
             self.handle_response,
             key_translator=key_translator,
-            translator_functions=translator_functions
+            translator_functions=translator_functions,
         )
 
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         specs = dict(name=resource_attributes.drone_uuid)
         specs.update(self.configuration.MachineTypeConfiguration[self._machine_type])
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.create(server=specs)
         logging.debug(f"{self.site_name} servers create returned {response}")
-        return self.handle_response(response['server'])
+        return self.handle_response(response["server"])
 
     @property
     def machine_meta_data(self) -> AttributeDict:
@@ -83,24 +84,27 @@ class OpenStackAdapter(SiteAdapter):
         return self._site_name
 
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.get(resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} servers get returned {response}")
-        return self.handle_response(response['server'])
+        return self.handle_response(response["server"])
 
     async def stop_resource(self, resource_attributes: AttributeDict):
         await self.nova.init_api(timeout=60)
-        params = {'os-stop': None}
+        params = {"os-stop": None}
         response = await self.nova.servers.run_action(
-            resource_attributes.remote_resource_uuid, **params)
+            resource_attributes.remote_resource_uuid, **params
+        )
         logging.debug(f"{self.site_name} servers stop returned {response}")
         return response
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.force_delete(
-            resource_attributes.remote_resource_uuid)
+            resource_attributes.remote_resource_uuid
+        )
         logging.debug(f"{self.site_name} servers terminate returned {response}")
         return response
 

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -22,22 +22,20 @@ import re
 
 
 async def slurm_status_updater(executor):
-    attributes = dict(JobId='JOBID', Host='NodeList', State='State')
+    attributes = dict(JobId="JOBID", Host="NodeList", State="State")
     # Escape slurm expressions and add them to attributes
-    attributes.update({
-        key: value for key, value in Configuration().BatchSystem.ratios.items()
-    })
+    attributes.update(
+        {key: value for key, value in Configuration().BatchSystem.ratios.items()}
+    )
     cmd = f'sacct -o "JobID,NodeList,State" -n -P'
     slurm_resource_status = {}
     logging.debug("Slurm status update is running.")
     slurm_status = await executor.run_command(cmd)
     for row in htcondor_csv_parser(
-            slurm_status.stdout,
-            fieldnames=tuple(attributes.keys()),
-            delimiter='|'
+        slurm_status.stdout, fieldnames=tuple(attributes.keys()), delimiter="|"
     ):
-        row['State'] = row["State"].strip()
-        slurm_resource_status[row['JobId']] = row
+        row["State"] = row["State"].strip()
+        slurm_resource_status[row["JobId"]] = row
     logging.debug("Slurm status update finished.")
     return slurm_resource_status
 
@@ -49,16 +47,15 @@ class SlurmAdapter(SiteAdapter):
         self._site_name = site_name
         self._startup_command = self.configuration.StartupCommand
 
-        self._executor = getattr(self.configuration, 'executor', ShellExecutor())
+        self._executor = getattr(self.configuration, "executor", ShellExecutor())
 
         self._slurm_status = AsyncCacheMap(
             update_coroutine=partial(slurm_status_updater, self._executor),
-            max_age=self.configuration.StatusUpdate * 60
+            max_age=self.configuration.StatusUpdate * 60,
         )
 
         key_translator = StaticMapping(
-            remote_resource_uuid='JobId',
-            resource_status='State'
+            remote_resource_uuid="JobId", resource_status="State"
         )
 
         # see job state codes at https://slurm.schedmd.com/squeue.html
@@ -77,37 +74,42 @@ class SlurmAdapter(SiteAdapter):
                 RESIZING=ResourceStatus.Error,
                 REVOKED=ResourceStatus.Error,
                 SUSPENDED=ResourceStatus.Running,
-                TIMEOUT=ResourceStatus.Stopped):
-            translator[x], JobId=lambda x: int(x)
+                TIMEOUT=ResourceStatus.Stopped,
+            ): translator[x],
+            JobId=lambda x: int(x),
         )
 
         self.handle_response = partial(
             self.handle_response,
             key_translator=key_translator,
-            translator_functions=translator_functions
+            translator_functions=translator_functions,
         )
 
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         machine_configuration = self.configuration.MachineTypeConfiguration[
-            self._machine_type]
-        request_command = f'sbatch -p {machine_configuration.Partition} ' \
-                          f'-N 1 -n {self.machine_meta_data.Cores} ' \
-                          f'--mem={self.machine_meta_data.Memory}gb ' \
-                          f'-t {machine_configuration.Walltime} ' \
-                          f'--export=SLURM_Walltime=' \
-                          f'{machine_configuration.Walltime} ' \
-                          f'{self._startup_command}'
+            self._machine_type
+        ]
+        request_command = (
+            f"sbatch -p {machine_configuration.Partition} "
+            f"-N 1 -n {self.machine_meta_data.Cores} "
+            f"--mem={self.machine_meta_data.Memory}gb "
+            f"-t {machine_configuration.Walltime} "
+            f"--export=SLURM_Walltime="
+            f"{machine_configuration.Walltime} "
+            f"{self._startup_command}"
+        )
         result = await self._executor.run_command(request_command)
         logging.debug(f"{self.site_name} servers create returned {result}")
-        pattern = re.compile(r'^Submitted batch job (\d*)', flags=re.MULTILINE)
+        pattern = re.compile(r"^Submitted batch job (\d*)", flags=re.MULTILINE)
         remote_resource_uuid = int(pattern.findall(result.stdout)[0])
         resource_attributes.update(
             remote_resource_uuid=remote_resource_uuid,
             created=datetime.now(),
             updated=datetime.now(),
             drone_uuid=self.drone_uuid(remote_resource_uuid),
-            resource_status=ResourceStatus.Booting
+            resource_status=ResourceStatus.Booting,
         )
         return resource_attributes
 
@@ -124,7 +126,8 @@ class SlurmAdapter(SiteAdapter):
         return self._site_name
 
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         await self._slurm_status.update_status()
         # In case the created timestamp is after last update timestamp of the
         # asynccachemap, no decision about the current state can be given,
@@ -133,34 +136,33 @@ class SlurmAdapter(SiteAdapter):
             resource_uuid = resource_attributes.remote_resource_uuid
             resource_status = self._slurm_status[str(resource_uuid)]
         except KeyError:
-            if (self._slurm_status.last_update - resource_attributes.created)\
-                    .total_seconds() < 0:
+            if (
+                self._slurm_status.last_update - resource_attributes.created
+            ).total_seconds() < 0:
                 raise TardisResourceStatusUpdateFailed
             else:
                 resource_status = {
                     "JobID": resource_attributes.remote_resource_uuid,
-                    "State": "COMPLETED"
+                    "State": "COMPLETED",
                 }
-        logging.debug(f'{self.site_name} has status {resource_status}.')
+        logging.debug(f"{self.site_name} has status {resource_status}.")
         resource_attributes.update(updated=datetime.now())
-        return convert_to_attribute_dict({
-            **resource_attributes,
-            **self.handle_response(resource_status)
-        })
+        return convert_to_attribute_dict(
+            {**resource_attributes, **self.handle_response(resource_status)}
+        )
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         request_command = f"scancel {resource_attributes.remote_resource_uuid}"
         await self._executor.run_command(request_command)
         resource_attributes.update(
-            resource_status=ResourceStatus.Stopped,
-            updated=datetime.now()
+            resource_status=ResourceStatus.Stopped, updated=datetime.now()
         )
-        return self.handle_response({
-            'JobId': resource_attributes.remote_resource_uuid
-        }, **resource_attributes)
+        return self.handle_response(
+            {"JobId": resource_attributes.remote_resource_uuid}, **resource_attributes
+        )
 
     async def stop_resource(self, resource_attributes: AttributeDict):
-        logging.debug('Slurm jobs cannot be stopped gracefully. Terminating instead.')
+        logging.debug("Slurm jobs cannot be stopped gracefully. Terminating instead.")
         return await self.terminate_resource(resource_attributes)
 
     @contextmanager

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -8,10 +8,12 @@ class SiteAgent(SiteAdapter):
         self._site_adapter = site_adapter
 
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         with self.handle_exceptions():
             response = await self._site_adapter.deploy_resource(
-                resource_attributes=resource_attributes)
+                resource_attributes=resource_attributes
+            )
             return convert_to_attribute_dict(response)
 
     def drone_uuid(self, uuid) -> str:
@@ -20,8 +22,13 @@ class SiteAgent(SiteAdapter):
     def handle_exceptions(self):
         return self._site_adapter.handle_exceptions()
 
-    def handle_response(self, response, key_translator: dict,
-                        translator_functions: dict, **additional_content):
+    def handle_response(
+        self,
+        response,
+        key_translator: dict,
+        translator_functions: dict,
+        **additional_content,
+    ):
         return NotImplemented
 
     @property
@@ -33,7 +40,8 @@ class SiteAgent(SiteAdapter):
         return self._site_adapter.machine_type
 
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         with self._site_adapter.handle_exceptions():
             return await self._site_adapter.resource_status(resource_attributes)
 

--- a/tardis/configuration/configuration.py
+++ b/tardis/configuration/configuration.py
@@ -1,8 +1,9 @@
 from ..interfaces.borg import Borg
 from ..utilities.attributedict import AttributeDict
 from ..utilities.attributedict import convert_to_attribute_dict
+
 # Need to import all pyyaml loadable classes (bootstrapping problem) FIX ME
-from ..utilities.executors import *   # noqa: F403, F401
+from ..utilities.executors import *  # noqa: F403, F401
 from ..utilities.simulators import *  # noqa: F403, F401
 
 from base64 import b64encode
@@ -13,8 +14,8 @@ import yaml
 def encode_user_data(obj):
     if isinstance(obj, AttributeDict):
         for key, value in obj.items():
-            if key == 'user_data':
-                with open(os.path.join(os.getcwd(), obj[key]), 'rb') as f:
+            if key == "user_data":
+                with open(os.path.join(os.getcwd(), obj[key]), "rb") as f:
                     obj[key] = b64encode(f.read())
             else:
                 obj[key] = encode_user_data(value)
@@ -39,6 +40,7 @@ class Configuration(Borg):
         :param config_file: The name of the configuration file to be loaded
         :type config_file: str
         """
-        with open(config_file, 'r') as config_file:
-            self._shared_state.update(encode_user_data(
-                convert_to_attribute_dict(yaml.safe_load(config_file))))
+        with open(config_file, "r") as config_file:
+            self._shared_state.update(
+                encode_user_data(convert_to_attribute_dict(yaml.safe_load(config_file)))
+            )

--- a/tardis/configuration/utilities.py
+++ b/tardis/configuration/utilities.py
@@ -14,6 +14,8 @@ def enable_yaml_load(tag):
                 parameters = loader.construct_sequence(node)
                 new_cls = cls(*parameters)
             return new_cls
+
         yaml.add_constructor(tag, class_factory, Loader=yaml.SafeLoader)
         return cls
+
     return yaml_load_decorator

--- a/tardis/exceptions/executorexceptions.py
+++ b/tardis/exceptions/executorexceptions.py
@@ -1,6 +1,12 @@
 class CommandExecutionFailure(Exception):
-    def __init__(self, message: str, exit_code: int = None, stdout: str = None,
-                 stderr: str = None, stdin: str = None):
+    def __init__(
+        self,
+        message: str,
+        exit_code: int = None,
+        stdout: str = None,
+        stderr: str = None,
+        stdin: str = None,
+    ):
         self.message = message
         self.exit_code = exit_code
         self.stdout = stdout
@@ -8,5 +14,7 @@ class CommandExecutionFailure(Exception):
         self.stdin = stdin
 
     def __str__(self):
-        return f"(message={self.message}, exit_code={self.exit_code}, " \
-               f"stdout={self.stdout}, stderr={self.stderr}, stdin={self.stdin})"
+        return (
+            f"(message={self.message}, exit_code={self.exit_code}, "
+            f"stdout={self.stdout}, stderr={self.stderr}, stdin={self.stdin})"
+        )

--- a/tardis/interfaces/borg.py
+++ b/tardis/interfaces/borg.py
@@ -14,6 +14,7 @@ class Borg(metaclass=ABCMeta):
         :return: item
         """
         if item not in self._shared_state:
-            raise AttributeError("Type object %r has no attribute %r)" %
-                                 (self.__class__.__name__, item))
+            raise AttributeError(
+                "Type object %r has no attribute %r)" % (self.__class__.__name__, item)
+            )
         return getattr(self, item)

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -15,7 +15,8 @@ class ResourceStatus(Enum):
 class SiteAdapter(metaclass=ABCMeta):
     @abstractmethod
     async def deploy_resource(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         return NotImplemented
 
     def drone_uuid(self, uuid) -> str:
@@ -25,14 +26,16 @@ class SiteAdapter(metaclass=ABCMeta):
         return NotImplemented
 
     @staticmethod
-    def handle_response(response, key_translator: dict,
-                        translator_functions: dict, **additional_content):
+    def handle_response(
+        response, key_translator: dict, translator_functions: dict, **additional_content
+    ):
         translated_response = AttributeDict()
 
         for translated_key, key in key_translator.items():
             try:
                 translated_response[translated_key] = translator_functions.get(
-                    key, lambda x: x)(response[key])
+                    key, lambda x: x
+                )(response[key])
             except KeyError:
                 continue
 
@@ -51,7 +54,8 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @abstractmethod
     async def resource_status(
-            self, resource_attributes: AttributeDict) -> AttributeDict:
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
         return NotImplemented
 
     @property

--- a/tardis/interfaces/state.py
+++ b/tardis/interfaces/state.py
@@ -31,7 +31,5 @@ class State(metaclass=ABCMeta):
     async def run_processing_pipeline(cls, drone: "Drone"):
         pipeline_processor = PipelineProcessor(cls.processing_pipeline)
         return await pipeline_processor.run_pipeline(
-            pipeline_input=cls.transition,
-            drone=drone,
-            current_state=cls
+            pipeline_input=cls.transition, drone=drone, current_state=cls
         )

--- a/tardis/plugins/telegrafmonitoring.py
+++ b/tardis/plugins/telegrafmonitoring.py
@@ -15,6 +15,7 @@ class TelegrafMonitoring(Plugin):
     implements an interface to monitor state changes of the Drones in a telegraf
     service running a UDP input module.
     """
+
     def __init__(self):
         self.logger = logging.getLogger("telegrafmonitoring")
         self.logger.setLevel(logging.DEBUG)
@@ -23,8 +24,8 @@ class TelegrafMonitoring(Plugin):
         host = config.host
         port = config.port
         default_tags = dict(tardis_machine_name=platform.node())
-        default_tags.update(getattr(config, 'default_tags', {}))
-        self.metric = getattr(config, 'metric', 'tardis_data')
+        default_tags.update(getattr(config, "default_tags", {}))
+        self.metric = getattr(config, "metric", "tardis_data")
 
         self.client = aiotelegraf.Client(host=host, port=port, tags=default_tags)
 
@@ -40,16 +41,17 @@ class TelegrafMonitoring(Plugin):
         :return: None
         """
         self.logger.debug(
-            f"Drone: {str(resource_attributes)} has changed state to {state}")
+            f"Drone: {str(resource_attributes)} has changed state to {state}"
+        )
         await self.client.connect()
         data = dict(
             state=str(state),
             created=datetime.timestamp(resource_attributes.created),
-            updated=datetime.timestamp(resource_attributes.updated)
+            updated=datetime.timestamp(resource_attributes.updated),
         )
         tags = dict(
             site_name=resource_attributes.site_name,
-            machine_type=resource_attributes.machine_type
+            machine_type=resource_attributes.machine_type,
         )
         self.client.metric(self.metric, data, tags=tags)
         await self.client.close()

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -19,10 +19,17 @@ import uuid
 
 @service(flavour=asyncio)
 class Drone(Pool):
-    def __init__(self, site_agent: SiteAgent, batch_system_agent: BatchSystemAgent,
-                 plugins: Optional[List[Plugin]] = None, remote_resource_uuid=None,
-                 drone_uuid=None, state: RequestState = RequestState(),
-                 created: float = None, updated: float = None):
+    def __init__(
+        self,
+        site_agent: SiteAgent,
+        batch_system_agent: BatchSystemAgent,
+        plugins: Optional[List[Plugin]] = None,
+        remote_resource_uuid=None,
+        drone_uuid=None,
+        state: RequestState = RequestState(),
+        created: float = None,
+        updated: float = None,
+    ):
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
         self._plugins = plugins or []
@@ -34,7 +41,7 @@ class Drone(Pool):
             remote_resource_uuid=remote_resource_uuid,
             created=created or datetime.now(),
             updated=updated or datetime.now(),
-            drone_uuid=drone_uuid or self.site_agent.drone_uuid(uuid.uuid4().hex[:10])
+            drone_uuid=drone_uuid or self.site_agent.drone_uuid(uuid.uuid4().hex[:10]),
         )
 
         self._allocation = 0.0
@@ -60,7 +67,7 @@ class Drone(Pool):
 
     @property
     def maximum_demand(self) -> float:
-        return self.site_agent.machine_meta_data['Cores']
+        return self.site_agent.machine_meta_data["Cores"]
 
     @property
     def supply(self) -> float:
@@ -80,7 +87,8 @@ class Drone(Pool):
             await asyncio.sleep(60)
             if isinstance(self.state, DownState):
                 logging.debug(
-                    f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}")
+                    f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}"
+                )
                 self._demand = 0
                 return
 

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -20,80 +20,113 @@ from importlib import import_module
 
 def str_to_state(resources):
     for entry in resources:
-        state_class = getattr(import_module(
-            name=f"tardis.resources.dronestates"), f"{entry['state']}")
-        entry['state'] = state_class()
+        state_class = getattr(
+            import_module(name=f"tardis.resources.dronestates"), f"{entry['state']}"
+        )
+        entry["state"] = state_class()
     return resources
 
 
-def create_composite_pool(configuration: str = 'tardis.yml') -> WeightedComposite:
+def create_composite_pool(configuration: str = "tardis.yml") -> WeightedComposite:
     configuration = Configuration(configuration)
 
     composites = []
 
     batch_system = configuration.BatchSystem
-    batch_system_adapter = getattr(import_module(
-        name=f"tardis.adapters.batchsystems.{batch_system.adapter.lower()}"),
-        f"{batch_system.adapter}Adapter")
+    batch_system_adapter = getattr(
+        import_module(
+            name=f"tardis.adapters.batchsystems.{batch_system.adapter.lower()}"
+        ),
+        f"{batch_system.adapter}Adapter",
+    )
     batch_system_agent = BatchSystemAgent(batch_system_adapter=batch_system_adapter())
 
     plugins = load_plugins()
 
     for site in configuration.Sites:
         site_composites = []
-        site_adapter = getattr(import_module(
-            name=f"tardis.adapters.sites.{site.adapter.lower()}"),
-            f'{site.adapter}Adapter')
+        site_adapter = getattr(
+            import_module(name=f"tardis.adapters.sites.{site.adapter.lower()}"),
+            f"{site.adapter}Adapter",
+        )
         for machine_type in getattr(configuration, site.name).MachineTypes:
-            site_agent = SiteAgent(site_adapter(
-                machine_type=machine_type,
-                site_name=site.name
-            ))
+            site_agent = SiteAgent(
+                site_adapter(machine_type=machine_type, site_name=site.name)
+            )
 
             check_pointed_resources = get_drones_to_restore(plugins, site, machine_type)
-            check_pointed_drones = [create_drone(site_agent=site_agent,
-                                                 batch_system_agent=batch_system_agent,
-                                                 plugins=plugins.values(),
-                                                 **resource_attributes)
-                                    for resource_attributes in check_pointed_resources]
+            check_pointed_drones = [
+                create_drone(
+                    site_agent=site_agent,
+                    batch_system_agent=batch_system_agent,
+                    plugins=plugins.values(),
+                    **resource_attributes,
+                )
+                for resource_attributes in check_pointed_resources
+            ]
 
             # create drone factory for COBalD FactoryPool
-            drone_factory = partial(create_drone, site_agent=site_agent,
-                                    batch_system_agent=batch_system_agent,
-                                    plugins=plugins.values())
-            cpu_cores = getattr(
-                configuration,
-                site.name
-            ).MachineMetaData[machine_type]['Cores']
-            site_composites.append(Logger(Standardiser(
-                FactoryPool(*check_pointed_drones, factory=drone_factory),
-                minimum=cpu_cores,
-                granularity=cpu_cores
-            ), name=f"{site.name.lower()}_{machine_type.lower()}"))
-        composites.append(Standardiser(WeightedComposite(*site_composites),
-                                       maximum=site.quota if site.quota >= 0 else inf))
+            drone_factory = partial(
+                create_drone,
+                site_agent=site_agent,
+                batch_system_agent=batch_system_agent,
+                plugins=plugins.values(),
+            )
+            cpu_cores = getattr(configuration, site.name).MachineMetaData[machine_type][
+                "Cores"
+            ]
+            site_composites.append(
+                Logger(
+                    Standardiser(
+                        FactoryPool(*check_pointed_drones, factory=drone_factory),
+                        minimum=cpu_cores,
+                        granularity=cpu_cores,
+                    ),
+                    name=f"{site.name.lower()}_{machine_type.lower()}",
+                )
+            )
+        composites.append(
+            Standardiser(
+                WeightedComposite(*site_composites),
+                maximum=site.quota if site.quota >= 0 else inf,
+            )
+        )
 
     return WeightedComposite(*composites)
 
 
-def create_drone(site_agent: SiteAgent, batch_system_agent: BatchSystemAgent,
-                 plugins: Optional[List[Plugin]] = None, remote_resource_uuid=None,
-                 drone_uuid=None, state: State = RequestState(), created: float = None,
-                 updated: float = None):
-    return Drone(site_agent=site_agent, batch_system_agent=batch_system_agent,
-                 plugins=plugins, remote_resource_uuid=remote_resource_uuid,
-                 drone_uuid=drone_uuid, state=state, created=created, updated=updated)
+def create_drone(
+    site_agent: SiteAgent,
+    batch_system_agent: BatchSystemAgent,
+    plugins: Optional[List[Plugin]] = None,
+    remote_resource_uuid=None,
+    drone_uuid=None,
+    state: State = RequestState(),
+    created: float = None,
+    updated: float = None,
+):
+    return Drone(
+        site_agent=site_agent,
+        batch_system_agent=batch_system_agent,
+        plugins=plugins,
+        remote_resource_uuid=remote_resource_uuid,
+        drone_uuid=drone_uuid,
+        state=state,
+        created=created,
+        updated=updated,
+    )
 
 
 def get_drones_to_restore(plugins: dict, site, machine_type: str):
     """Restore check_pointed resources from previously running tardis instance"""
     try:
-        sql_registry = plugins['SqliteRegistry']
+        sql_registry = plugins["SqliteRegistry"]
     except KeyError:
         return []
     else:
-        return str_to_state(sql_registry.get_resources(site_name=site.name,
-                                                       machine_type=machine_type))
+        return str_to_state(
+            sql_registry.get_resources(site_name=site.name, machine_type=machine_type)
+        )
 
 
 def load_plugins():
@@ -103,9 +136,12 @@ def load_plugins():
     except AttributeError:
         return {}
     else:
+
         def create_instance(plugin):
-            return getattr(import_module(
-                name=f"tardis.plugins.{plugin.lower()}"), f'{plugin}')()
+            return getattr(
+                import_module(name=f"tardis.plugins.{plugin.lower()}"), f"{plugin}"
+            )()
+
         return {
             plugin: create_instance(plugin) for plugin in plugin_configuration.keys()
         }

--- a/tardis/utilities/asynccachemap.py
+++ b/tardis/utilities/asynccachemap.py
@@ -37,7 +37,8 @@ class AsyncCacheMap(Mapping):
                     data = await self._update_coroutine()
                 except json.decoder.JSONDecodeError as je:
                     logging.error(
-                        f"AsyncMap update_status failed: Could not decode json {je}")
+                        f"AsyncMap update_status failed: Could not decode json {je}"
+                    )
                 except CommandExecutionFailure as cf:
                     logging.error(f"AsyncMap update_status failed: {cf}")
                 else:

--- a/tardis/utilities/attributedict.py
+++ b/tardis/utilities/attributedict.py
@@ -15,7 +15,8 @@ class AttributeDict(dict):
             return self[item]
         except KeyError:
             raise AttributeError(
-                f"{item} is not a valid attribute. Dict contains {str(self)}.")
+                f"{item} is not a valid attribute. Dict contains {str(self)}."
+            )
 
     def __setattr__(self, key, value):
         self[key] = value
@@ -25,4 +26,5 @@ class AttributeDict(dict):
             del self[item]
         except KeyError:
             raise AttributeError(
-                f"{item} is not a valid attribute. Dict contains {str(self)}.")
+                f"{item} is not a valid attribute. Dict contains {str(self)}."
+            )

--- a/tardis/utilities/executors/shellexecutor.py
+++ b/tardis/utilities/executors/shellexecutor.py
@@ -16,11 +16,12 @@ class ShellExecutor(Executor):
             command,
             stdin=stdin_input and asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+            stderr=asyncio.subprocess.PIPE,
         )
 
         stdout, stderr = await sub_process.communicate(
-            stdin_input and stdin_input.encode())
+            stdin_input and stdin_input.encode()
+        )
         exit_code = sub_process.returncode
 
         if exit_code:
@@ -29,10 +30,11 @@ class ShellExecutor(Executor):
                 exit_code=exit_code,
                 stdout=stdout.decode().strip(),
                 stderr=stderr.decode().strip(),
-                stdin=stdin_input
+                stdin=stdin_input,
             )
 
         return AttributeDict(
             stdout=stdout.decode().strip(),
             stderr=stderr.decode().strip(),
-            exit_code=exit_code)
+            exit_code=exit_code,
+        )

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -6,7 +6,7 @@ from ..attributedict import AttributeDict
 import asyncssh
 
 
-@enable_yaml_load('!SSHExecutor')
+@enable_yaml_load("!SSHExecutor")
 class SSHExecutor(Executor):
     def __init__(self, **parameters):
         self._parameters = parameters
@@ -15,9 +15,7 @@ class SSHExecutor(Executor):
         async with asyncssh.connect(**self._parameters) as conn:
             try:
                 response = await conn.run(
-                    command,
-                    check=True,
-                    input=stdin_input and stdin_input.encode()
+                    command, check=True, input=stdin_input and stdin_input.encode()
                 )
             except asyncssh.ProcessError as pe:
                 raise CommandExecutionFailure(
@@ -25,20 +23,24 @@ class SSHExecutor(Executor):
                     exit_code=pe.exit_status,
                     stdin=stdin_input,
                     stdout=pe.stdout,
-                    stderr=pe.stderr
+                    stderr=pe.stderr,
                 ) from pe
-            except (ConnectionResetError, asyncssh.misc.DisconnectError,
-                    asyncssh.misc.ConnectionLost, BrokenPipeError) as ce:
+            except (
+                ConnectionResetError,
+                asyncssh.misc.DisconnectError,
+                asyncssh.misc.ConnectionLost,
+                BrokenPipeError,
+            ) as ce:
                 raise CommandExecutionFailure(
                     message=f"Could not run command {command} due to SSH failure: {ce}",
                     exit_code=255,
                     stdout="",
-                    stderr="SSH failure"
+                    stderr="SSH failure",
                 ) from ce
 
             else:
                 return AttributeDict(
                     stdout=response.stdout,
                     stderr=response.stderr,
-                    exit_code=response.exit_status
+                    exit_code=response.exit_status,
                 )

--- a/tardis/utilities/simulators/periodicvalue.py
+++ b/tardis/utilities/simulators/periodicvalue.py
@@ -18,4 +18,5 @@ class PeriodicValue(Simulator):
     def get_value(self) -> float:
         t = (datetime.now() - self._start_time).total_seconds()
         return self._offset + self._amplitude * sin(
-            ((t / self._period) * 2 * pi) + self._phase)
+            ((t / self._period) * 2 * pi) + self._phase
+        )

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -23,19 +23,19 @@ async def async_run_command(cmd, shell_executor=ShellExecutor()):
 
 
 def htcondor_cmd_option_formatter(options):
-    options = (f"-{name} {value}" if value is not None else f"-{name}"
-               for name, value in options.items())
+    options = (
+        f"-{name} {value}" if value is not None else f"-{name}"
+        for name, value in options.items()
+    )
 
     return " ".join(options)
 
 
-def htcondor_csv_parser(htcondor_input, fieldnames, delimiter='\t', replacements=None):
+def htcondor_csv_parser(htcondor_input, fieldnames, delimiter="\t", replacements=None):
     replacements = replacements or {}
     with StringIO(htcondor_input) as csv_input:
         cvs_reader = csv.DictReader(
-            csv_input,
-            fieldnames=fieldnames,
-            delimiter=delimiter
+            csv_input, fieldnames=fieldnames, delimiter=delimiter
         )
         for row in cvs_reader:
             yield {

--- a/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
+++ b/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
@@ -10,9 +10,12 @@ from unittest import TestCase
 
 class TestFakeBatchSystemAdapter(TestCase):
     mock_config_patcher = None
+
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.batchsystems.fakebatchsystem.Configuration')
+        cls.mock_config_patcher = patch(
+            "tardis.adapters.batchsystems.fakebatchsystem.Configuration"
+        )
         cls.mock_config = cls.mock_config_patcher.start()
 
     @classmethod
@@ -28,30 +31,36 @@ class TestFakeBatchSystemAdapter(TestCase):
         self.fake_adapter = FakeBatchSystemAdapter()
 
     def test_disintegrate_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.disintegrate_machine, 'test-123'))
+        self.assertIsNone(run_async(self.fake_adapter.disintegrate_machine, "test-123"))
 
     def test_drain_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.drain_machine, 'test-123'))
+        self.assertIsNone(run_async(self.fake_adapter.drain_machine, "test-123"))
 
     def test_integrate_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.integrate_machine, 'test-123'))
+        self.assertIsNone(run_async(self.fake_adapter.integrate_machine, "test-123"))
 
     def test_get_allocation(self):
-        self.assertEqual(run_async(self.fake_adapter.get_allocation, 'test-123'), 1.0)
+        self.assertEqual(run_async(self.fake_adapter.get_allocation, "test-123"), 1.0)
 
         self.config.BatchSystem.allocation = AttributeDict(get_value=lambda: 0.9)
         self.fake_adapter = FakeBatchSystemAdapter()
-        self.assertEqual(run_async(self.fake_adapter.get_allocation, 'test-123'), 0.9)
+        self.assertEqual(run_async(self.fake_adapter.get_allocation, "test-123"), 0.9)
 
     def test_get_machine_status(self):
-        self.assertEqual(run_async(self.fake_adapter.get_machine_status, 'test-123'), MachineStatus.Available)
+        self.assertEqual(
+            run_async(self.fake_adapter.get_machine_status, "test-123"),
+            MachineStatus.Available,
+        )
 
-        run_async(self.fake_adapter.drain_machine, 'test-123')
-        self.assertEqual(run_async(self.fake_adapter.get_machine_status, 'test-123'), MachineStatus.Drained)
+        run_async(self.fake_adapter.drain_machine, "test-123")
+        self.assertEqual(
+            run_async(self.fake_adapter.get_machine_status, "test-123"),
+            MachineStatus.Drained,
+        )
 
     def test_get_utilization(self):
-        self.assertEqual(run_async(self.fake_adapter.get_utilization, 'test-123'), 1.0)
+        self.assertEqual(run_async(self.fake_adapter.get_utilization, "test-123"), 1.0)
 
         self.config.BatchSystem.utilization = AttributeDict(get_value=lambda: 0.9)
         self.fake_adapter = FakeBatchSystemAdapter()
-        self.assertEqual(run_async(self.fake_adapter.get_utilization, 'test-123'), 0.9)
+        self.assertEqual(run_async(self.fake_adapter.get_utilization, "test-123"), 0.9)

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -14,8 +14,12 @@ from unittest import TestCase
 class TestHTCondorAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.batchsystems.htcondor.Configuration')
-        cls.mock_async_run_command_patcher = patch('tardis.adapters.batchsystems.htcondor.async_run_command')
+        cls.mock_config_patcher = patch(
+            "tardis.adapters.batchsystems.htcondor.Configuration"
+        )
+        cls.mock_async_run_command_patcher = patch(
+            "tardis.adapters.batchsystems.htcondor.async_run_command"
+        )
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_async_run_command = cls.mock_async_run_command_patcher.start()
 
@@ -27,25 +31,34 @@ class TestHTCondorAdapter(TestCase):
     def setUp(self):
         self.cpu_ratio = 0.9
         self.memory_ratio = 0.8
-        self.command = "condor_status -af:t Machine State Activity TardisDroneUuid " \
-                       "'Real(TotalSlotCpus-Cpus)/TotalSlotCpus' " \
-                       "'Real(TotalSlotMemory-Memory)/TotalSlotMemory' -constraint PartitionableSlot=?=True" \
-                       " -pool my-htcondor.local -test"
+        self.command = (
+            "condor_status -af:t Machine State Activity TardisDroneUuid "
+            "'Real(TotalSlotCpus-Cpus)/TotalSlotCpus' "
+            "'Real(TotalSlotMemory-Memory)/TotalSlotMemory' -constraint PartitionableSlot=?=True"
+            " -pool my-htcondor.local -test"
+        )
 
-        self.command_wo_options = "condor_status -af:t Machine State Activity TardisDroneUuid " \
-                                  "'Real(TotalSlotCpus-Cpus)/TotalSlotCpus' " \
-                                  "'Real(TotalSlotMemory-Memory)/TotalSlotMemory' -constraint PartitionableSlot=?=True"
+        self.command_wo_options = (
+            "condor_status -af:t Machine State Activity TardisDroneUuid "
+            "'Real(TotalSlotCpus-Cpus)/TotalSlotCpus' "
+            "'Real(TotalSlotMemory-Memory)/TotalSlotMemory' -constraint PartitionableSlot=?=True"
+        )
 
-        return_value = "\n".join([f"test\tUnclaimed\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
-                                  f"test_drain\tDrained\tRetiring\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
-                                  f"test_drained\tDrained\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
-                                  f"test_owner\tOwner\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
-                                  f"test_uuid_plus\tUnclaimed\tIdle\ttest_uuid\t{self.cpu_ratio}\t{self.memory_ratio}",
-                                  "exoscale-26d361290f\tUnclaimed\tIdle\tundefined\t0.125\t0.125"])
-        self.mock_async_run_command.return_value = async_return(return_value=return_value)
+        return_value = "\n".join(
+            [
+                f"test\tUnclaimed\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
+                f"test_drain\tDrained\tRetiring\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
+                f"test_drained\tDrained\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
+                f"test_owner\tOwner\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",
+                f"test_uuid_plus\tUnclaimed\tIdle\ttest_uuid\t{self.cpu_ratio}\t{self.memory_ratio}",
+                "exoscale-26d361290f\tUnclaimed\tIdle\tundefined\t0.125\t0.125",
+            ]
+        )
+        self.mock_async_run_command.return_value = async_return(
+            return_value=return_value
+        )
 
-        self.setup_config_mock(options={'pool': 'my-htcondor.local',
-                                        'test': None})
+        self.setup_config_mock(options={"pool": "my-htcondor.local", "test": None})
 
         self.htcondor_adapter = HTCondorAdapter()
 
@@ -54,8 +67,10 @@ class TestHTCondorAdapter(TestCase):
 
     def setup_config_mock(self, options=None):
         self.config = self.mock_config.return_value
-        self.config.BatchSystem.ratios = {'cpu_ratio': 'Real(TotalSlotCpus-Cpus)/TotalSlotCpus',
-                                          'memory_ratio': 'Real(TotalSlotMemory-Memory)/TotalSlotMemory'}
+        self.config.BatchSystem.ratios = {
+            "cpu_ratio": "Real(TotalSlotCpus-Cpus)/TotalSlotCpus",
+            "memory_ratio": "Real(TotalSlotMemory-Memory)/TotalSlotMemory",
+        }
         self.config.BatchSystem.max_age = 10
         if options:
             self.config.BatchSystem.options = options
@@ -63,22 +78,32 @@ class TestHTCondorAdapter(TestCase):
             self.config.BatchSystem.options = {}
 
     def test_disintegrate_machine(self):
-        self.assertIsNone(run_async(self.htcondor_adapter.disintegrate_machine, drone_uuid='test'))
+        self.assertIsNone(
+            run_async(self.htcondor_adapter.disintegrate_machine, drone_uuid="test")
+        )
 
     def test_drain_machine(self):
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid='test')
-        self.mock_async_run_command.assert_called_with('condor_drain -pool my-htcondor.local -test -graceful test')
-        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists"))
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Does not exists",
-                                                                          exit_code=1,
-                                                                          stderr="Does not exists")
-        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
+        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+        self.mock_async_run_command.assert_called_with(
+            "condor_drain -pool my-htcondor.local -test -graceful test"
+        )
+        self.assertIsNone(
+            run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists")
+        )
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(
+            message="Does not exists", exit_code=1, stderr="Does not exists"
+        )
+        self.assertIsNone(
+            run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+        )
 
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Unhandled error",
-                                                                          exit_code=2,
-                                                                          stderr="Unhandled error")
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(
+            message="Unhandled error", exit_code=2, stderr="Unhandled error"
+        )
         with self.assertRaises(CommandExecutionFailure):
-            self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
+            self.assertIsNone(
+                run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+            )
 
         self.mock_async_run_command.side_effect = None
 
@@ -86,73 +111,124 @@ class TestHTCondorAdapter(TestCase):
         self.setup_config_mock()
         self.htcondor_adapter = HTCondorAdapter()
 
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid='test')
-        self.mock_async_run_command.assert_called_with('condor_drain -graceful test')
+        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+        self.mock_async_run_command.assert_called_with("condor_drain -graceful test")
 
     def test_integrate_machine(self):
-        self.assertIsNone(run_async(self.htcondor_adapter.integrate_machine, drone_uuid='test'))
+        self.assertIsNone(
+            run_async(self.htcondor_adapter.integrate_machine, drone_uuid="test")
+        )
 
     def test_get_resource_ratios(self):
-        self.assertCountEqual(list(run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid='test')),
-                              [self.cpu_ratio, self.memory_ratio])
+        self.assertCountEqual(
+            list(
+                run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid="test")
+            ),
+            [self.cpu_ratio, self.memory_ratio],
+        )
         self.mock_async_run_command.assert_called_with(self.command)
 
-        self.assertEqual(run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid='not_exists'), {})
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_resource_ratios, drone_uuid="not_exists"
+            ),
+            {},
+        )
 
     def test_get_resource_ratios_without_options(self):
         self.setup_config_mock()
         del self.config.BatchSystem.options
         self.htcondor_adapter = HTCondorAdapter()
 
-        self.assertCountEqual(list(run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid='test')),
-                             [self.cpu_ratio, self.memory_ratio])
+        self.assertCountEqual(
+            list(
+                run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid="test")
+            ),
+            [self.cpu_ratio, self.memory_ratio],
+        )
 
         self.mock_async_run_command.assert_called_with(self.command_wo_options)
 
     def test_get_allocation(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_allocation, drone_uuid='test'),
-                         max([self.cpu_ratio, self.memory_ratio]))
+        self.assertEqual(
+            run_async(self.htcondor_adapter.get_allocation, drone_uuid="test"),
+            max([self.cpu_ratio, self.memory_ratio]),
+        )
         self.mock_async_run_command.assert_called_with(self.command)
 
     def test_get_machine_status(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test'),
-                         MachineStatus.Available)
+        self.assertEqual(
+            run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test"),
+            MachineStatus.Available,
+        )
         self.mock_async_run_command.assert_called_with(self.command)
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='not_exists'),
-                         MachineStatus.NotAvailable)
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_machine_status, drone_uuid="not_exists"
+            ),
+            MachineStatus.NotAvailable,
+        )
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_drain'),
-                         MachineStatus.Draining)
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_machine_status, drone_uuid="test_drain"
+            ),
+            MachineStatus.Draining,
+        )
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_drained'),
-                         MachineStatus.Drained)
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_machine_status, drone_uuid="test_drained"
+            ),
+            MachineStatus.Drained,
+        )
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_owner'),
-                         MachineStatus.NotAvailable)
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_machine_status, drone_uuid="test_owner"
+            ),
+            MachineStatus.NotAvailable,
+        )
         self.mock_async_run_command.reset_mock()
 
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_uuid'),
-                         MachineStatus.Available)
+        self.assertEqual(
+            run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test_uuid"),
+            MachineStatus.Available,
+        )
         self.mock_async_run_command.reset_mock()
 
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(message="Test", exit_code=123,
-                                                                          stderr="Test")
-        with self.assertLogs(level='ERROR'):
+        self.mock_async_run_command.side_effect = CommandExecutionFailure(
+            message="Test", exit_code=123, stderr="Test"
+        )
+        with self.assertLogs(level="ERROR"):
             with self.assertRaises(CommandExecutionFailure):
-                attributes = {"Machine": "Machine", "State": "State",
-                              "Activity": "Activity",
-                              "TardisDroneUuid": "TardisDroneUuid"}
+                attributes = {
+                    "Machine": "Machine",
+                    "State": "State",
+                    "Activity": "Activity",
+                    "TardisDroneUuid": "TardisDroneUuid",
+                }
                 # Escape htcondor expressions and add them to attributes
-                attributes.update({key: quote(value) for key, value in
-                                   self.config.BatchSystem.ratios.items()})
+                attributes.update(
+                    {
+                        key: quote(value)
+                        for key, value in self.config.BatchSystem.ratios.items()
+                    }
+                )
                 run_async(
-                    partial(htcondor_status_updater, self.config.BatchSystem.options,
-                            attributes))
+                    partial(
+                        htcondor_status_updater,
+                        self.config.BatchSystem.options,
+                        attributes,
+                    )
+                )
                 self.mock_async_run_command.assert_called_with(self.command)
         self.mock_async_run_command.side_effect = None
 
     def test_get_utilization(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_utilization, drone_uuid='test'),
-                         min([self.cpu_ratio, self.memory_ratio]))
+        self.assertEqual(
+            run_async(self.htcondor_adapter.get_utilization, drone_uuid="test"),
+            min([self.cpu_ratio, self.memory_ratio]),
+        )
         self.mock_async_run_command.assert_called_with(self.command)

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -20,9 +20,13 @@ import asyncio
 class TestCloudStackAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.cloudstack.Configuration')
+        cls.mock_config_patcher = patch(
+            "tardis.adapters.sites.cloudstack.Configuration"
+        )
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_cloudstack_api_patcher = patch('tardis.adapters.sites.cloudstack.CloudStack')
+        cls.mock_cloudstack_api_patcher = patch(
+            "tardis.adapters.sites.cloudstack.CloudStack"
+        )
         cls.mock_cloudstack_api = cls.mock_cloudstack_api_patcher.start()
 
     @classmethod
@@ -33,73 +37,122 @@ class TestCloudStackAdapter(TestCase):
     def setUp(self):
         config = self.mock_config.return_value
         test_site_config = config.TestSite
-        test_site_config.end_point = 'https://test.cloudstack.local/compute'
-        test_site_config.api_key = '1234567890abcdef'
-        test_site_config.api_secret = 'fedcba0987654321'
-        test_site_config.MachineTypeConfiguration = \
-            AttributeDict(test2large=AttributeDict(templateid="1b0b9253-929e-4865-874b-7d2c3491987b",
-                                                   serviceofferingid="74bfaf4e-7d67-4adf-9322-12b9a36e84f7",
-                                                   zoneid="35eb7739-d19e-45f7-a581-4687c54d6d02",
-                                                   keypair="MG",
-                                                   rootdisksize=500))
+        test_site_config.end_point = "https://test.cloudstack.local/compute"
+        test_site_config.api_key = "1234567890abcdef"
+        test_site_config.api_secret = "fedcba0987654321"
+        test_site_config.MachineTypeConfiguration = AttributeDict(
+            test2large=AttributeDict(
+                templateid="1b0b9253-929e-4865-874b-7d2c3491987b",
+                serviceofferingid="74bfaf4e-7d67-4adf-9322-12b9a36e84f7",
+                zoneid="35eb7739-d19e-45f7-a581-4687c54d6d02",
+                keypair="MG",
+                rootdisksize=500,
+            )
+        )
 
-        test_site_config.MachineMetaData = AttributeDict(test2large=AttributeDict(Cores=128))
+        test_site_config.MachineMetaData = AttributeDict(
+            test2large=AttributeDict(Cores=128)
+        )
 
         cloudstack_api = self.mock_cloudstack_api.return_value
-        self.deploy_return_value = AttributeDict(virtualmachine=AttributeDict(name='testsite-089123',
-                                                                              id='123456', state='Present'))
-        cloudstack_api.deployVirtualMachine.return_value = async_return(return_value=self.deploy_return_value)
-        self.list_vm_return_value = AttributeDict(virtualmachine=[AttributeDict(name='testsite-089123',
-                                                                                id='123456', state='Running')])
-        cloudstack_api.listVirtualMachines.return_value = async_return(return_value=self.list_vm_return_value)
+        self.deploy_return_value = AttributeDict(
+            virtualmachine=AttributeDict(
+                name="testsite-089123", id="123456", state="Present"
+            )
+        )
+        cloudstack_api.deployVirtualMachine.return_value = async_return(
+            return_value=self.deploy_return_value
+        )
+        self.list_vm_return_value = AttributeDict(
+            virtualmachine=[
+                AttributeDict(name="testsite-089123", id="123456", state="Running")
+            ]
+        )
+        cloudstack_api.listVirtualMachines.return_value = async_return(
+            return_value=self.list_vm_return_value
+        )
 
         cloudstack_api.stopVirtualMachine.return_value = async_return(return_value=None)
 
-        cloudstack_api.destroyVirtualMachine.return_value = async_return(return_value=None)
+        cloudstack_api.destroyVirtualMachine.return_value = async_return(
+            return_value=None
+        )
 
-        self.cloudstack_adapter = CloudStackAdapter(machine_type='test2large', site_name='TestSite')
+        self.cloudstack_adapter = CloudStackAdapter(
+            machine_type="test2large", site_name="TestSite"
+        )
 
     def tearDown(self):
         self.mock_cloudstack_api.reset_mock()
 
     def test_deploy_resource(self):
-        self.assertEqual(run_async(self.cloudstack_adapter.deploy_resource,
-                                   resource_attributes=AttributeDict(drone_uuid='testsite-089123')),
-                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='123456',
-                                       resource_status=ResourceStatus.Booting))
+        self.assertEqual(
+            run_async(
+                self.cloudstack_adapter.deploy_resource,
+                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            ),
+            AttributeDict(
+                drone_uuid="testsite-089123",
+                remote_resource_uuid="123456",
+                resource_status=ResourceStatus.Booting,
+            ),
+        )
 
         self.mock_cloudstack_api.return_value.deployVirtualMachine.assert_called_with(
-            name='testsite-089123', templateid="1b0b9253-929e-4865-874b-7d2c3491987b",
-            serviceofferingid="74bfaf4e-7d67-4adf-9322-12b9a36e84f7", zoneid="35eb7739-d19e-45f7-a581-4687c54d6d02",
-            keypair="MG", rootdisksize=500)
+            name="testsite-089123",
+            templateid="1b0b9253-929e-4865-874b-7d2c3491987b",
+            serviceofferingid="74bfaf4e-7d67-4adf-9322-12b9a36e84f7",
+            zoneid="35eb7739-d19e-45f7-a581-4687c54d6d02",
+            keypair="MG",
+            rootdisksize=500,
+        )
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.cloudstack_adapter.machine_meta_data, AttributeDict(Cores=128))
+        self.assertEqual(
+            self.cloudstack_adapter.machine_meta_data, AttributeDict(Cores=128)
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.cloudstack_adapter.machine_type, 'test2large')
+        self.assertEqual(self.cloudstack_adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.cloudstack_adapter.site_name, 'TestSite')
+        self.assertEqual(self.cloudstack_adapter.site_name, "TestSite")
 
     def test_resource_status(self):
-        self.assertEqual(run_async(self.cloudstack_adapter.resource_status,
-                                   resource_attributes=AttributeDict(remote_resource_uuid='123456')),
-                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='123456',
-                                       resource_status=ResourceStatus.Running))
-        self.mock_cloudstack_api.return_value.listVirtualMachines.assert_called_with(id='123456')
+        self.assertEqual(
+            run_async(
+                self.cloudstack_adapter.resource_status,
+                resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+            ),
+            AttributeDict(
+                drone_uuid="testsite-089123",
+                remote_resource_uuid="123456",
+                resource_status=ResourceStatus.Running,
+            ),
+        )
+        self.mock_cloudstack_api.return_value.listVirtualMachines.assert_called_with(
+            id="123456"
+        )
 
     def test_stop_resource(self):
-        run_async(self.cloudstack_adapter.stop_resource,
-                  resource_attributes=AttributeDict(remote_resource_uuid='123456'))
+        run_async(
+            self.cloudstack_adapter.stop_resource,
+            resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+        )
 
-        self.mock_cloudstack_api.return_value.stopVirtualMachine.assert_called_with(id='123456')
+        self.mock_cloudstack_api.return_value.stopVirtualMachine.assert_called_with(
+            id="123456"
+        )
 
     def test_terminate_resource(self):
-        run_async(self.cloudstack_adapter.terminate_resource,
-                  resource_attributes=AttributeDict(remote_resource_uuid='123456'))
+        run_async(
+            self.cloudstack_adapter.terminate_resource,
+            resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+        )
 
-        self.mock_cloudstack_api.return_value.destroyVirtualMachine.assert_called_with(id='123456')
+        self.mock_cloudstack_api.return_value.destroyVirtualMachine.assert_called_with(
+            id="123456"
+        )
 
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
@@ -107,26 +160,50 @@ class TestCloudStackAdapter(TestCase):
                 with self.cloudstack_adapter.handle_exceptions():
                     raise to_raise
 
-        matrix = [(CloudStackClientException(message="Quota Exceeded",
-                                             error_code=535,
-                                             error_text="Quota Exceeded"), TardisQuotaExceeded),
-                  (asyncio.TimeoutError(), TardisTimeout),
-                  (ClientConnectionError(), TardisResourceStatusUpdateFailed),
-                  (CloudStackClientException(message="Timeout",
-                                             error_code=500,
-                                             response={'message': 'timed out after 1000.0 ms'}), TardisTimeout),
-                  (CloudStackClientException(message="Timeout",
-                                             error_code=500,
-                                             response={'message': 'connection was closed'}),
-                   TardisResourceStatusUpdateFailed),
-                  (CloudStackClientException(message="Something else",
-                                             error_code=500,
-                                             response={'message': 'Something else'}),
-                   TardisError),
-                  (CloudStackClientException(message="Something Else",
-                                             error_code=666,
-                                             error_text="Something Else"), TardisError)
-                  ]
+        matrix = [
+            (
+                CloudStackClientException(
+                    message="Quota Exceeded",
+                    error_code=535,
+                    error_text="Quota Exceeded",
+                ),
+                TardisQuotaExceeded,
+            ),
+            (asyncio.TimeoutError(), TardisTimeout),
+            (ClientConnectionError(), TardisResourceStatusUpdateFailed),
+            (
+                CloudStackClientException(
+                    message="Timeout",
+                    error_code=500,
+                    response={"message": "timed out after 1000.0 ms"},
+                ),
+                TardisTimeout,
+            ),
+            (
+                CloudStackClientException(
+                    message="Timeout",
+                    error_code=500,
+                    response={"message": "connection was closed"},
+                ),
+                TardisResourceStatusUpdateFailed,
+            ),
+            (
+                CloudStackClientException(
+                    message="Something else",
+                    error_code=500,
+                    response={"message": "Something else"},
+                ),
+                TardisError,
+            ),
+            (
+                CloudStackClientException(
+                    message="Something Else",
+                    error_code=666,
+                    error_text="Something Else",
+                ),
+                TardisError,
+            ),
+        ]
 
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)

--- a/tests/adapters_t/sites_t/test_fakesite.py
+++ b/tests/adapters_t/sites_t/test_fakesite.py
@@ -16,7 +16,7 @@ class TestFakeSiteAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.fakesite.Configuration')
+        cls.mock_config_patcher = patch("tardis.adapters.sites.fakesite.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
 
     @classmethod
@@ -31,7 +31,7 @@ class TestFakeSiteAdapter(TestCase):
         test_site_config.api_response_delay = AttributeDict(get_value=lambda: 0)
         test_site_config.resource_boot_time = AttributeDict(get_value=lambda: 100)
 
-        self.adapter = FakeSiteAdapter(machine_type='test2large', site_name='TestSite')
+        self.adapter = FakeSiteAdapter(machine_type="test2large", site_name="TestSite")
 
     @property
     def machine_meta_data(self):
@@ -39,7 +39,7 @@ class TestFakeSiteAdapter(TestCase):
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict(jdl='submit.jdl'))
+        return AttributeDict(test2large=AttributeDict(jdl="submit.jdl"))
 
     def test_deploy_resource(self):
         response = run_async(self.adapter.deploy_resource, AttributeDict())
@@ -48,19 +48,26 @@ class TestFakeSiteAdapter(TestCase):
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.adapter.machine_meta_data, self.machine_meta_data.test2large)
+        self.assertEqual(
+            self.adapter.machine_meta_data, self.machine_meta_data.test2large
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.adapter.machine_type, 'test2large')
+        self.assertEqual(self.adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.adapter.site_name, 'TestSite')
+        self.assertEqual(self.adapter.site_name, "TestSite")
 
     def test_resource_status(self):
         # test tardis restart, where resource_boot_time is not set
-        response = run_async(self.adapter.resource_status, AttributeDict(created=datetime.now(),
-                                                                         resource_status=ResourceStatus.Booting,
-                                                                         drone_uuid="test-123"))
+        response = run_async(
+            self.adapter.resource_status,
+            AttributeDict(
+                created=datetime.now(),
+                resource_status=ResourceStatus.Booting,
+                drone_uuid="test-123",
+            ),
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
         deploy_response = run_async(self.adapter.deploy_resource, AttributeDict())
@@ -69,7 +76,9 @@ class TestFakeSiteAdapter(TestCase):
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
         past_timestamp = datetime.now() - timedelta(seconds=100)
-        deploy_response.update(AttributeDict(created=past_timestamp, drone_uuid="test-123"))
+        deploy_response.update(
+            AttributeDict(created=past_timestamp, drone_uuid="test-123")
+        )
         response = run_async(self.adapter.resource_status, deploy_response)
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -57,9 +57,11 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.htcondor.Configuration')
+        cls.mock_config_patcher = patch("tardis.adapters.sites.htcondor.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_executor_patcher = patch('tardis.adapters.sites.htcondor.ShellExecutor')
+        cls.mock_executor_patcher = patch(
+            "tardis.adapters.sites.htcondor.ShellExecutor"
+        )
         cls.mock_executor = cls.mock_executor_patcher.start()
 
     @classmethod
@@ -75,143 +77,225 @@ class TestHTCondorSiteAdapter(TestCase):
         test_site_config.executor = self.mock_executor.return_value
         test_site_config.max_age = 10
 
-        self.adapter = HTCondorAdapter(machine_type='test2large', site_name='TestSite')
+        self.adapter = HTCondorAdapter(machine_type="test2large", site_name="TestSite")
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=8, Memory=32, Disk=160),
-                             testunkownresource=AttributeDict(Cores=8, Memory=32, Disk=160, Foo=3))
+        return AttributeDict(
+            test2large=AttributeDict(Cores=8, Memory=32, Disk=160),
+            testunkownresource=AttributeDict(Cores=8, Memory=32, Disk=160, Foo=3),
+        )
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict(jdl='tests/data/submit.jdl'),
-                             testunkownresource=AttributeDict(jdl='tests/data/submit.jdl'))
+        return AttributeDict(
+            test2large=AttributeDict(jdl="tests/data/submit.jdl"),
+            testunkownresource=AttributeDict(jdl="tests/data/submit.jdl"),
+        )
 
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
-        response = run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
+        response = run_async(
+            self.adapter.deploy_resource, AttributeDict(drone_uuid="test-123")
+        )
         self.assertEqual(response.remote_resource_uuid, "1351043")
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
-        self.mock_executor.return_value.run_command.assert_called_with("condor_submit", stdin_input=CONDOR_SUBMIT_JDL)
+        self.mock_executor.return_value.run_command.assert_called_with(
+            "condor_submit", stdin_input=CONDOR_SUBMIT_JDL
+        )
         self.mock_executor.reset()
 
     def test_translate_resources_raises_logs(self):
-        self.adapter = HTCondorAdapter(machine_type='testunkownresource', site_name='TestSite')
+        self.adapter = HTCondorAdapter(
+            machine_type="testunkownresource", site_name="TestSite"
+        )
         with self.assertLogs(logging.getLogger(), logging.ERROR):
             with self.assertRaises(KeyError):
-                run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
+                run_async(
+                    self.adapter.deploy_resource, AttributeDict(drone_uuid="test-123")
+                )
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.adapter.machine_meta_data, self.machine_meta_data.test2large)
+        self.assertEqual(
+            self.adapter.machine_meta_data, self.machine_meta_data.test2large
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.adapter.machine_type, 'test2large')
+        self.assertEqual(self.adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.adapter.site_name, 'TestSite')
+        self.assertEqual(self.adapter.site_name, "TestSite")
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
     def test_resource_status_run(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_REMOVING)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status,
-                             AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_HELD)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT)
     def test_resource_status_idle(self):
-        response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUSPENDED)
     def test_resource_status_unexpanded(self):
-        response = run_async(self.adapter.resource_status,
-                             AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
-                                                                                  stderr="Failed", exit_code=2))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+        ),
+    )
     def test_resource_status_raise_future(self):
         future_timestamp = datetime.now() + timedelta(minutes=1)
         with self.assertLogs(logging.getLogger(), logging.ERROR):
             with self.assertRaises(TardisResourceStatusUpdateFailed):
-                run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043",
-                                                                      created=future_timestamp))
+                run_async(
+                    self.adapter.resource_status,
+                    AttributeDict(
+                        remote_resource_uuid="1351043", created=future_timestamp
+                    ),
+                )
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message="Failed", stdout="Failed",
-                                                                                  stderr="Failed", exit_code=2))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+        ),
+    )
     def test_resource_status_raise_past(self):
         # Update interval is 10 minutes, so set last update back by 11 minutes in order to execute condor_q command and
         # creation date to 12 minutes ago
         past_timestamp = datetime.now() - timedelta(minutes=12)
-        self.adapter._htcondor_queue._last_update = datetime.now() - timedelta(minutes=11)
+        self.adapter._htcondor_queue._last_update = datetime.now() - timedelta(
+            minutes=11
+        )
         with self.assertLogs(logging.getLogger(), logging.ERROR):
-            response = run_async(self.adapter.resource_status, AttributeDict(remote_resource_uuid="1351043",
-                                                                             created=past_timestamp))
+            response = run_async(
+                self.adapter.resource_status,
+                AttributeDict(remote_resource_uuid="1351043", created=past_timestamp),
+            )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     @mock_executor_run_command(stdout=CONDOR_SUSPEND_OUTPUT)
     def test_stop_resource(self):
-        response = run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043")
+        )
         self.assertEqual(response.remote_resource_uuid, "1351043")
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(
-        message=CONDOR_SUSPEND_FAILED_MESSAGE,
-        exit_code=1,
-        stderr=CONDOR_SUSPEND_FAILED_OUTPUT,
-        stdout="", stdin=""))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message=CONDOR_SUSPEND_FAILED_MESSAGE,
+            exit_code=1,
+            stderr=CONDOR_SUSPEND_FAILED_OUTPUT,
+            stdout="",
+            stdin="",
+        ),
+    )
     def test_stop_resource_failed_redo(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043"))
+            run_async(
+                self.adapter.stop_resource,
+                AttributeDict(remote_resource_uuid="1351043"),
+            )
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_SUSPEND_FAILED_MESSAGE,
-                                                                                  exit_code=2,
-                                                                                  stderr=CONDOR_SUSPEND_FAILED_OUTPUT,
-                                                                                  stdout="", stdin=""))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message=CONDOR_SUSPEND_FAILED_MESSAGE,
+            exit_code=2,
+            stderr=CONDOR_SUSPEND_FAILED_OUTPUT,
+            stdout="",
+            stdin="",
+        ),
+    )
     def test_stop_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043"))
+            run_async(
+                self.adapter.stop_resource,
+                AttributeDict(remote_resource_uuid="1351043"),
+            )
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
-        response = run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
+        response = run_async(
+            self.adapter.terminate_resource,
+            AttributeDict(remote_resource_uuid="1351043"),
+        )
         self.assertEqual(response.remote_resource_uuid, "1351043")
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
-                                                                                  exit_code=1,
-                                                                                  stderr=CONDOR_RM_FAILED_OUTPUT,
-                                                                                  stdout="", stdin=""))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message=CONDOR_RM_FAILED_MESSAGE,
+            exit_code=1,
+            stderr=CONDOR_RM_FAILED_OUTPUT,
+            stdout="",
+            stdin="",
+        ),
+    )
     def test_terminate_resource_failed_redo(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
+            run_async(
+                self.adapter.terminate_resource,
+                AttributeDict(remote_resource_uuid="1351043"),
+            )
 
-    @mock_executor_run_command(stdout="", raise_exception=CommandExecutionFailure(message=CONDOR_RM_FAILED_MESSAGE,
-                                                                                  exit_code=2,
-                                                                                  stderr=CONDOR_RM_FAILED_OUTPUT,
-                                                                                  stdout="", stdin=""))
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message=CONDOR_RM_FAILED_MESSAGE,
+            exit_code=2,
+            stderr=CONDOR_RM_FAILED_OUTPUT,
+            stdout="",
+            stdin="",
+        ),
+    )
     def test_terminate_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(self.adapter.terminate_resource, AttributeDict(remote_resource_uuid="1351043"))
+            run_async(
+                self.adapter.terminate_resource,
+                AttributeDict(remote_resource_uuid="1351043"),
+            )
 
     def test_exception_handling(self):
         def test_exception_handling(raise_it, catch_it):
@@ -219,8 +303,10 @@ class TestHTCondorSiteAdapter(TestCase):
                 with self.adapter.handle_exceptions():
                     raise raise_it
 
-        matrix = [(Exception, TardisError),
-                  (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed)]
+        matrix = [
+            (Exception, TardisError),
+            (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed),
+        ]
 
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -16,9 +16,9 @@ from datetime import datetime, timedelta
 import asyncio
 import asyncssh
 
-__all__ = ['TestMoabAdapter']
+__all__ = ["TestMoabAdapter"]
 
-TEST_RESOURCE_STATUS_RESPONSE = '''
+TEST_RESOURCE_STATUS_RESPONSE = """
 <Data>
  <Object>queue</Object>
  <cluster LocalActiveNodes="68" LocalAllocProcs="1360" LocalConfigNodes="1037" LocalIdleNodes="7" LocalIdleProcs="7192" LocalUpNodes="922" LocalUpProcs="18432" RemoteActiveNodes="0" RemoteAllocProcs="0" RemoteConfigNodes="0" RemoteIdleNodes="0" RemoteIdleProcs="0" RemoteUpNodes="0" RemoteUpProcs="0" time="1553503935"/>
@@ -37,9 +37,9 @@ TEST_RESOURCE_STATUS_RESPONSE = '''
  </queue>
 </Data>
 
-'''
+"""
 
-TEST_RESOURCE_STATUS_RESPONSE_RUNNING = '''
+TEST_RESOURCE_STATUS_RESPONSE_RUNNING = """
 <Data>
  <Object>queue</Object>
  <cluster LocalActiveNodes="2" LocalAllocProcs="40" LocalConfigNodes="1038" LocalIdleNodes="5" LocalIdleProcs="555" LocalUpNodes="917" LocalUpProcs="18320" RemoteActiveNodes="0" RemoteAllocProcs="0" RemoteConfigNodes="0" RemoteIdleNodes="0" RemoteIdleProcs="0" RemoteUpNodes="0" RemoteUpProcs="0" time="1551959144"/>
@@ -57,35 +57,35 @@ TEST_RESOURCE_STATUS_RESPONSE_RUNNING = '''
  </queue>
 </Data>
 
-'''
+"""
 
-TEST_DEPLOY_RESOURCE_RESPONSE = '''
+TEST_DEPLOY_RESOURCE_RESPONSE = """
 
 4761849
-'''
+"""
 
-TEST_TERMINATE_RESOURCE_RESPONSE = '''
+TEST_TERMINATE_RESOURCE_RESPONSE = """
 
 job '4761849' cancelled
 
-'''
+"""
 
-TEST_TIMEOUT_RESPONSE = '''
+TEST_TIMEOUT_RESPONSE = """
 ERROR:  client timed out after 30 seconds (hostname:port=mg1.nemo.privat:42559)
-'''
+"""
 
-TEST_TERMINATE_DEAD_RESOURCE_RESPONSE = '''
+TEST_TERMINATE_DEAD_RESOURCE_RESPONSE = """
 ERROR:  invalid job specified (4761849)
 
-'''
+"""
 
 
 class TestMoabAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.moab.Configuration')
+        cls.mock_config_patcher = patch("tardis.adapters.sites.moab.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_executor_patcher = patch('tardis.adapters.sites.moab.ShellExecutor')
+        cls.mock_executor_patcher = patch("tardis.adapters.sites.moab.ShellExecutor")
         cls.mock_executor = cls.mock_executor_patcher.start()
 
     @classmethod
@@ -97,84 +97,125 @@ class TestMoabAdapter(TestCase):
         config = self.mock_config.return_value
         self.test_site_config = config.TestSite
         self.test_site_config.MachineMetaData = self.machine_meta_data
-        self.test_site_config.StartupCommand = 'startVM.py'
+        self.test_site_config.StartupCommand = "startVM.py"
         self.test_site_config.StatusUpdate = 10
         self.test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         self.test_site_config.executor = self.mock_executor.return_value
 
-        self.moab_adapter = MoabAdapter(machine_type='test2large', site_name='TestSite')
+        self.moab_adapter = MoabAdapter(machine_type="test2large", site_name="TestSite")
 
     def tearDown(self):
         pass
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=128, Memory='120'))
+        return AttributeDict(test2large=AttributeDict(Cores=128, Memory="120"))
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict(NodeType='1:ppn=20', Walltime='02:00:00:00'))
+        return AttributeDict(
+            test2large=AttributeDict(NodeType="1:ppn=20", Walltime="02:00:00:00")
+        )
 
     @property
     def resource_attributes(self):
-        return AttributeDict(machine_type='test2large',
-                             site_name='TestSite',
-                             remote_resource_uuid=4761849,
-                             resource_status=ResourceStatus.Booting,
-                             created=datetime.strptime("Wed Jan 23 2019 15:01:47", '%a %b %d %Y %H:%M:%S'),
-                             updated=datetime.strptime("Wed Jan 23 2019 15:02:17", '%a %b %d %Y %H:%M:%S'),
-                             drone_uuid='testsite-4761849')
+        return AttributeDict(
+            machine_type="test2large",
+            site_name="TestSite",
+            remote_resource_uuid=4761849,
+            resource_status=ResourceStatus.Booting,
+            created=datetime.strptime(
+                "Wed Jan 23 2019 15:01:47", "%a %b %d %Y %H:%M:%S"
+            ),
+            updated=datetime.strptime(
+                "Wed Jan 23 2019 15:02:17", "%a %b %d %Y %H:%M:%S"
+            ),
+            drone_uuid="testsite-4761849",
+        )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(created=datetime.now(), updated=datetime.now())
-        return_resource_attributes = run_async(self.moab_adapter.deploy_resource,
-                                               resource_attributes=AttributeDict(machine_type='test2large',
-                                                                                 site_name='TestSite'))
-        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(seconds=1) or \
-                return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            created=datetime.now(), updated=datetime.now()
+        )
+        return_resource_attributes = run_async(
+            self.moab_adapter.deploy_resource,
+            resource_attributes=AttributeDict(
+                machine_type="test2large", site_name="TestSite"
+            ),
+        )
+        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(
+            seconds=1
+        ) or return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(
+            seconds=1
+        ):
             raise Exception("Creation time or update time wrong!")
-        del expected_resource_attributes.created, expected_resource_attributes.updated, \
-            return_resource_attributes.created, return_resource_attributes.updated
+        del (
+            expected_resource_attributes.created,
+            expected_resource_attributes.updated,
+            return_resource_attributes.created,
+            return_resource_attributes.updated,
+        )
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
         self.mock_executor.return_value.run_command.assert_called_with(
-            'msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py')
+            "msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py"
+        )
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.moab_adapter.machine_meta_data, self.machine_meta_data['test2large'])
+        self.assertEqual(
+            self.moab_adapter.machine_meta_data, self.machine_meta_data["test2large"]
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.moab_adapter.machine_type, 'test2large')
+        self.assertEqual(self.moab_adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.moab_adapter.site_name, 'TestSite')
+        self.assertEqual(self.moab_adapter.site_name, "TestSite")
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE)
     def test_resource_status(self):
         expected_resource_attributes = self.resource_attributes
         expected_resource_attributes.update(updated=datetime.now())
-        return_resource_attributes = run_async(self.moab_adapter.resource_status,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        return_resource_attributes = run_async(
+            self.moab_adapter.resource_status,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
     def test_resource_status_update(self):
-        self.assertEqual(self.resource_attributes["resource_status"], ResourceStatus.Booting)
-        return_resource_attributes = run_async(self.moab_adapter.resource_status,
-                                               resource_attributes=self.resource_attributes)
-        self.assertEqual(return_resource_attributes["resource_status"], ResourceStatus.Running)
+        self.assertEqual(
+            self.resource_attributes["resource_status"], ResourceStatus.Booting
+        )
+        return_resource_attributes = run_async(
+            self.moab_adapter.resource_status,
+            resource_attributes=self.resource_attributes,
+        )
+        self.assertEqual(
+            return_resource_attributes["resource_status"], ResourceStatus.Running
+        )
 
     @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
     def test_stop_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.moab_adapter.stop_resource,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.moab_adapter.stop_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
@@ -182,33 +223,58 @@ class TestMoabAdapter(TestCase):
     @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
     def test_terminate_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.moab_adapter.terminate_resource,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.moab_adapter.terminate_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
 
-    @mock_executor_run_command("", stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE, exit_code=1,
-                               raise_exception=CommandExecutionFailure(message='Test',
-                                                                       stdout="",
-                                                                       stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
-                                                                       exit_code=1))
+    @mock_executor_run_command(
+        "",
+        stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
+        exit_code=1,
+        raise_exception=CommandExecutionFailure(
+            message="Test",
+            stdout="",
+            stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
+            exit_code=1,
+        ),
+    )
     def test_terminate_dead_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.moab_adapter.terminate_resource,
-                                               resource_attributes=self.resource_attributes)
-        self.assertEqual(return_resource_attributes["resource_status"], ResourceStatus.Stopped)
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.moab_adapter.terminate_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        self.assertEqual(
+            return_resource_attributes["resource_status"], ResourceStatus.Stopped
+        )
 
-    @mock_executor_run_command("", exit_code=2, raise_exception=CommandExecutionFailure(message='Test',
-                                                                                        stdout="",
-                                                                                        stderr="",
-                                                                                        exit_code=2))
+    @mock_executor_run_command(
+        "",
+        exit_code=2,
+        raise_exception=CommandExecutionFailure(
+            message="Test", stdout="", stderr="", exit_code=2
+        ),
+    )
     def test_terminate_resource_error(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(self.moab_adapter.terminate_resource, resource_attributes=self.resource_attributes)
+            run_async(
+                self.moab_adapter.terminate_resource,
+                resource_attributes=self.resource_attributes,
+            )
 
     def test_resource_status_raise(self):
         # Update interval is 10 minutes, so set last update back by 2 minutes in order to execute sacct command and
@@ -217,10 +283,15 @@ class TestMoabAdapter(TestCase):
         new_timestamp = datetime.now() - timedelta(minutes=2)
         self.moab_adapter._moab_status._last_update = new_timestamp
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            response = run_async(self.moab_adapter.resource_status,
-                                 AttributeDict(resource_id=1351043, remote_resource_uuid=1351043,
-                                               resource_state=ResourceStatus.Booting,
-                                               created=created_timestamp))
+            response = run_async(
+                self.moab_adapter.resource_status,
+                AttributeDict(
+                    resource_id=1351043,
+                    remote_resource_uuid=1351043,
+                    resource_state=ResourceStatus.Booting,
+                    created=created_timestamp,
+                ),
+            )
 
     def test_resource_status_raise_past(self):
         # Update interval is 10 minutes, so set last update back by 11 minutes in order to execute sacct command and
@@ -228,9 +299,14 @@ class TestMoabAdapter(TestCase):
         creation_timestamp = datetime.now() - timedelta(minutes=12)
         last_update_timestamp = datetime.now() - timedelta(minutes=11)
         self.moab_adapter._moab_status._last_update = last_update_timestamp
-        response = run_async(self.moab_adapter.resource_status, AttributeDict(resource_id=1390065,
-                                                                              remote_resource_uuid=1351043,
-                                                                              created=creation_timestamp))
+        response = run_async(
+            self.moab_adapter.resource_status,
+            AttributeDict(
+                resource_id=1390065,
+                remote_resource_uuid=1351043,
+                created=creation_timestamp,
+            ),
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     def test_exception_handling(self):
@@ -239,22 +315,31 @@ class TestMoabAdapter(TestCase):
                 with self.moab_adapter.handle_exceptions():
                     raise to_raise
 
-        matrix = [(asyncio.TimeoutError(), TardisTimeout),
-                  (asyncssh.Error(code=255,
-                                  reason="Test",
-                                  lang="Test"), TardisResourceStatusUpdateFailed),
-                  (IndexError, TardisResourceStatusUpdateFailed),
-                  (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed),
-                  (CommandExecutionFailure(message="Run test command",
-                                           exit_code=1,
-                                           stdout="Test",
-                                           stderr="Test"), TardisResourceStatusUpdateFailed),
-                  (Exception, TardisError)]
+        matrix = [
+            (asyncio.TimeoutError(), TardisTimeout),
+            (
+                asyncssh.Error(code=255, reason="Test", lang="Test"),
+                TardisResourceStatusUpdateFailed,
+            ),
+            (IndexError, TardisResourceStatusUpdateFailed),
+            (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed),
+            (
+                CommandExecutionFailure(
+                    message="Run test command",
+                    exit_code=1,
+                    stdout="Test",
+                    stderr="Test",
+                ),
+                TardisResourceStatusUpdateFailed,
+            ),
+            (Exception, TardisError),
+        ]
 
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)
 
     def test_check_remote_resource_uuid(self):
         with self.assertRaises(TardisError):
-            self.moab_adapter.check_remote_resource_uuid(AttributeDict(remote_resource_uuid=1),
-                                                         regex=r"^(\d)$", response="2")
+            self.moab_adapter.check_remote_resource_uuid(
+                AttributeDict(remote_resource_uuid=1), regex=r"^(\d)$", response="2"
+            )

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -23,9 +23,11 @@ import asyncio
 class TestOpenStackAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.openstack.Configuration')
+        cls.mock_config_patcher = patch("tardis.adapters.sites.openstack.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_openstack_api_patcher = patch('tardis.adapters.sites.openstack.NovaClient')
+        cls.mock_openstack_api_patcher = patch(
+            "tardis.adapters.sites.openstack.NovaClient"
+        )
         cls.mock_openstack_api = cls.mock_openstack_api_patcher.start()
 
     @classmethod
@@ -36,76 +38,127 @@ class TestOpenStackAdapter(TestCase):
     def setUp(self):
         config = self.mock_config.return_value
         test_site_config = config.TestSite
-        test_site_config.auth_url = 'https://test.nova.client.local'
-        test_site_config.username = 'TestUser'
-        test_site_config.password = 'test123'
-        test_site_config.project_name = 'TestProject'
-        test_site_config.user_domain_name = 'TestDomain'
-        test_site_config.project_domain_name = 'TestProjectDomain'
-        test_site_config.MachineTypeConfiguration = \
-            AttributeDict(test2large=AttributeDict(imageRef='bc613271-6a54-48ca-9222-47e009dc0c29'))
-        test_site_config.MachineMetaData = AttributeDict(test2large=AttributeDict(Cores=128))
+        test_site_config.auth_url = "https://test.nova.client.local"
+        test_site_config.username = "TestUser"
+        test_site_config.password = "test123"
+        test_site_config.project_name = "TestProject"
+        test_site_config.user_domain_name = "TestDomain"
+        test_site_config.project_domain_name = "TestProjectDomain"
+        test_site_config.MachineTypeConfiguration = AttributeDict(
+            test2large=AttributeDict(imageRef="bc613271-6a54-48ca-9222-47e009dc0c29")
+        )
+        test_site_config.MachineMetaData = AttributeDict(
+            test2large=AttributeDict(Cores=128)
+        )
 
         openstack_api = self.mock_openstack_api.return_value
         openstack_api.init_api.return_value = async_return(return_value=None)
 
-        self.create_return_value = AttributeDict(server=AttributeDict(name='testsite-089123'))
-        openstack_api.servers.create.return_value = async_return(return_value=self.create_return_value)
+        self.create_return_value = AttributeDict(
+            server=AttributeDict(name="testsite-089123")
+        )
+        openstack_api.servers.create.return_value = async_return(
+            return_value=self.create_return_value
+        )
 
-        self.get_return_value = AttributeDict(server=AttributeDict(name='testsite-089123', id='029312-1231-123123',
-                                                                   status='ACTIVE'))
-        openstack_api.servers.get.return_value = async_return(return_value=self.get_return_value)
+        self.get_return_value = AttributeDict(
+            server=AttributeDict(
+                name="testsite-089123", id="029312-1231-123123", status="ACTIVE"
+            )
+        )
+        openstack_api.servers.get.return_value = async_return(
+            return_value=self.get_return_value
+        )
 
         openstack_api.servers.run_action.return_value = async_return(return_value=None)
 
-        openstack_api.servers.force_delete.return_value = async_return(return_value=None)
+        openstack_api.servers.force_delete.return_value = async_return(
+            return_value=None
+        )
 
-        self.mock_openstack_api.return_value.init_api.return_value = async_return(return_value=True)
-        self.openstack_adapter = OpenStackAdapter(machine_type='test2large', site_name='TestSite')
+        self.mock_openstack_api.return_value.init_api.return_value = async_return(
+            return_value=True
+        )
+        self.openstack_adapter = OpenStackAdapter(
+            machine_type="test2large", site_name="TestSite"
+        )
 
     def tearDown(self):
         self.mock_openstack_api.reset_mock()
 
     def test_deploy_resource(self):
-        self.assertEqual(run_async(self.openstack_adapter.deploy_resource,
-                                   resource_attributes=AttributeDict(drone_uuid='testsite-089123')),
-                         AttributeDict(drone_uuid='testsite-089123'))
+        self.assertEqual(
+            run_async(
+                self.openstack_adapter.deploy_resource,
+                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            ),
+            AttributeDict(drone_uuid="testsite-089123"),
+        )
 
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
 
         self.mock_openstack_api.return_value.servers.create.assert_called_with(
-            server={'imageRef': 'bc613271-6a54-48ca-9222-47e009dc0c29', 'name': 'testsite-089123'})
+            server={
+                "imageRef": "bc613271-6a54-48ca-9222-47e009dc0c29",
+                "name": "testsite-089123",
+            }
+        )
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.openstack_adapter.machine_meta_data, AttributeDict(Cores=128))
+        self.assertEqual(
+            self.openstack_adapter.machine_meta_data, AttributeDict(Cores=128)
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.openstack_adapter.machine_type, 'test2large')
+        self.assertEqual(self.openstack_adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.openstack_adapter.site_name, 'TestSite')
+        self.assertEqual(self.openstack_adapter.site_name, "TestSite")
 
     def test_resource_status(self):
-        self.assertEqual(run_async(self.openstack_adapter.resource_status,
-                                   resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123')),
-                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='029312-1231-123123',
-                                       resource_status=ResourceStatus.Running))
+        self.assertEqual(
+            run_async(
+                self.openstack_adapter.resource_status,
+                resource_attributes=AttributeDict(
+                    remote_resource_uuid="029312-1231-123123"
+                ),
+            ),
+            AttributeDict(
+                drone_uuid="testsite-089123",
+                remote_resource_uuid="029312-1231-123123",
+                resource_status=ResourceStatus.Running,
+            ),
+        )
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
-        self.mock_openstack_api.return_value.servers.get.assert_called_with('029312-1231-123123')
+        self.mock_openstack_api.return_value.servers.get.assert_called_with(
+            "029312-1231-123123"
+        )
 
     def test_stop_resource(self):
-        run_async(self.openstack_adapter.stop_resource,
-                  resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123'))
-        params = {'os-stop': None}
+        run_async(
+            self.openstack_adapter.stop_resource,
+            resource_attributes=AttributeDict(
+                remote_resource_uuid="029312-1231-123123"
+            ),
+        )
+        params = {"os-stop": None}
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
-        self.mock_openstack_api.return_value.servers.run_action.assert_called_with('029312-1231-123123', **params)
+        self.mock_openstack_api.return_value.servers.run_action.assert_called_with(
+            "029312-1231-123123", **params
+        )
 
     def test_terminate_resource(self):
-        run_async(self.openstack_adapter.terminate_resource,
-                  resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123'))
+        run_async(
+            self.openstack_adapter.terminate_resource,
+            resource_attributes=AttributeDict(
+                remote_resource_uuid="029312-1231-123123"
+            ),
+        )
 
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
-        self.mock_openstack_api.return_value.servers.force_delete.assert_called_with('029312-1231-123123')
+        self.mock_openstack_api.return_value.servers.force_delete.assert_called_with(
+            "029312-1231-123123"
+        )
 
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
@@ -113,12 +166,22 @@ class TestOpenStackAdapter(TestCase):
                 with self.openstack_adapter.handle_exceptions():
                     raise to_raise
 
-        matrix = [(asyncio.TimeoutError(), TardisTimeout),
-                  (AuthError(message="Test_Error", response="Not Allowed"), TardisAuthError),
-                  (ContentTypeError(request_info=AttributeDict(real_url="Test"), history="Test"), TardisResourceStatusUpdateFailed),
-                  (ClientError(message="Test_Error", response="Internal Server Error"), TardisDroneCrashed),
-                  (ClientConnectionError(), TardisResourceStatusUpdateFailed),
-                  (Exception, TardisError)]
+        matrix = [
+            (asyncio.TimeoutError(), TardisTimeout),
+            (AuthError(message="Test_Error", response="Not Allowed"), TardisAuthError),
+            (
+                ContentTypeError(
+                    request_info=AttributeDict(real_url="Test"), history="Test"
+                ),
+                TardisResourceStatusUpdateFailed,
+            ),
+            (
+                ClientError(message="Test_Error", response="Internal Server Error"),
+                TardisDroneCrashed,
+            ),
+            (ClientConnectionError(), TardisResourceStatusUpdateFailed),
+            (Exception, TardisError),
+        ]
 
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -15,40 +15,42 @@ from datetime import datetime, timedelta
 
 import asyncio
 
-__all__ = ['TestSlurmAdapter']
+__all__ = ["TestSlurmAdapter"]
 
-TEST_RESOURCE_STATUS_RESPONSE = '''
+TEST_RESOURCE_STATUS_RESPONSE = """
 1390065|None assigned|PENDING
 1391999|fh2n1573|TIMEOUT
 1391999.batch|fh2n1573|CANCELLED
-'''
+"""
 
-TEST_RESOURCE_STATUS_RESPONSE_RUNNING = '''
+TEST_RESOURCE_STATUS_RESPONSE_RUNNING = """
 1390065|fh2n1552|RUNNING
 1390065.batch|fh2n1552|RUNNING
 1391999|fh2n1573|TIMEOUT
 1391999.batch|fh2n1573|CANCELLED
-'''
+"""
 
-TEST_RESOURCE_STATUS_RESPONSE_DEAD = '''
+TEST_RESOURCE_STATUS_RESPONSE_DEAD = """
 1390065|fh2n1552|TIMEOUT
 1390065.batch|fh2n1552|CANCELLED
 1391999|fh2n1573|TIMEOUT
 1391999.batch|fh2n1573|CANCELLED
-'''
+"""
 
-TEST_DEPLOY_RESOURCE_RESPONSE = '''
+TEST_DEPLOY_RESOURCE_RESPONSE = """
 Submitted batch job 1390065
-'''
+"""
 
 
 def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):
     def decorator(func):
         def wrapper(self):
             executor = self.mock_executor.return_value
-            executor.run_command.return_value = async_return(return_value=AttributeDict(stdout=stdout,
-                                                                                        stderr=stderr,
-                                                                                        exit_code=exit_code))
+            executor.run_command.return_value = async_return(
+                return_value=AttributeDict(
+                    stdout=stdout, stderr=stderr, exit_code=exit_code
+                )
+            )
             executor.run_command.side_effect = raise_exception
             func(self)
             executor.run_command.side_effect = None
@@ -61,9 +63,9 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
 class TestSlurmAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.adapters.sites.slurm.Configuration')
+        cls.mock_config_patcher = patch("tardis.adapters.sites.slurm.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_executor_patcher = patch('tardis.adapters.sites.slurm.ShellExecutor')
+        cls.mock_executor_patcher = patch("tardis.adapters.sites.slurm.ShellExecutor")
         cls.mock_executor = cls.mock_executor_patcher.start()
 
     @classmethod
@@ -75,86 +77,129 @@ class TestSlurmAdapter(TestCase):
         config = self.mock_config.return_value
         self.test_site_config = config.TestSite
         self.test_site_config.MachineMetaData = self.machine_meta_data
-        self.test_site_config.StartupCommand = 'pilot.sh'
+        self.test_site_config.StartupCommand = "pilot.sh"
         self.test_site_config.StatusUpdate = 10
         self.test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         self.test_site_config.executor = self.mock_executor.return_value
 
-        self.slurm_adapter = SlurmAdapter(machine_type='test2large', site_name='TestSite')
+        self.slurm_adapter = SlurmAdapter(
+            machine_type="test2large", site_name="TestSite"
+        )
 
     def tearDown(self):
         pass
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=20, Memory='62'))
+        return AttributeDict(test2large=AttributeDict(Cores=20, Memory="62"))
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict(Partition='normal', Walltime='60'))
+        return AttributeDict(
+            test2large=AttributeDict(Partition="normal", Walltime="60")
+        )
 
     @property
     def resource_attributes(self):
-        return AttributeDict(machine_type='test2large',
-                             site_name='TestSite',
-                             remote_resource_uuid=1390065,
-                             resource_status=ResourceStatus.Booting,
-                             created=datetime.strptime("Wed Jan 23 2019 15:01:47", '%a %b %d %Y %H:%M:%S'),
-                             updated=datetime.strptime("Wed Jan 23 2019 15:02:17", '%a %b %d %Y %H:%M:%S'),
-                             drone_uuid='testsite-1390065')
+        return AttributeDict(
+            machine_type="test2large",
+            site_name="TestSite",
+            remote_resource_uuid=1390065,
+            resource_status=ResourceStatus.Booting,
+            created=datetime.strptime(
+                "Wed Jan 23 2019 15:01:47", "%a %b %d %Y %H:%M:%S"
+            ),
+            updated=datetime.strptime(
+                "Wed Jan 23 2019 15:02:17", "%a %b %d %Y %H:%M:%S"
+            ),
+            drone_uuid="testsite-1390065",
+        )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(created=datetime.now(), updated=datetime.now())
-        return_resource_attributes = run_async(self.slurm_adapter.deploy_resource,
-                                               resource_attributes=AttributeDict(machine_type='test2large',
-                                                                                 site_name='TestSite'))
-        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(seconds=1) or \
-                return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            created=datetime.now(), updated=datetime.now()
+        )
+        return_resource_attributes = run_async(
+            self.slurm_adapter.deploy_resource,
+            resource_attributes=AttributeDict(
+                machine_type="test2large", site_name="TestSite"
+            ),
+        )
+        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(
+            seconds=1
+        ) or return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(
+            seconds=1
+        ):
             raise Exception("Creation time or update time wrong!")
-        del expected_resource_attributes.created, expected_resource_attributes.updated, \
-            return_resource_attributes.created, return_resource_attributes.updated
+        del (
+            expected_resource_attributes.created,
+            expected_resource_attributes.updated,
+            return_resource_attributes.created,
+            return_resource_attributes.updated,
+        )
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
         self.mock_executor.return_value.run_command.assert_called_with(
-            'sbatch -p normal -N 1 -n 20 --mem=62gb -t 60 --export=SLURM_Walltime=60 pilot.sh')
+            "sbatch -p normal -N 1 -n 20 --mem=62gb -t 60 --export=SLURM_Walltime=60 pilot.sh"
+        )
 
     def test_machine_meta_data(self):
-        self.assertEqual(self.slurm_adapter.machine_meta_data, self.machine_meta_data['test2large'])
+        self.assertEqual(
+            self.slurm_adapter.machine_meta_data, self.machine_meta_data["test2large"]
+        )
 
     def test_machine_type(self):
-        self.assertEqual(self.slurm_adapter.machine_type, 'test2large')
+        self.assertEqual(self.slurm_adapter.machine_type, "test2large")
 
     def test_site_name(self):
-        self.assertEqual(self.slurm_adapter.site_name, 'TestSite')
+        self.assertEqual(self.slurm_adapter.site_name, "TestSite")
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE)
     def test_resource_status(self):
         expected_resource_attributes = self.resource_attributes
         expected_resource_attributes.update(updated=datetime.now())
 
-        return_resource_attributes = run_async(self.slurm_adapter.resource_status,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        return_resource_attributes = run_async(
+            self.slurm_adapter.resource_status,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
     def test_resource_status_update(self):
-        self.assertEqual(self.resource_attributes["resource_status"], ResourceStatus.Booting)
-        return_resource_attributes = run_async(self.slurm_adapter.resource_status,
-                                               resource_attributes=self.resource_attributes)
-        self.assertEqual(return_resource_attributes["resource_status"], ResourceStatus.Running)
-        self.assertEqual(return_resource_attributes["drone_uuid"], 'testsite-1390065')
+        self.assertEqual(
+            self.resource_attributes["resource_status"], ResourceStatus.Booting
+        )
+        return_resource_attributes = run_async(
+            self.slurm_adapter.resource_status,
+            resource_attributes=self.resource_attributes,
+        )
+        self.assertEqual(
+            return_resource_attributes["resource_status"], ResourceStatus.Running
+        )
+        self.assertEqual(return_resource_attributes["drone_uuid"], "testsite-1390065")
 
     @mock_executor_run_command(stdout="", stderr="", exit_code=0)
     def test_stop_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.slurm_adapter.stop_resource,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.slurm_adapter.stop_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
@@ -162,10 +207,17 @@ class TestSlurmAdapter(TestCase):
     @mock_executor_run_command(stdout="", stderr="", exit_code=0)
     def test_terminate_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.slurm_adapter.terminate_resource,
-                                               resource_attributes=self.resource_attributes)
-        if return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(seconds=1):
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.slurm_adapter.terminate_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        if (
+            return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
+        ):
             raise Exception("Update time wrong!")
         del expected_resource_attributes.updated, return_resource_attributes.updated
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
@@ -173,16 +225,26 @@ class TestSlurmAdapter(TestCase):
     @mock_executor_run_command(stdout="", stderr="", exit_code=0)
     def test_terminate_dead_resource(self):
         expected_resource_attributes = self.resource_attributes
-        expected_resource_attributes.update(updated=datetime.now(), resource_status=ResourceStatus.Stopped)
-        return_resource_attributes = run_async(self.slurm_adapter.terminate_resource,
-                                               resource_attributes=self.resource_attributes)
-        self.assertEqual(return_resource_attributes["resource_status"], ResourceStatus.Stopped)
+        expected_resource_attributes.update(
+            updated=datetime.now(), resource_status=ResourceStatus.Stopped
+        )
+        return_resource_attributes = run_async(
+            self.slurm_adapter.terminate_resource,
+            resource_attributes=self.resource_attributes,
+        )
+        self.assertEqual(
+            return_resource_attributes["resource_status"], ResourceStatus.Stopped
+        )
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_DEAD)
     def test_dead_resource(self):
-        return_resource_attributes = run_async(self.slurm_adapter.resource_status,
-                                               resource_attributes=self.resource_attributes)
-        self.assertEqual(return_resource_attributes["resource_status"], ResourceStatus.Stopped)
+        return_resource_attributes = run_async(
+            self.slurm_adapter.resource_status,
+            resource_attributes=self.resource_attributes,
+        )
+        self.assertEqual(
+            return_resource_attributes["resource_status"], ResourceStatus.Stopped
+        )
 
     def test_resource_status_raise(self):
         # Update interval is 10 minutes, so set last update back by 2 minutes in order to execute sacct command and
@@ -191,10 +253,15 @@ class TestSlurmAdapter(TestCase):
         new_timestamp = datetime.now() - timedelta(minutes=2)
         self.slurm_adapter._slurm_status._last_update = new_timestamp
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            response = run_async(self.slurm_adapter.resource_status,
-                                 AttributeDict(resource_id=1351043, remote_resource_uuid=1351043,
-                                               resource_state=ResourceStatus.Booting,
-                                               created=created_timestamp))
+            response = run_async(
+                self.slurm_adapter.resource_status,
+                AttributeDict(
+                    resource_id=1351043,
+                    remote_resource_uuid=1351043,
+                    resource_state=ResourceStatus.Booting,
+                    created=created_timestamp,
+                ),
+            )
 
     def test_resource_status_raise_past(self):
         # Update interval is 10 minutes, so set last update back by 11 minutes in order to execute sacct command and
@@ -202,9 +269,14 @@ class TestSlurmAdapter(TestCase):
         past_timestamp = datetime.now() - timedelta(minutes=12)
         new_timestamp = datetime.now() - timedelta(minutes=11)
         self.slurm_adapter._slurm_status._last_update = new_timestamp
-        response = run_async(self.slurm_adapter.resource_status, AttributeDict(resource_id=1390065,
-                                                                               remote_resource_uuid=1351043,
-                                                                               created=past_timestamp))
+        response = run_async(
+            self.slurm_adapter.resource_status,
+            AttributeDict(
+                resource_id=1390065,
+                remote_resource_uuid=1351043,
+                created=past_timestamp,
+            ),
+        )
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     def test_exception_handling(self):
@@ -213,11 +285,17 @@ class TestSlurmAdapter(TestCase):
                 with self.slurm_adapter.handle_exceptions():
                     raise to_raise
 
-        matrix = [(asyncio.TimeoutError(), TardisTimeout),
-                  (CommandExecutionFailure(message="Test", exit_code=255, stdout="Test", stderr="Test"),
-                   TardisResourceStatusUpdateFailed),
-                  (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed),
-                  (Exception, TardisError)]
+        matrix = [
+            (asyncio.TimeoutError(), TardisTimeout),
+            (
+                CommandExecutionFailure(
+                    message="Test", exit_code=255, stdout="Test", stderr="Test"
+                ),
+                TardisResourceStatusUpdateFailed,
+            ),
+            (TardisResourceStatusUpdateFailed, TardisResourceStatusUpdateFailed),
+            (Exception, TardisError),
+        ]
 
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)

--- a/tests/agents_t/test_batchsystemagent.py
+++ b/tests/agents_t/test_batchsystemagent.py
@@ -14,30 +14,30 @@ class TestBatchSystemAgent(TestCase):
 
     def test_disintegrate_machine(self):
         self.batch_system_adapter.disintegrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.disintegrate_machine, drone_uuid='test')
-        self.batch_system_adapter.disintegrate_machine.assert_called_with('test')
+        run_async(self.batch_system_agent.disintegrate_machine, drone_uuid="test")
+        self.batch_system_adapter.disintegrate_machine.assert_called_with("test")
 
     def test_drain_machine(self):
         self.batch_system_adapter.drain_machine.side_effect = async_return
-        run_async(self.batch_system_agent.drain_machine, drone_uuid='test')
-        self.batch_system_adapter.drain_machine.assert_called_with('test')
+        run_async(self.batch_system_agent.drain_machine, drone_uuid="test")
+        self.batch_system_adapter.drain_machine.assert_called_with("test")
 
     def test_integrate_machine(self):
         self.batch_system_adapter.integrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.integrate_machine, drone_uuid='test')
-        self.batch_system_adapter.integrate_machine.assert_called_with('test')
+        run_async(self.batch_system_agent.integrate_machine, drone_uuid="test")
+        self.batch_system_adapter.integrate_machine.assert_called_with("test")
 
     def test_get_allocation(self):
         self.batch_system_adapter.get_allocation.side_effect = async_return
-        run_async(self.batch_system_agent.get_allocation, drone_uuid='test')
-        self.batch_system_adapter.get_allocation.assert_called_with('test')
+        run_async(self.batch_system_agent.get_allocation, drone_uuid="test")
+        self.batch_system_adapter.get_allocation.assert_called_with("test")
 
     def test_get_machine_status(self):
         self.batch_system_adapter.get_machine_status.side_effect = async_return
-        run_async(self.batch_system_agent.get_machine_status, drone_uuid='test')
-        self.batch_system_adapter.get_machine_status.assert_called_with('test')
+        run_async(self.batch_system_agent.get_machine_status, drone_uuid="test")
+        self.batch_system_adapter.get_machine_status.assert_called_with("test")
 
     def test_get_utilization(self):
         self.batch_system_adapter.get_utilization.side_effect = async_return
-        run_async(self.batch_system_agent.get_utilization, drone_uuid='test')
-        self.batch_system_adapter.get_utilization.assert_called_with('test')
+        run_async(self.batch_system_agent.get_utilization, drone_uuid="test")
+        self.batch_system_adapter.get_utilization.assert_called_with("test")

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -16,12 +16,12 @@ class TestSiteAgent(TestCase):
     def test_deploy_resource(self):
         self.site_adapter.deploy_resource.side_effect = async_return
         run_async(self.site_agent.deploy_resource, resource_attributes="test")
-        self.site_adapter.deploy_resource.assert_called_with(resource_attributes='test')
+        self.site_adapter.deploy_resource.assert_called_with(resource_attributes="test")
 
     def test_drone_uuid(self):
         self.site_adapter.drone_uuid.return_value = None
         self.site_agent.drone_uuid(uuid="test")
-        self.site_adapter.drone_uuid.assert_called_with(uuid='test')
+        self.site_adapter.drone_uuid.assert_called_with(uuid="test")
 
     def test_handle_exceptions(self):
         self.site_adapter.handle_exceptions.return_value = None
@@ -29,7 +29,10 @@ class TestSiteAgent(TestCase):
         self.site_adapter.handle_exceptions.assert_called_with()
 
     def test_handle_response(self):
-        self.assertEqual(self.site_agent.handle_response("Test", {'test': 1}, {'test': 2}), NotImplemented)
+        self.assertEqual(
+            self.site_agent.handle_response("Test", {"test": 1}, {"test": 2}),
+            NotImplemented,
+        )
 
     def test_machine_meta_data(self):
         type(self.site_adapter).machine_meta_data = PropertyMock(return_value="Test123")
@@ -42,7 +45,7 @@ class TestSiteAgent(TestCase):
     def test_resource_status(self):
         self.site_adapter.resource_status.side_effect = async_return
         run_async(self.site_agent.resource_status, resource_attributes="test")
-        self.site_adapter.resource_status.assert_called_with(resource_attributes='test')
+        self.site_adapter.resource_status.assert_called_with(resource_attributes="test")
 
     def test_site_name(self):
         type(self.site_adapter).site_name = PropertyMock(return_value="Test123")
@@ -51,9 +54,11 @@ class TestSiteAgent(TestCase):
     def test_stop_resource(self):
         self.site_adapter.stop_resource.side_effect = async_return
         run_async(self.site_agent.stop_resource, resource_attributes="test")
-        self.site_adapter.stop_resource.assert_called_with(resource_attributes='test')
+        self.site_adapter.stop_resource.assert_called_with(resource_attributes="test")
 
     def test_terminate_resource(self):
         self.site_adapter.terminate_resource.side_effect = async_return
         run_async(self.site_agent.terminate_resource, resource_attributes="test")
-        self.site_adapter.terminate_resource.assert_called_with(resource_attributes='test')
+        self.site_adapter.terminate_resource.assert_called_with(
+            resource_attributes="test"
+        )

--- a/tests/configuration_t/test_configuration.py
+++ b/tests/configuration_t/test_configuration.py
@@ -7,26 +7,40 @@ import os
 class TestConfiguration(TestCase):
     def setUp(self):
         self.test_path = os.path.dirname(os.path.realpath(__file__))
-        self.configuration1 = Configuration(os.path.join(self.test_path, 'CloudStackAIO.yml'))
+        self.configuration1 = Configuration(
+            os.path.join(self.test_path, "CloudStackAIO.yml")
+        )
         self.configuration2 = Configuration()
 
     def test_configuration_instances(self):
         self.assertNotEqual(id(self.configuration1), id(self.configuration2))
 
     def test_shared_state(self):
-        self.assertEqual(id(self.configuration1.CloudStackAIO), id(self.configuration2.CloudStackAIO))
+        self.assertEqual(
+            id(self.configuration1.CloudStackAIO), id(self.configuration2.CloudStackAIO)
+        )
 
     def test_load_configuration(self):
-        self.configuration1.load_config(os.path.join(self.test_path, 'Sites.yml'))
+        self.configuration1.load_config(os.path.join(self.test_path, "Sites.yml"))
         self.assertEqual(id(self.configuration1.Sites), id(self.configuration2.Sites))
-        self.assertEqual(self.configuration1.Sites, [dict(name='EXOSCALE', adapter='CloudStack')])
-        self.assertEqual(self.configuration2.CloudStackAIO, {'api_key': 'asdfghjkl', 'api_secret': 'qwertzuiop'})
+        self.assertEqual(
+            self.configuration1.Sites, [dict(name="EXOSCALE", adapter="CloudStack")]
+        )
+        self.assertEqual(
+            self.configuration2.CloudStackAIO,
+            {"api_key": "asdfghjkl", "api_secret": "qwertzuiop"},
+        )
 
     def test_base64_encoded_user_data(self):
-        result = (b'I2Nsb3VkLWNvbmZpZwoKd3JpdGVfZmlsZXM6CiAgLSBwYXRoOiAvZXRjL2huc2NpY2xvdWQvc2l0ZS1pZC5jZmcKICAgIGNvbn',
-                  b'RlbnQ6IHwKICAgICAgRXhvc2NhbGUKICAgIHBlcm1pc3Npb25zOiAnMDY0NCcK')
-        self.configuration1.load_config(os.path.join(self.test_path, 'Sites.yml'))
-        self.assertEqual(self.configuration1.EXOSCALE.MachineTypeConfiguration.Micro.user_data, b''.join(result))
+        result = (
+            b"I2Nsb3VkLWNvbmZpZwoKd3JpdGVfZmlsZXM6CiAgLSBwYXRoOiAvZXRjL2huc2NpY2xvdWQvc2l0ZS1pZC5jZmcKICAgIGNvbn",
+            b"RlbnQ6IHwKICAgICAgRXhvc2NhbGUKICAgIHBlcm1pc3Npb25zOiAnMDY0NCcK",
+        )
+        self.configuration1.load_config(os.path.join(self.test_path, "Sites.yml"))
+        self.assertEqual(
+            self.configuration1.EXOSCALE.MachineTypeConfiguration.Micro.user_data,
+            b"".join(result),
+        )
 
     def test_access_missing_attribute(self):
         with self.assertRaises(AttributeError):

--- a/tests/configuration_t/test_utilities.py
+++ b/tests/configuration_t/test_utilities.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import yaml
 
 
-@enable_yaml_load('!TestDummy')
+@enable_yaml_load("!TestDummy")
 class TestDummy(object):
     def __init__(self, *args, **kwargs):
         self.args = args
@@ -24,7 +24,7 @@ class TestEnableYAMLLoad(TestCase):
         - test
         """
         instance = yaml.safe_load(args_yml)
-        self.assertEqual(instance.args, ('test',))
+        self.assertEqual(instance.args, ("test",))
         self.assertEqual(instance.kwargs, {})
 
         kwargs_yml = """
@@ -33,4 +33,4 @@ class TestEnableYAMLLoad(TestCase):
         """
         instance = yaml.safe_load(kwargs_yml)
         self.assertEqual(instance.args, ())
-        self.assertEqual(instance.kwargs, {'test': 'test'})
+        self.assertEqual(instance.kwargs, {"test": "test"})

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -18,45 +18,57 @@ import sqlite3
 class TestSqliteRegistry(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.test_site_name = 'MyGreatTestSite'
-        cls.test_machine_type = 'MyGreatTestMachineType'
-        cls.tables_in_db = {'MachineTypes', 'Resources', 'ResourceStates', 'Sites'}
-        cls.test_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
-                                        'drone_uuid': f'{cls.test_site_name}-07af52405e',
-                                        'site_name': cls.test_site_name,
-                                        'machine_type': cls.test_machine_type,
-                                        'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
-                                        'updated': datetime.datetime(2018, 11, 16, 15, 49, 58)}
-        cls.test_updated_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
-                                                'drone_uuid': f'{cls.test_site_name}-07af52405e',
-                                                'site_name': cls.test_site_name,
-                                                'machine_type': cls.test_machine_type,
-                                                'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
-                                                'updated': datetime.datetime(2018, 11, 16, 15, 50, 58)}
+        cls.test_site_name = "MyGreatTestSite"
+        cls.test_machine_type = "MyGreatTestMachineType"
+        cls.tables_in_db = {"MachineTypes", "Resources", "ResourceStates", "Sites"}
+        cls.test_resource_attributes = {
+            "remote_resource_uuid": "bf85022b-fdd6-42b1-932d-086c288d4755",
+            "drone_uuid": f"{cls.test_site_name}-07af52405e",
+            "site_name": cls.test_site_name,
+            "machine_type": cls.test_machine_type,
+            "created": datetime.datetime(2018, 11, 16, 15, 49, 58),
+            "updated": datetime.datetime(2018, 11, 16, 15, 49, 58),
+        }
+        cls.test_updated_resource_attributes = {
+            "remote_resource_uuid": "bf85022b-fdd6-42b1-932d-086c288d4755",
+            "drone_uuid": f"{cls.test_site_name}-07af52405e",
+            "site_name": cls.test_site_name,
+            "machine_type": cls.test_machine_type,
+            "created": datetime.datetime(2018, 11, 16, 15, 49, 58),
+            "updated": datetime.datetime(2018, 11, 16, 15, 50, 58),
+        }
 
-        cls.test_get_resources_result = {'remote_resource_uuid': cls.test_resource_attributes['remote_resource_uuid'],
-                                         'drone_uuid': cls.test_resource_attributes['drone_uuid'],
-                                         'state': str(BootingState()),
-                                         'created': cls.test_resource_attributes['created'],
-                                         'updated': cls.test_resource_attributes['updated']}
+        cls.test_get_resources_result = {
+            "remote_resource_uuid": cls.test_resource_attributes[
+                "remote_resource_uuid"
+            ],
+            "drone_uuid": cls.test_resource_attributes["drone_uuid"],
+            "state": str(BootingState()),
+            "created": cls.test_resource_attributes["created"],
+            "updated": cls.test_resource_attributes["updated"],
+        }
 
-        cls.test_notify_result = (cls.test_resource_attributes['remote_resource_uuid'],
-                                  cls.test_resource_attributes['drone_uuid'],
-                                  str(BootingState()),
-                                  cls.test_resource_attributes['site_name'],
-                                  cls.test_resource_attributes['machine_type'],
-                                  str(cls.test_resource_attributes['created']),
-                                  str(cls.test_resource_attributes['updated']))
+        cls.test_notify_result = (
+            cls.test_resource_attributes["remote_resource_uuid"],
+            cls.test_resource_attributes["drone_uuid"],
+            str(BootingState()),
+            cls.test_resource_attributes["site_name"],
+            cls.test_resource_attributes["machine_type"],
+            str(cls.test_resource_attributes["created"]),
+            str(cls.test_resource_attributes["updated"]),
+        )
 
-        cls.test_updated_notify_result = (cls.test_updated_resource_attributes['remote_resource_uuid'],
-                                          cls.test_updated_resource_attributes['drone_uuid'],
-                                          str(IntegrateState()),
-                                          cls.test_updated_resource_attributes['site_name'],
-                                          cls.test_updated_resource_attributes['machine_type'],
-                                          str(cls.test_updated_resource_attributes['created']),
-                                          str(cls.test_updated_resource_attributes['updated']))
+        cls.test_updated_notify_result = (
+            cls.test_updated_resource_attributes["remote_resource_uuid"],
+            cls.test_updated_resource_attributes["drone_uuid"],
+            str(IntegrateState()),
+            cls.test_updated_resource_attributes["site_name"],
+            cls.test_updated_resource_attributes["machine_type"],
+            str(cls.test_updated_resource_attributes["created"]),
+            str(cls.test_updated_resource_attributes["updated"]),
+        )
 
-        cls.mock_config_patcher = patch('tardis.plugins.sqliteregistry.Configuration')
+        cls.mock_config_patcher = patch("tardis.plugins.sqliteregistry.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
 
     @classmethod
@@ -65,7 +77,7 @@ class TestSqliteRegistry(TestCase):
 
     def setUp(self):
         self.test_path = os.path.dirname(os.path.realpath(__file__))
-        self.test_db = os.path.join(self.test_path, 'test.db')
+        self.test_db = os.path.join(self.test_path, "test.db")
         try:
             os.remove(self.test_db)
         except FileNotFoundError:
@@ -83,8 +95,10 @@ class TestSqliteRegistry(TestCase):
 
         with sqlite3.connect(self.test_db) as connection:
             cursor = connection.cursor()
-            cursor.execute("""SELECT MachineTypes.machine_type, Sites.site_name FROM MachineTypes 
-                              JOIN Sites ON MachineTypes.site_id=Sites.site_id""")
+            cursor.execute(
+                """SELECT MachineTypes.machine_type, Sites.site_name FROM MachineTypes 
+                              JOIN Sites ON MachineTypes.site_id=Sites.site_id"""
+            )
             for row in cursor:
                 self.assertEqual(row, (self.test_machine_type, self.test_site_name))
 
@@ -94,7 +108,7 @@ class TestSqliteRegistry(TestCase):
 
         with sqlite3.connect(self.test_db) as connection:
             cursor = connection.cursor()
-            cursor.execute('SELECT site_name FROM Sites')
+            cursor.execute("SELECT site_name FROM Sites")
             for row in cursor:
                 self.assertEqual(row[0], self.test_site_name)
 
@@ -104,35 +118,44 @@ class TestSqliteRegistry(TestCase):
         with sqlite3.connect(self.test_db) as connection:
             cursor = connection.cursor()
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            created_tables = {table_name[0] for table_name in cursor.fetchall() if table_name[0] != "sqlite_sequence"}
+            created_tables = {
+                table_name[0]
+                for table_name in cursor.fetchall()
+                if table_name[0] != "sqlite_sequence"
+            }
         self.assertEqual(created_tables, self.tables_in_db)
 
     def test_double_schema_deployment(self):
         SqliteRegistry()
         SqliteRegistry()
 
-    @patch('tardis.plugins.sqliteregistry.logging', Mock())
+    @patch("tardis.plugins.sqliteregistry.logging", Mock())
     def test_get_resources(self):
         registry = SqliteRegistry()
         registry.add_site(self.test_site_name)
         registry.add_machine_types(self.test_site_name, self.test_machine_type)
         run_async(registry.notify, BootingState(), self.test_resource_attributes)
 
-        self.assertListEqual(registry.get_resources(site_name=self.test_site_name,
-                                                    machine_type=self.test_machine_type),
-                             [self.test_get_resources_result])
+        self.assertListEqual(
+            registry.get_resources(
+                site_name=self.test_site_name, machine_type=self.test_machine_type
+            ),
+            [self.test_get_resources_result],
+        )
 
-    @patch('tardis.plugins.sqliteregistry.logging', Mock())
+    @patch("tardis.plugins.sqliteregistry.logging", Mock())
     def test_notify(self):
         def fetch_row(db):
             with sqlite3.connect(db) as connection:
                 cursor = connection.cursor()
-                cursor.execute("""SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, S.site_name, MT.machine_type, 
+                cursor.execute(
+                    """SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, S.site_name, MT.machine_type, 
                 R.created, R.updated
                 FROM Resources R
                 JOIN ResourceStates RS ON R.state_id = RS.state_id
                 JOIN Sites S ON R.site_id = S.site_id
-                JOIN MachineTypes MT ON R.machine_type_id = MT.machine_type_id""")
+                JOIN MachineTypes MT ON R.machine_type_id = MT.machine_type_id"""
+                )
                 return cursor.fetchone()
 
         registry = SqliteRegistry()
@@ -143,7 +166,9 @@ class TestSqliteRegistry(TestCase):
 
         self.assertEqual(self.test_notify_result, fetch_row(self.test_db))
 
-        run_async(registry.notify, IntegrateState(), self.test_updated_resource_attributes)
+        run_async(
+            registry.notify, IntegrateState(), self.test_updated_resource_attributes
+        )
 
         self.assertEqual(self.test_updated_notify_result, fetch_row(self.test_db))
 

--- a/tests/plugins_t/test_telegrafmonitoring.py
+++ b/tests/plugins_t/test_telegrafmonitoring.py
@@ -16,8 +16,12 @@ import platform
 class TestTelegrafMonitoring(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.plugins.telegrafmonitoring.Configuration')
-        cls.mock_aiotelegraf_patcher = patch('tardis.plugins.telegrafmonitoring.aiotelegraf')
+        cls.mock_config_patcher = patch(
+            "tardis.plugins.telegrafmonitoring.Configuration"
+        )
+        cls.mock_aiotelegraf_patcher = patch(
+            "tardis.plugins.telegrafmonitoring.aiotelegraf"
+        )
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_aiotelegraf = cls.mock_aiotelegraf_patcher.start()
 
@@ -26,12 +30,12 @@ class TestTelegrafMonitoring(TestCase):
         cls.mock_config_patcher.stop()
         cls.mock_aiotelegraf_patcher.stop()
 
-    @patch('tardis.plugins.telegrafmonitoring.logging', Mock())
+    @patch("tardis.plugins.telegrafmonitoring.logging", Mock())
     def setUp(self):
         self.config = self.mock_config.return_value
         self.config.Plugins.TelegrafMonitoring.host = "telegraf.test"
         self.config.Plugins.TelegrafMonitoring.port = 1234
-        self.config.Plugins.TelegrafMonitoring.default_tags = {'test_tag': 'test'}
+        self.config.Plugins.TelegrafMonitoring.default_tags = {"test_tag": "test"}
         self.config.Plugins.TelegrafMonitoring.metric = "tardis_data"
 
         telegraf_client = self.mock_aiotelegraf.Client.return_value
@@ -40,36 +44,52 @@ class TestTelegrafMonitoring(TestCase):
 
         self.plugin = TelegrafMonitoring()
 
-    @patch('tardis.plugins.telegrafmonitoring.logging', Mock())
+    @patch("tardis.plugins.telegrafmonitoring.logging", Mock())
     def test_notify(self):
-        test_param = AttributeDict(site_name='test-site',
-                                   machine_type='test_machine_type',
-                                   created=datetime.now(),
-                                   updated=datetime.now())
+        test_param = AttributeDict(
+            site_name="test-site",
+            machine_type="test_machine_type",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
         test_state = RequestState()
         test_result = dict(state=str(test_state))
-        test_result.update(created=datetime.timestamp(test_param.created),
-                           updated=datetime.timestamp(test_param.updated))
-        test_tags = dict(site_name=test_param.site_name, machine_type=test_param.machine_type)
+        test_result.update(
+            created=datetime.timestamp(test_param.created),
+            updated=datetime.timestamp(test_param.updated),
+        )
+        test_tags = dict(
+            site_name=test_param.site_name, machine_type=test_param.machine_type
+        )
         run_async(self.plugin.notify, test_state, test_param)
-        self.mock_aiotelegraf.Client.assert_called_with(host='telegraf.test', port=1234,
-                                                        tags={'tardis_machine_name': platform.node(),
-                                                              'test_tag': 'test'})
+        self.mock_aiotelegraf.Client.assert_called_with(
+            host="telegraf.test",
+            port=1234,
+            tags={"tardis_machine_name": platform.node(), "test_tag": "test"},
+        )
         self.mock_aiotelegraf.Client.return_value.connect.assert_called_with()
-        self.mock_aiotelegraf.Client.return_value.metric.assert_called_with('tardis_data', test_result, tags=test_tags)
+        self.mock_aiotelegraf.Client.return_value.metric.assert_called_with(
+            "tardis_data", test_result, tags=test_tags
+        )
         self.mock_aiotelegraf.Client.return_value.close.assert_called_with()
 
         self.mock_aiotelegraf.reset()
 
         # Test to overwrite tardis_node_name in plugin configuration
-        self.config.Plugins.TelegrafMonitoring.default_tags = {'test_tag': 'test',
-                                                               'tardis_machine_name': 'my_test_node'}
+        self.config.Plugins.TelegrafMonitoring.default_tags = {
+            "test_tag": "test",
+            "tardis_machine_name": "my_test_node",
+        }
         self.plugin = TelegrafMonitoring()
         run_async(self.plugin.notify, test_state, test_param)
 
-        self.mock_aiotelegraf.Client.assert_called_with(host='telegraf.test', port=1234,
-                                                        tags={'tardis_machine_name': 'my_test_node',
-                                                              'test_tag': 'test'})
+        self.mock_aiotelegraf.Client.assert_called_with(
+            host="telegraf.test",
+            port=1234,
+            tags={"tardis_machine_name": "my_test_node", "test_tag": "test"},
+        )
         self.mock_aiotelegraf.Client.return_value.connect.assert_called_with()
-        self.mock_aiotelegraf.Client.return_value.metric.assert_called_with('tardis_data', test_result, tags=test_tags)
+        self.mock_aiotelegraf.Client.return_value.metric.assert_called_with(
+            "tardis_data", test_result, tags=test_tags
+        )
         self.mock_aiotelegraf.Client.return_value.close.assert_called_with()

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -12,8 +12,10 @@ from unittest.mock import patch
 class TestPoolFactory(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch('tardis.resources.poolfactory.Configuration')
-        cls.mock_sqliteregistry_patcher = patch('tardis.plugins.sqliteregistry.SqliteRegistry')
+        cls.mock_config_patcher = patch("tardis.resources.poolfactory.Configuration")
+        cls.mock_sqliteregistry_patcher = patch(
+            "tardis.plugins.sqliteregistry.SqliteRegistry"
+        )
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_sqliteregistry = cls.mock_sqliteregistry_patcher.start()
 
@@ -24,27 +26,39 @@ class TestPoolFactory(TestCase):
 
     def setUp(self):
         self.config = self.mock_config.return_value
-        self.config.Sites.name = 'TestSite'
-        self.config.Plugins = AttributeDict(SqliteRegistry=AttributeDict(db_file='test.db'))
+        self.config.Sites.name = "TestSite"
+        self.config.Plugins = AttributeDict(
+            SqliteRegistry=AttributeDict(db_file="test.db")
+        )
         sqlite_registry = self.mock_sqliteregistry.return_value
-        sqlite_registry.get_resources.return_value = [{'state': 'RequestState'}]
+        sqlite_registry.get_resources.return_value = [{"state": "RequestState"}]
 
     def test_str_to_state(self):
-        test = [{'state': 'RequestState', 'drone_uuid': 'test-abc123'}]
+        test = [{"state": "RequestState", "drone_uuid": "test-abc123"}]
         converted_test = str_to_state(test)
-        self.assertTrue(converted_test[0]['state'], RequestState)
-        self.assertEqual(converted_test[0]['drone_uuid'], 'test-abc123')
+        self.assertTrue(converted_test[0]["state"], RequestState)
+        self.assertEqual(converted_test[0]["drone_uuid"], "test-abc123")
 
     def test_load_plugins(self):
-        self.assertEqual(load_plugins(), {'SqliteRegistry': self.mock_sqliteregistry()})
+        self.assertEqual(load_plugins(), {"SqliteRegistry": self.mock_sqliteregistry()})
 
         self.mock_config.side_effect = AttributeError
         self.assertEqual(load_plugins(), {})
         self.mock_config.side_effect = None
 
     def test_get_drones_to_restore(self):
-        self.assertEqual(get_drones_to_restore(plugins={}, site=self.config.Sites, machine_type='TestMachineType'), [])
+        self.assertEqual(
+            get_drones_to_restore(
+                plugins={}, site=self.config.Sites, machine_type="TestMachineType"
+            ),
+            [],
+        )
 
-        self.assertIsInstance(get_drones_to_restore(plugins={'SqliteRegistry': self.mock_sqliteregistry()},
-                                                    site=self.config.Sites,
-                                                    machine_type='TestMachineType')[0]['state'], RequestState)
+        self.assertIsInstance(
+            get_drones_to_restore(
+                plugins={"SqliteRegistry": self.mock_sqliteregistry()},
+                site=self.config.Sites,
+                machine_type="TestMachineType",
+            )[0]["state"],
+            RequestState,
+        )

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -12,9 +12,11 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
     def decorator(func):
         def wrapper(self):
             executor = self.mock_executor.return_value
-            executor.run_command.return_value = async_return(return_value=AttributeDict(stdout=stdout,
-                                                                                        stderr=stderr,
-                                                                                        exit_code=exit_code))
+            executor.run_command.return_value = async_return(
+                return_value=AttributeDict(
+                    stdout=stdout, stderr=stderr, exit_code=exit_code
+                )
+            )
             executor.run_command.side_effect = raise_exception
             func(self)
             executor.run_command.side_effect = None

--- a/tests/utilities_t/executors_t/test_shellexecutor.py
+++ b/tests/utilities_t/executors_t/test_shellexecutor.py
@@ -13,29 +13,42 @@ class TestAsyncRunCommand(TestCase):
 
     def test_run_command(self):
 
-        self.assertEqual(run_async(self.executor.run_command, 'exit 0').exit_code, 0)
+        self.assertEqual(run_async(self.executor.run_command, "exit 0").exit_code, 0)
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, 'exit 255')
+            run_async(self.executor.run_command, "exit 255")
         self.assertEqual(cf.exception.exit_code, 255)
 
-        self.assertEqual(run_async(self.executor.run_command, 'echo "Test"').stdout, "Test")
+        self.assertEqual(
+            run_async(self.executor.run_command, 'echo "Test"').stdout, "Test"
+        )
 
-        self.assertEqual(run_async(self.executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test")
+        self.assertEqual(
+            run_async(self.executor.run_command, 'echo "Test" >>/dev/stderr').stderr,
+            "Test",
+        )
 
-        self.assertEqual(run_async(self.executor.run_command, 'read test; echo $test',
-                                   stdin_input="Test").stdout, "Test")
+        self.assertEqual(
+            run_async(
+                self.executor.run_command, "read test; echo $test", stdin_input="Test"
+            ).stdout,
+            "Test",
+        )
 
     def test_construction_by_yaml(self):
-        executor = yaml.safe_load("""
+        executor = yaml.safe_load(
+            """
                       !ShellExecutor
-        """)
-        self.assertEqual(run_async(executor.run_command, 'exit 0').exit_code, 0)
+        """
+        )
+        self.assertEqual(run_async(executor.run_command, "exit 0").exit_code, 0)
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, 'exit 255')
+            run_async(self.executor.run_command, "exit 255")
         self.assertEqual(cf.exception.exit_code, 255)
 
         self.assertEqual(run_async(executor.run_command, 'echo "Test"').stdout, "Test")
 
-        self.assertEqual(run_async(executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test")
+        self.assertEqual(
+            run_async(executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test"
+        )

--- a/tests/utilities_t/simulators_t/test_periodicvalue.py
+++ b/tests/utilities_t/simulators_t/test_periodicvalue.py
@@ -13,9 +13,11 @@ class TestPeriodicValue(TestCase):
         self.assertLessEqual(self.simulator.get_value(), 1.0)
 
     def test_construction_by_yaml(self):
-        periodic_value = yaml.safe_load("""!PeriodicValue
+        periodic_value = yaml.safe_load(
+            """!PeriodicValue
                                            period: 3600
                                            amplitude: 0.5
                                            offset: 0.5
-                                           phase: 0""")
+                                           phase: 0"""
+        )
         self.assertIsInstance(periodic_value.get_value(), float)

--- a/tests/utilities_t/simulators_t/test_randomgauss.py
+++ b/tests/utilities_t/simulators_t/test_randomgauss.py
@@ -16,9 +16,11 @@ class TestRandomGauss(TestCase):
         self.assertGreater(value, -10)
 
     def test_construction_by_yaml(self):
-        random_gauss = yaml.safe_load("""
+        random_gauss = yaml.safe_load(
+            """
                               !RandomGauss
                               mu: 0
                               sigma: 1
-                              """)
+                              """
+        )
         self.assertIsInstance(random_gauss.get_value(), float)

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -13,16 +13,22 @@ import logging
 
 class TestAsyncCacheMap(TestCase):
     def setUp(self):
-        self.test_data = {'testA': 123, 'testB': 'Random String'}
+        self.test_data = {"testA": 123, "testB": "Random String"}
         self.async_cache_map = AsyncCacheMap(update_coroutine=self.update_function)
-        self.json_failing_async_cache_map = AsyncCacheMap(update_coroutine=self.json_failing_update_function)
-        self.command_failing_async_cache_map = AsyncCacheMap(update_coroutine=self.command_failing_update_function)
+        self.json_failing_async_cache_map = AsyncCacheMap(
+            update_coroutine=self.json_failing_update_function
+        )
+        self.command_failing_async_cache_map = AsyncCacheMap(
+            update_coroutine=self.command_failing_update_function
+        )
 
     async def json_failing_update_function(self):
-        raise JSONDecodeError(msg='Bla', doc='Blubb', pos=99)
+        raise JSONDecodeError(msg="Bla", doc="Blubb", pos=99)
 
     async def command_failing_update_function(self):
-        raise CommandExecutionFailure(message='Failure', stdout='Failure', stderr='Failure', exit_code=2)
+        raise CommandExecutionFailure(
+            message="Failure", stdout="Failure", stderr="Failure", exit_code=2
+        )
 
     async def update_function(self):
         return self.test_data
@@ -39,8 +45,8 @@ class TestAsyncCacheMap(TestCase):
 
     def test_get_async_cache_map(self):
         self.update_status()
-        self.assertEqual(self.async_cache_map.get('testA'), self.test_data.get('testA'))
-        self.assertEqual(self.async_cache_map['testB'], self.test_data['testB'])
+        self.assertEqual(self.async_cache_map.get("testA"), self.test_data.get("testA"))
+        self.assertEqual(self.async_cache_map["testB"], self.test_data["testB"])
 
     def test_iter_async_cache_map(self):
         self.update_status()
@@ -61,4 +67,6 @@ class TestAsyncCacheMap(TestCase):
     def test_last_update(self):
         self.assertEqual(self.async_cache_map.last_update, datetime.fromtimestamp(0))
         run_async(self.async_cache_map.update_status)
-        self.assertTrue(datetime.now()-self.async_cache_map.last_update < timedelta(seconds=1))
+        self.assertTrue(
+            datetime.now() - self.async_cache_map.last_update < timedelta(seconds=1)
+        )

--- a/tests/utilities_t/test_attributedict.py
+++ b/tests/utilities_t/test_attributedict.py
@@ -7,18 +7,18 @@ class TestAttributeDict(TestCase):
         self.test_dictionary = AttributeDict(test=1, another_test=2)
 
     def test_index_access(self):
-        self.assertEqual(self.test_dictionary['test'], 1)
-        self.assertEqual(self.test_dictionary['another_test'], 2)
+        self.assertEqual(self.test_dictionary["test"], 1)
+        self.assertEqual(self.test_dictionary["another_test"], 2)
 
     def test_access_via_attribute(self):
         self.assertEqual(self.test_dictionary.test, 1)
         self.assertEqual(self.test_dictionary.another_test, 2)
 
     def test_set_via_index(self):
-        self.test_dictionary['test'] = 3
-        self.assertEqual(self.test_dictionary['test'], 3)
-        self.test_dictionary['yet_another_test'] = 4
-        self.assertEqual(self.test_dictionary['yet_another_test'], 4)
+        self.test_dictionary["test"] = 3
+        self.assertEqual(self.test_dictionary["test"], 3)
+        self.test_dictionary["yet_another_test"] = 4
+        self.assertEqual(self.test_dictionary["yet_another_test"], 4)
 
     def test_set_via_attribute(self):
         self.test_dictionary.test = 3
@@ -27,14 +27,14 @@ class TestAttributeDict(TestCase):
         self.assertEqual(self.test_dictionary.yet_another_test, 4)
 
     def test_del_via_index(self):
-        del self.test_dictionary['another_test']
+        del self.test_dictionary["another_test"]
         with self.assertRaises(KeyError):
-            self.test_dictionary['another_test']
+            self.test_dictionary["another_test"]
 
     def test_del_via_attribute(self):
         del self.test_dictionary.another_test
         with self.assertRaises(KeyError):
-            self.test_dictionary['another_test']
+            self.test_dictionary["another_test"]
 
         with self.assertRaises(AttributeError):
             self.test_dictionary.another_test

--- a/tests/utilities_t/test_pipeline.py
+++ b/tests/utilities_t/test_pipeline.py
@@ -15,17 +15,30 @@ class TestPipelineProcessor(TestCase):
         self.pipeline_processor = PipelineProcessor([test_update])
 
     def test_pipeline_processor(self):
-        self.assertEqual(run_async(self.pipeline_processor.run_pipeline, pipeline_input=10,
-                                   drone="drone_place_holder"), 1)
+        self.assertEqual(
+            run_async(
+                self.pipeline_processor.run_pipeline,
+                pipeline_input=10,
+                drone="drone_place_holder",
+            ),
+            1,
+        )
 
     def test_add_function(self):
         async def test_add(pipeline_input, drone):
             self.assertEqual(pipeline_input, 1)
             self.assertEqual(drone, "drone_place_holder")
             return 2
+
         self.pipeline_processor.add_to_pipeline(test_add)
-        self.assertEqual(run_async(self.pipeline_processor.run_pipeline, pipeline_input=10,
-                                   drone="drone_place_holder"), 2)
+        self.assertEqual(
+            run_async(
+                self.pipeline_processor.run_pipeline,
+                pipeline_input=10,
+                drone="drone_place_holder",
+            ),
+            2,
+        )
 
     def test_stop_processing(self):
         def test_stop_processing(pipeline_input, drone):
@@ -34,4 +47,11 @@ class TestPipelineProcessor(TestCase):
             raise StopProcessing(last_result=99)
 
         pipeline_processor = PipelineProcessor([test_stop_processing])
-        self.assertEqual(run_async(pipeline_processor.run_pipeline, pipeline_input=10, drone="drone_place_holder"), 99)
+        self.assertEqual(
+            run_async(
+                pipeline_processor.run_pipeline,
+                pipeline_input=10,
+                drone="drone_place_holder",
+            ),
+            99,
+        )

--- a/tests/utilities_t/test_staticmapping.py
+++ b/tests/utilities_t/test_staticmapping.py
@@ -5,15 +5,15 @@ from unittest import TestCase
 
 class TestStaticMapping(TestCase):
     def setUp(self):
-        self.test_data = {'testA': 123, 'testB': 'Random String'}
+        self.test_data = {"testA": 123, "testB": "Random String"}
         self.static_map = StaticMapping(**self.test_data)
 
     def test_len_static_mapping(self):
         self.assertEqual(len(self.static_map), len(self.test_data))
 
     def test_get_item_static_mapping(self):
-        self.assertEqual(self.static_map.get('testA'), self.test_data.get('testA'))
-        self.assertEqual(self.static_map['testB'], self.test_data['testB'])
+        self.assertEqual(self.static_map.get("testA"), self.test_data.get("testA"))
+        self.assertEqual(self.static_map["testB"], self.test_data["testB"])
 
     def test_iter_static_mapping(self):
         static_map = StaticMapping(**self.test_data)
@@ -23,6 +23,6 @@ class TestStaticMapping(TestCase):
 
     def test_modify_static_mapping(self):
         with self.assertRaises(TypeError):
-            self.static_map['testB'] = 456
+            self.static_map["testB"] = 456
         with self.assertRaises(TypeError):
-            self.static_map['testC'] = 456
+            self.static_map["testC"] = 456

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -10,19 +10,18 @@ from unittest import TestCase
 
 class TestAsyncRunCommand(TestCase):
     def test_async_run_command(self):
-        run_async(async_run_command, 'exit 0')
-        run_async(async_run_command,'exit 255')
+        run_async(async_run_command, "exit 0")
+        run_async(async_run_command, "exit 255")
 
         with self.assertRaises(CommandExecutionFailure):
-            run_async(async_run_command, 'exit 1')
+            run_async(async_run_command, "exit 1")
 
         self.assertEqual(run_async(async_run_command, 'echo "Test"'), "Test")
 
 
 class TestHTCondorCMDOptionFormatter(TestCase):
     def test_htcondor_cmd_option_formatter(self):
-        options = {'pool': 'my-htcondor.local',
-                   'test': None}
+        options = {"pool": "my-htcondor.local", "test": None}
         options_string = htcondor_cmd_option_formatter(options)
 
         self.assertEqual(options_string, "-pool my-htcondor.local -test")
@@ -30,21 +29,37 @@ class TestHTCondorCMDOptionFormatter(TestCase):
 
 class TestHTCondorCSVParser(TestCase):
     def test_htcondor_csv_parser(self):
-        htcondor_input = "\n".join(["exoscale-26d361290f\tUnclaimed\tIdle\t0.125\t0.125",
-                                    "test_replace\tOwner\tIdle\tundefined\tundefined"])
+        htcondor_input = "\n".join(
+            [
+                "exoscale-26d361290f\tUnclaimed\tIdle\t0.125\t0.125",
+                "test_replace\tOwner\tIdle\tundefined\tundefined",
+            ]
+        )
 
-        parsed_rows = htcondor_csv_parser(htcondor_input=htcondor_input,
-                                          fieldnames=('Machine', 'State', 'Activity', 'Test1', 'Test2'),
-                                          replacements=dict(undefined=None))
+        parsed_rows = htcondor_csv_parser(
+            htcondor_input=htcondor_input,
+            fieldnames=("Machine", "State", "Activity", "Test1", "Test2"),
+            replacements=dict(undefined=None),
+        )
 
-        self.assertEqual(next(parsed_rows), dict(Machine="exoscale-26d361290f",
-                                                 State="Unclaimed",
-                                                 Activity="Idle",
-                                                 Test1="0.125",
-                                                 Test2="0.125"))
+        self.assertEqual(
+            next(parsed_rows),
+            dict(
+                Machine="exoscale-26d361290f",
+                State="Unclaimed",
+                Activity="Idle",
+                Test1="0.125",
+                Test2="0.125",
+            ),
+        )
 
-        self.assertEqual(next(parsed_rows), dict(Machine="test_replace",
-                                                 State="Owner",
-                                                 Activity="Idle",
-                                                 Test1=None,
-                                                 Test2=None))
+        self.assertEqual(
+            next(parsed_rows),
+            dict(
+                Machine="test_replace",
+                State="Owner",
+                Activity="Idle",
+                Test1=None,
+                Test2=None,
+            ),
+        )


### PR DESCRIPTION
This PR makes the [Black code formatter](https://github.com/psf/black) mandatory for ``tardis`` source. This PR includes:

* [x] mandatory runs of Black on CI tests,
* [x] extension of contribution guidelines,
* [x] reformatting of all code to satisfy Black.