### PR TITLE
Refactor access to site adapter properties to avoid code duplication

### DIFF
--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -30,6 +30,7 @@ class CloudStackAdapter(SiteAdapter):
             api_secret=self.configuration.api_secret,
             event_loop=runtime._meta_runner.runners[asyncio].event_loop,
         )
+        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 
@@ -64,10 +65,6 @@ class CloudStackAdapter(SiteAdapter):
         )
         logging.debug(f"{self.site_name} deployVirtualMachine returned {response}")
         return self.handle_response(response["virtualmachine"])
-
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
 
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -73,10 +73,6 @@ class CloudStackAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -59,8 +59,7 @@ class CloudStackAdapter(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         response = await self.cloud_stack_client.deployVirtualMachine(
-            name=resource_attributes.drone_uuid,
-            **self._configuration.MachineTypeConfiguration[self._machine_type],
+            name=resource_attributes.drone_uuid, **self.machine_type_configuration
         )
         logging.debug(f"{self.site_name} deployVirtualMachine returned {response}")
         return self.handle_response(response["virtualmachine"])

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -23,14 +23,14 @@ import logging
 
 class CloudStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self.configuration = getattr(Configuration(), site_name)
+        self._configuration = getattr(Configuration(), site_name)
         self.cloud_stack_client = CloudStack(
-            end_point=self.configuration.end_point,
-            api_key=self.configuration.api_key,
-            api_secret=self.configuration.api_secret,
+            end_point=self._configuration.end_point,
+            api_key=self._configuration.api_key,
+            api_secret=self._configuration.api_secret,
             event_loop=runtime._meta_runner.runners[asyncio].event_loop,
         )
-        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
+        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 
@@ -61,7 +61,7 @@ class CloudStackAdapter(SiteAdapter):
     ) -> AttributeDict:
         response = await self.cloud_stack_client.deployVirtualMachine(
             name=resource_attributes.drone_uuid,
-            **self.configuration.MachineTypeConfiguration[self._machine_type],
+            **self._configuration.MachineTypeConfiguration[self._machine_type],
         )
         logging.debug(f"{self.site_name} deployVirtualMachine returned {response}")
         return self.handle_response(response["virtualmachine"])

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -69,10 +69,6 @@ class CloudStackAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -30,7 +30,6 @@ class CloudStackAdapter(SiteAdapter):
             api_secret=self._configuration.api_secret,
             event_loop=runtime._meta_runner.runners[asyncio].event_loop,
         )
-        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -62,10 +62,6 @@ class FakeSiteAdapter(SiteAdapter):
             ] = self._resource_boot_time.get_value()
             return resource_boot_time
 
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self._configuration.MachineMetaData[self._machine_type]
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -70,10 +70,6 @@ class FakeSiteAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -66,10 +66,6 @@ class FakeSiteAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -16,11 +16,11 @@ import asyncio
 
 class FakeSiteAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str) -> None:
-        self.configuration = getattr(Configuration(), site_name)
+        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._api_response_delay = self.configuration.api_response_delay
-        self._resource_boot_time = self.configuration.resource_boot_time
+        self._api_response_delay = self._configuration.api_response_delay
+        self._resource_boot_time = self._configuration.resource_boot_time
 
         key_translator = StaticMapping(
             remote_resource_uuid="remote_resource_uuid",
@@ -64,7 +64,7 @@ class FakeSiteAdapter(SiteAdapter):
 
     @property
     def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
+        return self._configuration.MachineMetaData[self._machine_type]
 
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -132,10 +132,6 @@ class HTCondorAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -61,7 +61,6 @@ htcondor_translate_resources_prefix = {"Cores": 1, "Memory": 1024, "Disk": 1024}
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self._configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
         self._executor = getattr(self._configuration, "executor", ShellExecutor())

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -60,11 +60,11 @@ htcondor_translate_resources_prefix = {"Cores": 1, "Memory": 1024, "Disk": 1024}
 
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self.configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
+        self._configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
-        self._executor = getattr(self.configuration, "executor", ShellExecutor())
+        self._executor = getattr(self._configuration, "executor", ShellExecutor())
 
         key_translator = StaticMapping(
             remote_resource_uuid="ClusterId",
@@ -90,13 +90,13 @@ class HTCondorAdapter(SiteAdapter):
 
         self._htcondor_queue = AsyncCacheMap(
             update_coroutine=partial(htcondor_queue_updater, self._executor),
-            max_age=self.configuration.max_age * 60,
+            max_age=self._configuration.max_age * 60,
         )
 
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        jdl_file = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
+        jdl_file = self._configuration.MachineTypeConfiguration[self._machine_type].jdl
         with open(jdl_file, "r") as f:
             jdl_template = Template(f.read())
 

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -61,6 +61,7 @@ htcondor_translate_resources_prefix = {"Cores": 1, "Memory": 1024, "Disk": 1024}
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self.configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
         self._executor = getattr(self.configuration, "executor", ShellExecutor())
@@ -127,10 +128,6 @@ class HTCondorAdapter(SiteAdapter):
         response = AttributeDict(pattern.search(response.stdout).groupdict())
         response.update(self.create_timestamps())
         return self.handle_response(response)
-
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
 
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -136,10 +136,6 @@ class HTCondorAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -95,7 +95,7 @@ class HTCondorAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        jdl_file = self._configuration.MachineTypeConfiguration[self._machine_type].jdl
+        jdl_file = self.machine_type_configuration.jdl
         with open(jdl_file, "r") as f:
             jdl_template = Template(f.read())
 

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -46,17 +46,16 @@ async def moab_status_updater(executor):
 
 class MoabAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self.configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
+        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._startup_command = self.configuration.StartupCommand
+        self._startup_command = self._configuration.StartupCommand
 
-        self._executor = getattr(self.configuration, "executor", ShellExecutor())
+        self._executor = getattr(self._configuration, "executor", ShellExecutor())
 
         self._moab_status = AsyncCacheMap(
             update_coroutine=partial(moab_status_updater, self._executor),
-            max_age=self.configuration.StatusUpdate * 60,
+            max_age=self._configuration.StatusUpdate * 60,
         )
         key_translator = StaticMapping(
             remote_resource_uuid="JobID", resource_status="State"
@@ -82,7 +81,7 @@ class MoabAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        machine_configuration = self.configuration.MachineTypeConfiguration[
+        machine_configuration = self._configuration.MachineTypeConfiguration[
             self._machine_type
         ]
         request_command = (

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -108,10 +108,6 @@ class MoabAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     @staticmethod
     def check_remote_resource_uuid(resource_attributes, regex, response):
         pattern = re.compile(regex, flags=re.MULTILINE)

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -47,6 +47,7 @@ async def moab_status_updater(executor):
 class MoabAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self.configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
         self._startup_command = self.configuration.StartupCommand
@@ -103,10 +104,6 @@ class MoabAdapter(SiteAdapter):
             resource_status=ResourceStatus.Booting,
         )
         return resource_attributes
-
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
 
     @staticmethod
     def check_remote_resource_uuid(resource_attributes, regex, response):

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -81,14 +81,11 @@ class MoabAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        machine_configuration = self._configuration.MachineTypeConfiguration[
-            self._machine_type
-        ]
         request_command = (
             f"msub -j oe -m p -l "
-            f"walltime={machine_configuration.Walltime},"
+            f"walltime={self.machine_type_configuration.Walltime},"
             f"mem={self.machine_meta_data.Memory}gb,"
-            f"nodes={machine_configuration.NodeType} "
+            f"nodes={self.machine_type_configuration.NodeType} "
             f"{self._startup_command}"
         )
         result = await self._executor.run_command(request_command)

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -112,10 +112,6 @@ class MoabAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     @staticmethod
     def check_remote_resource_uuid(resource_attributes, regex, response):
         pattern = re.compile(regex, flags=re.MULTILINE)

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -75,10 +75,6 @@ class OpenStackAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -26,7 +26,6 @@ import logging
 class OpenStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self._configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -25,18 +25,18 @@ import logging
 
 class OpenStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self.configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
+        self._configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 
         auth = AuthPassword(
-            auth_url=self.configuration.auth_url,
-            username=self.configuration.username,
-            password=self.configuration.password,
-            project_name=self.configuration.project_name,
-            user_domain_name=self.configuration.user_domain_name,
-            project_domain_name=self.configuration.project_domain_name,
+            auth_url=self._configuration.auth_url,
+            username=self._configuration.username,
+            password=self._configuration.password,
+            project_name=self._configuration.project_name,
+            user_domain_name=self._configuration.user_domain_name,
+            project_domain_name=self._configuration.project_domain_name,
         )
 
         self.nova = NovaClient(session=auth)
@@ -66,7 +66,7 @@ class OpenStackAdapter(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         specs = dict(name=resource_attributes.drone_uuid)
-        specs.update(self.configuration.MachineTypeConfiguration[self._machine_type])
+        specs.update(self._configuration.MachineTypeConfiguration[self._machine_type])
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.create(server=specs)
         logging.debug(f"{self.site_name} servers create returned {response}")

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -79,10 +79,6 @@ class OpenStackAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -26,6 +26,7 @@ import logging
 class OpenStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self.configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
 
@@ -70,10 +71,6 @@ class OpenStackAdapter(SiteAdapter):
         response = await self.nova.servers.create(server=specs)
         logging.debug(f"{self.site_name} servers create returned {response}")
         return self.handle_response(response["server"])
-
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
 
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -65,7 +65,7 @@ class OpenStackAdapter(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         specs = dict(name=resource_attributes.drone_uuid)
-        specs.update(self._configuration.MachineTypeConfiguration[self._machine_type])
+        specs.update(self.machine_type_configuration)
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.create(server=specs)
         logging.debug(f"{self.site_name} servers create returned {response}")

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -43,7 +43,6 @@ async def slurm_status_updater(executor):
 class SlurmAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self._configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
         self._startup_command = self._configuration.StartupCommand

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -42,17 +42,17 @@ async def slurm_status_updater(executor):
 
 class SlurmAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self.configuration = getattr(Configuration(), site_name)
-        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
+        self._configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self._configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
-        self._startup_command = self.configuration.StartupCommand
+        self._startup_command = self._configuration.StartupCommand
 
-        self._executor = getattr(self.configuration, "executor", ShellExecutor())
+        self._executor = getattr(self._configuration, "executor", ShellExecutor())
 
         self._slurm_status = AsyncCacheMap(
             update_coroutine=partial(slurm_status_updater, self._executor),
-            max_age=self.configuration.StatusUpdate * 60,
+            max_age=self._configuration.StatusUpdate * 60,
         )
 
         key_translator = StaticMapping(
@@ -89,7 +89,7 @@ class SlurmAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        machine_configuration = self.configuration.MachineTypeConfiguration[
+        machine_configuration = self._configuration.MachineTypeConfiguration[
             self._machine_type
         ]
         request_command = (

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -88,16 +88,13 @@ class SlurmAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        machine_configuration = self._configuration.MachineTypeConfiguration[
-            self._machine_type
-        ]
         request_command = (
-            f"sbatch -p {machine_configuration.Partition} "
+            f"sbatch -p {self.machine_type_configuration.Partition} "
             f"-N 1 -n {self.machine_meta_data.Cores} "
             f"--mem={self.machine_meta_data.Memory}gb "
-            f"-t {machine_configuration.Walltime} "
+            f"-t {self.machine_type_configuration.Walltime} "
             f"--export=SLURM_Walltime="
-            f"{machine_configuration.Walltime} "
+            f"{self.machine_type_configuration.Walltime} "
             f"{self._startup_command}"
         )
         result = await self._executor.run_command(request_command)

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -121,10 +121,6 @@ class SlurmAdapter(SiteAdapter):
     def machine_type(self) -> str:
         return self._machine_type
 
-    @property
-    def site_name(self) -> str:
-        return self._site_name
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -117,10 +117,6 @@ class SlurmAdapter(SiteAdapter):
     def machine_meta_data(self) -> AttributeDict:
         return self.configuration.MachineMetaData[self._machine_type]
 
-    @property
-    def machine_type(self) -> str:
-        return self._machine_type
-
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -43,6 +43,7 @@ async def slurm_status_updater(executor):
 class SlurmAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
         self.configuration = getattr(Configuration(), site_name)
+        self._machine_meta_data = self.configuration.MachineMetaData[machine_type]
         self._machine_type = machine_type
         self._site_name = site_name
         self._startup_command = self.configuration.StartupCommand
@@ -112,10 +113,6 @@ class SlurmAdapter(SiteAdapter):
             resource_status=ResourceStatus.Booting,
         )
         return resource_attributes
-
-    @property
-    def machine_meta_data(self) -> AttributeDict:
-        return self.configuration.MachineMetaData[self._machine_type]
 
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -50,7 +50,13 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def machine_type(self) -> str:
-        return NotImplemented
+        try:
+            # noinspection PyUnresolvedReferences
+            return self._machine_type
+        except AttributeError as ae:
+            raise AttributeError(
+                f"Class {self.__class__.__name__} must have an '_machine_type' instance variable"
+            ) from ae
 
     @abstractmethod
     async def resource_status(

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -26,7 +26,7 @@ class SiteAdapter(metaclass=ABCMeta):
     @property
     def configuration(self) -> AttributeDict:
         """
-        Property to provides access to configuration of the actual
+        Property to provide access to configuration of the actual
         implementation of the SiteAdapter.
         :return: returns the configuration of the Site Adapter
         :rtype: AttributeDict

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -46,7 +46,13 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def machine_meta_data(self) -> AttributeDict:
-        return NotImplemented
+        try:
+            # noinspection PyUnresolvedReferences
+            return self._machine_meta_data
+        except AttributeError as ae:
+            raise AttributeError(
+                f"Class {self.__class__.__name__} must have an '_machine_meta_data' instance variable"
+            ) from ae
 
     @property
     def machine_type(self) -> str:

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -32,6 +32,7 @@ class SiteAdapter(metaclass=ABCMeta):
     def drone_uuid(self, uuid) -> str:
         return f"{self.site_name.lower()}-{uuid}"
 
+    @abstractmethod
     def handle_exceptions(self):
         raise NotImplementedError
 

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -5,6 +5,10 @@ from enum import Enum
 
 
 class ResourceStatus(Enum):
+    """
+    Status of the resource at the resource provider (batch system, cloud provider, etc.)
+    """
+
     Booting = 1
     Running = 2
     Stopped = 3
@@ -13,8 +17,20 @@ class ResourceStatus(Enum):
 
 
 class SiteAdapter(metaclass=ABCMeta):
+    """
+    Abstract base class defining the interface for SiteAdapters which provide
+    access to various Cloud APIs and batch systems in order to manage
+    opportunistic resources.
+    """
+
     @property
     def configuration(self) -> AttributeDict:
+        """
+        Property to provides access to configuration of the actual
+        implementation of the SiteAdapter.
+        :return: returns the configuration of the Site Adapter
+        :rtype: AttributeDict
+        """
         try:
             # noinspection PyUnresolvedReferences
             return self._configuration
@@ -27,19 +43,61 @@ class SiteAdapter(metaclass=ABCMeta):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
+        """
+        Abstract method to define the interface to deploy a new resource at a
+        resource provider.
+        :param resource_attributes: Contains describing attributes of the resource,
+        defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
+        :type resource_attributes: AttributeDict
+        :return: Contains updated describing attributes of the resource.
+        :rtype: AttributeDict
+        """
         raise NotImplementedError
 
-    def drone_uuid(self, uuid) -> str:
+    def drone_uuid(self, uuid: str) -> str:
+        """
+        Returns the drone uuid consisting of the lower case site name and the
+        first 10 bytes of uuid4 due to constraints on length of a full DNS name
+        (253 bytes).
+        :param uuid: The first 10 bytes of a uuid4
+        :type uuid: str
+        :return: The drone uuid consisting of the lower case site name and the
+        first 10 bytes of uuid4.
+        :rtype: str
+        """
         return f"{self.site_name.lower()}-{uuid}"
 
     @abstractmethod
     def handle_exceptions(self):
+        """
+        Abstract method defining the interface to handle exception occurring
+        during interacting with the resource provider.
+        :return: None
+        """
         raise NotImplementedError
 
     @staticmethod
     def handle_response(
         response, key_translator: dict, translator_functions: dict, **additional_content
     ):
+        """
+        Method to handle the responses of the resource provider and translating
+        it to a uniform format.
+        :param response: A dictionary containing with the response of the
+        resource provider.
+        :type response: dict
+        :param key_translator: A dictionary containing the translation of keys
+        of the original response of the provider in keys of the common format.
+        :type key_translator: dict
+        :param translator_functions: A dictionary containing functions to
+        transform value of the original reponse of the provider into values of
+        the common format.
+        :type translator_functions: dict
+        :param additional_content: Additional content to be put into response,
+        which is not part of the original response of the resource provider.
+        :return: Translated response of the resource provider in a common format.
+        :rtype: dict
+        """
         translated_response = AttributeDict()
 
         for translated_key, key in key_translator.items():
@@ -57,10 +115,23 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def machine_meta_data(self) -> AttributeDict:
+        """
+        Property to access the machine_meta_data (like cores, memory and disk)
+        of a resource.
+        :return: The machine_meta_data of a resource.
+        :rtype: AttributeDict
+        """
         return self.configuration.MachineMetaData[self.machine_type]
 
     @property
     def machine_type(self) -> str:
+        """
+        Property to access the machine_type (flavour) of a resource and ensuring
+        that the all sub-classes of the SiteAdapter have a _machine_type
+        class variable .
+        :return: The machine_type of a resource.
+        :rtype: str
+        """
         try:
             # noinspection PyUnresolvedReferences
             return self._machine_type
@@ -73,10 +144,26 @@ class SiteAdapter(metaclass=ABCMeta):
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
+        """
+        Abstract method to define the interface to check the status of resources
+        at a resource provider.
+        :param resource_attributes: Contains describing attributes of the resource,
+        defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
+        :type resource_attributes: AttributeDict
+        :return: Contains updated describing attributes of the resource.
+        :rtype: AttributeDict
+        """
         raise NotImplementedError
 
     @property
     def site_name(self) -> str:
+        """
+        Property to access the site_name of a resource and ensuring
+        that the all sub-classes of the SiteAdapter have a _site_name
+        class variable.
+        :return: The site_name of a resource.
+        :rtype: str
+        """
         try:
             # noinspection PyUnresolvedReferences
             return self._site_name
@@ -87,8 +174,26 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @abstractmethod
     async def stop_resource(self, resource_attributes: AttributeDict):
+        """
+        Abstract method to define the interface to stop resources at a resource
+        provider.
+        :param resource_attributes: Contains describing attributes of the resource,
+        defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
+        :type resource_attributes: AttributeDict
+        :return: Contains updated describing attributes of the resource.
+        :rtype: AttributeDict
+        """
         raise NotImplementedError
 
     @abstractmethod
     async def terminate_resource(self, resource_attributes: AttributeDict):
+        """
+        Abstract method to define the interface to terminate resources at a
+        resource provider.
+        :param resource_attributes: Contains describing attributes of the resource,
+        defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
+        :type resource_attributes: AttributeDict
+        :return: Contains updated describing attributes of the resource.
+        :rtype: AttributeDict
+        """
         raise NotImplementedError

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -60,7 +60,13 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def site_name(self) -> str:
-        return NotImplemented
+        try:
+            # noinspection PyUnresolvedReferences
+            return self._site_name
+        except AttributeError as ae:
+            raise AttributeError(
+                f"Class {self.__class__.__name__} must have an '_site_name' instance variable"
+            ) from ae
 
     @abstractmethod
     async def stop_resource(self, resource_attributes: AttributeDict):

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -13,6 +13,16 @@ class ResourceStatus(Enum):
 
 
 class SiteAdapter(metaclass=ABCMeta):
+    @property
+    def configuration(self) -> AttributeDict:
+        try:
+            # noinspection PyUnresolvedReferences
+            return self._configuration
+        except AttributeError as ae:
+            raise AttributeError(
+                f"Class {self.__class__.__name__} must have an '_configuration' instance variable"
+            ) from ae
+
     @abstractmethod
     async def deploy_resource(
         self, resource_attributes: AttributeDict
@@ -46,13 +56,7 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def machine_meta_data(self) -> AttributeDict:
-        try:
-            # noinspection PyUnresolvedReferences
-            return self._machine_meta_data
-        except AttributeError as ae:
-            raise AttributeError(
-                f"Class {self.__class__.__name__} must have an '_machine_meta_data' instance variable"
-            ) from ae
+        return self.configuration.MachineMetaData[self.machine_type]
 
     @property
     def machine_type(self) -> str:

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -83,7 +83,7 @@ class SiteAdapter(metaclass=ABCMeta):
         """
         Method to handle the responses of the resource provider and translating
         it to a uniform format.
-        :param response: A dictionary containing with the response of the
+        :param response: A dictionary containing the response of the
         resource provider.
         :type response: dict
         :param key_translator: A dictionary containing the translation of keys

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -27,13 +27,13 @@ class SiteAdapter(metaclass=ABCMeta):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        return NotImplemented
+        raise NotImplementedError
 
     def drone_uuid(self, uuid) -> str:
         return f"{self.site_name.lower()}-{uuid}"
 
     def handle_exceptions(self):
-        return NotImplemented
+        raise NotImplementedError
 
     @staticmethod
     def handle_response(
@@ -72,7 +72,7 @@ class SiteAdapter(metaclass=ABCMeta):
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def site_name(self) -> str:
@@ -86,8 +86,8 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @abstractmethod
     async def stop_resource(self, resource_attributes: AttributeDict):
-        return NotImplemented
+        raise NotImplementedError
 
     @abstractmethod
     async def terminate_resource(self, resource_attributes: AttributeDict):
-        return NotImplemented
+        raise NotImplementedError

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -20,7 +20,7 @@ class SiteAdapter(metaclass=ABCMeta):
             return self._configuration
         except AttributeError as ae:
             raise AttributeError(
-                f"Class {self.__class__.__name__} must have an '_configuration' instance variable"
+                f"Class {self.__class__.__name__} must have an '_configuration' instance variable"  # noqa
             ) from ae
 
     @abstractmethod
@@ -65,7 +65,7 @@ class SiteAdapter(metaclass=ABCMeta):
             return self._machine_type
         except AttributeError as ae:
             raise AttributeError(
-                f"Class {self.__class__.__name__} must have an '_machine_type' instance variable"
+                f"Class {self.__class__.__name__} must have an '_machine_type' instance variable"  # noqa
             ) from ae
 
     @abstractmethod
@@ -81,7 +81,7 @@ class SiteAdapter(metaclass=ABCMeta):
             return self._site_name
         except AttributeError as ae:
             raise AttributeError(
-                f"Class {self.__class__.__name__} must have an '_site_name' instance variable"
+                f"Class {self.__class__.__name__} must have an '_site_name' instance variable"  # noqa
             ) from ae
 
     @abstractmethod

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -169,7 +169,7 @@ class SiteAdapter(metaclass=ABCMeta):
     def site_name(self) -> str:
         """
         Property to access the site_name of a resource and ensuring
-        that the all sub-classes of the SiteAdapter have a _site_name
+        that all sub-classes of the SiteAdapter have a _site_name
         class variable.
         :return: The site_name of a resource.
         :rtype: str

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -140,6 +140,16 @@ class SiteAdapter(metaclass=ABCMeta):
                 f"Class {self.__class__.__name__} must have an '_machine_type' instance variable"  # noqa
             ) from ae
 
+    @property
+    def machine_type_configuration(self) -> AttributeDict:
+        """
+        Property to access the machine_type_configuration (arguments of the API
+        calls to the provider) of a resource.
+        :return: The machine_type_configuration of a resource.
+        :rtype: AttributeDict
+        """
+        return self.configuration.MachineTypeConfiguration[self.machine_type]
+
     @abstractmethod
     async def resource_status(
         self, resource_attributes: AttributeDict

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -127,7 +127,7 @@ class SiteAdapter(metaclass=ABCMeta):
     def machine_type(self) -> str:
         """
         Property to access the machine_type (flavour) of a resource and ensuring
-        that the all sub-classes of the SiteAdapter have a _machine_type
+        that all sub-classes of the SiteAdapter have a _machine_type
         class variable .
         :return: The machine_type of a resource.
         :rtype: str

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -17,12 +17,12 @@ class TestSiteAdapter(TestCase):
             self.site_adapter.configuration
 
     def test_deploy_resource(self):
-        self.assertEqual(
-            run_async(self.site_adapter.deploy_resource, dict()), NotImplemented
-        )
+        with self.assertRaises(NotImplementedError):
+            run_async(self.site_adapter.deploy_resource, dict())
 
     def test_handle_exception(self):
-        self.assertEqual(self.site_adapter.handle_exceptions(), NotImplemented)
+        with self.assertRaises(NotImplementedError):
+            self.site_adapter.handle_exceptions()
 
     def test_handle_response_matching(self):
         test_response = {"test": 123}
@@ -70,20 +70,17 @@ class TestSiteAdapter(TestCase):
             self.site_adapter.machine_type
 
     def test_resource_status(self):
-        self.assertEqual(
-            run_async(self.site_adapter.resource_status, dict()), NotImplemented
-        )
+        with self.assertRaises(NotImplementedError):
+            run_async(self.site_adapter.resource_status, dict())
 
     def test_site_name(self):
         with self.assertRaises(AttributeError):
             self.site_adapter.site_name
 
     def test_stop_resource(self):
-        self.assertEqual(
-            run_async(self.site_adapter.stop_resource, dict()), NotImplemented
-        )
+        with self.assertRaises(NotImplementedError):
+            run_async(self.site_adapter.stop_resource, dict())
 
     def test_terminate_resource(self):
-        self.assertEqual(
-            run_async(self.site_adapter.terminate_resource, dict()), NotImplemented
-        )
+        with self.assertRaises(NotImplementedError):
+            run_async(self.site_adapter.terminate_resource, dict())

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -1,0 +1,89 @@
+from tardis.interfaces.siteadapter import SiteAdapter
+from tardis.utilities.attributedict import AttributeDict
+
+from ..utilities.utilities import run_async
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestSiteAdapter(TestCase):
+    @patch.multiple(SiteAdapter, __abstractmethods__=set())
+    def setUp(self) -> None:
+        self.site_adapter = SiteAdapter()
+
+    def test_configuration(self):
+        with self.assertRaises(AttributeError):
+            self.site_adapter.configuration
+
+    def test_deploy_resource(self):
+        self.assertEqual(
+            run_async(self.site_adapter.deploy_resource, dict()), NotImplemented
+        )
+
+    def test_handle_exception(self):
+        self.assertEqual(self.site_adapter.handle_exceptions(), NotImplemented)
+
+    def test_handle_response_matching(self):
+        test_response = {"test": 123}
+        test_key_translator = {"new_test": "test"}
+        test_translator_functions = {"test": str}
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response,
+                test_key_translator,
+                test_translator_functions,
+                additional="test123",
+            ),
+            AttributeDict(new_test="123", additional="test123"),
+        )
+
+    def test_handle_response_non_matching_with_additional(self):
+        test_response = {"other_test": 123}
+        test_key_translator = {"new_test": "test"}
+        test_translator_functions = {"test": str}
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response,
+                test_key_translator,
+                test_translator_functions,
+                additional="test123",
+            ),
+            AttributeDict(additional="test123"),
+        )
+
+    def test_handle_response_non_matching_wo_additional(self):
+        test_response = {"other_test": 123}
+        test_key_translator = {"new_test": "test"}
+        test_translator_functions = {"test": str}
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response, test_key_translator, test_translator_functions
+            ),
+            AttributeDict(),
+        )
+
+    def test_machine_type(self):
+        with self.assertRaises(AttributeError):
+            self.site_adapter.machine_type
+
+    def test_resource_status(self):
+        self.assertEqual(
+            run_async(self.site_adapter.resource_status, dict()), NotImplemented
+        )
+
+    def test_site_name(self):
+        with self.assertRaises(AttributeError):
+            self.site_adapter.site_name
+
+    def test_stop_resource(self):
+        self.assertEqual(
+            run_async(self.site_adapter.stop_resource, dict()), NotImplemented
+        )
+
+    def test_terminate_resource(self):
+        self.assertEqual(
+            run_async(self.site_adapter.terminate_resource, dict()), NotImplemented
+        )

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -16,6 +16,9 @@ class TestSiteAdapter(TestCase):
         with self.assertRaises(AttributeError):
             self.site_adapter.configuration
 
+        self.site_adapter._configuration = "Test"
+        self.assertEqual(self.site_adapter.configuration, "Test")
+
     def test_deploy_resource(self):
         with self.assertRaises(NotImplementedError):
             run_async(self.site_adapter.deploy_resource, dict())
@@ -65,9 +68,22 @@ class TestSiteAdapter(TestCase):
             AttributeDict(),
         )
 
+    def test_machine_meta_data(self):
+        with self.assertRaises(AttributeError):
+            self.site_adapter.machine_meta_data
+
+        self.site_adapter._configuration = AttributeDict(
+            MachineMetaData=AttributeDict(TestFlavour="Test")
+        )
+        self.site_adapter._machine_type = "TestFlavour"
+        self.assertEqual(self.site_adapter.machine_meta_data, "Test")
+
     def test_machine_type(self):
         with self.assertRaises(AttributeError):
             self.site_adapter.machine_type
+
+        self.site_adapter._machine_type = "TestFlavour"
+        self.assertEqual(self.site_adapter.machine_type, "TestFlavour")
 
     def test_resource_status(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This pull request refactors the access to the `machine_meta_data`, `machine_type` and `site_name` properties of the site adapters to avoid code duplication. 

Currently this properties containing the very same code are part of any implementation of the `SiteAdapter` abstract base class. This pull request move this code into the `SiteAdapter` abstract base class ensuring that the necessary instances variables `_configuration`,  `_machine_type` and `_site_name` are part of any `SiteAdapter` sub-class by raising reasonable errors if not.

Approval is needed before fixing #114.