### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: flake8
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+        args:
+        -   --py36


### PR DESCRIPTION
Enable usage of `pre-commit` in `TARDIS` in order check code style and correct code formating using black right before commiting to the repository. See [`pre-commit` documentation](https://pre-commit.com) on how to enable it in your local repository.