### PR TITLE
Adding drone lifetime

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -11,10 +11,14 @@ Site Adapter
 
     Sites are generally configured in the `Sites` configuration block. One has to specify a site name, the adapter to use
     and a site quota in units of cores. Negative values for the site quota are interpreted as infinity. Optionally a
-    life time in seconds of the :py:class:`~tardis.resources.drone.Drone` can be specified. This is defined as the time
-    the :py:class:`~tardis.resources.drone.Drone` remains in :py:class:`~tardis.resources.dronestates.AvailableState`
-    before draining it. If no value is given, infinite life time is assumed. Multiple sites are supported by using
-    SequenceNodes.
+    minimum lifetime in seconds of the :py:class:`~tardis.resources.drone.Drone` can be specified. This is defined as
+    the time the :py:class:`~tardis.resources.drone.Drone` remains in
+    :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. If no value is given, infinite lifetime
+    is assumed. Multiple sites are supported by using SequenceNodes.
+
+.. note::
+    Even a minimum lifetime is set, it is not guaranteed that the :py:class:`~tardis.resources.drone.Drone` is not
+    drained due to a dropping demand for it before its minimum lifetime is exceeded.
 
 
 Generic Site Adapter Configuration
@@ -27,17 +31,17 @@ Available configuration options
 
 .. container:: left-col
 
-    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | Option          | Short Description                                                                                                     |  Requirement  |
-    +=================+=======================================================================================================================+===============+
-    | name            | Name of the site                                                                                                      |  **Required** |
-    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | adapter         | Site adapter to use. Adapter will be auto-imported (class name without Adapter)                                       |  **Required** |
-    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | quota           | Core quota to be used for this site. Negative values are interpreted as infinity                                      |  **Required** |
-    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | drone_life_time | Time in seconds the drone will remain in :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. |  **Optional** |
-    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | Option                 | Short Description                                                                                                     |  Requirement  |
+    +========================+=======================================================================================================================+===============+
+    | name                   | Name of the site                                                                                                      |  **Required** |
+    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | adapter                | Site adapter to use. Adapter will be auto-imported (class name without Adapter)                                       |  **Required** |
+    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | quota                  | Core quota to be used for this site. Negative values are interpreted as infinity                                      |  **Required** |
+    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | drone_minimum_lifetime | Time in seconds the drone will remain in :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. |  **Optional** |
+    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
 
     For each site in the `Sites` configuration block. A site specific configuration block carrying the site name
     has to be added to the configuration as well.
@@ -63,7 +67,7 @@ Available configuration options
           - name: MySiteName_1
             adapter: MyAdapter2Use
             quota: 123
-            drone_life_time: 3600
+            drone_minimum_lifetime: 3600
           - name: MySiteName_2
             adapter: OtherAdapter2Use
             quota: 987

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -10,8 +10,11 @@ Site Adapter
     of resources and a dynamic orchestration of pre-built VM images and containers.
 
     Sites are generally configured in the `Sites` configuration block. One has to specify a site name, the adapter to use
-    and a site quota in units of cores. Negative values for the site quota are interpreted as infinity. Multiple sites are
-    supported by using SequenceNodes.
+    and a site quota in units of cores. Negative values for the site quota are interpreted as infinity. Optionally a
+    life time in seconds of the :py:class:`~tardis.resources.drone.Drone` can be specified. This is defined as the time
+    the :py:class:`~tardis.resources.drone.Drone` remains in :py:class:`~tardis.resources.dronestates.AvailableState`
+    before draining it. If no value is given, infinite life time is assumed. Multiple sites are supported by using
+    SequenceNodes.
 
 
 Generic Site Adapter Configuration
@@ -24,15 +27,17 @@ Available configuration options
 
 .. container:: left-col
 
-    +---------+----------------------------------------------------------------------------------+-----------------+
-    | Option  | Short Description                                                                | Requirement     |
-    +=========+==================================================================================+=================+
-    | name    | Name of the site                                                                 |  **Required**   |
-    +---------+----------------------------------------------------------------------------------+-----------------+
-    | adapter | Site adapter to use. Adapter will be auto-imported (class name without Adapter)  |  **Required**   |
-    +---------+----------------------------------------------------------------------------------+-----------------+
-    | quota   | Core quota to be used for this site. Negative values are interpreted as infinity |  **Required**   |
-    +---------+----------------------------------------------------------------------------------+-----------------+
+    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | Option          | Short Description                                                                                                     |  Requirement  |
+    +=================+=======================================================================================================================+===============+
+    | name            | Name of the site                                                                                                      |  **Required** |
+    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | adapter         | Site adapter to use. Adapter will be auto-imported (class name without Adapter)                                       |  **Required** |
+    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | quota           | Core quota to be used for this site. Negative values are interpreted as infinity                                      |  **Required** |
+    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | drone_life_time | Time in seconds the drone will remain in :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. |  **Optional** |
+    +-----------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
 
     For each site in the `Sites` configuration block. A site specific configuration block carrying the site name
     has to be added to the configuration as well.
@@ -58,6 +63,7 @@ Available configuration options
           - name: MySiteName_1
             adapter: MyAdapter2Use
             quota: 123
+            drone_life_time: 3600
           - name: MySiteName_2
             adapter: OtherAdapter2Use
             quota: 987

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -32,8 +32,8 @@ class SiteAgent(SiteAdapter):
         return NotImplemented
 
     @property
-    def drone_life_time(self) -> int:
-        return self._site_adapter.drone_life_time
+    def drone_minimum_lifetime(self) -> int:
+        return self._site_adapter.drone_minimum_lifetime
 
     @property
     def machine_meta_data(self) -> AttributeDict:

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -32,6 +32,10 @@ class SiteAgent(SiteAdapter):
         return NotImplemented
 
     @property
+    def drone_life_time(self) -> int:
+        return self._site_adapter.drone_life_time
+
+    @property
     def machine_meta_data(self) -> AttributeDict:
         return self._site_adapter.machine_meta_data
 

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -114,6 +114,13 @@ class SiteAdapter(metaclass=ABCMeta):
         return translated_response
 
     @property
+    def drone_life_time(self) -> [int, None]:
+        try:
+            return self.configuration.drone_life_time
+        except AttributeError:
+            return None
+
+    @property
     def machine_meta_data(self) -> AttributeDict:
         """
         Property to access the machine_meta_data (like cores, memory and disk)

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -114,9 +114,9 @@ class SiteAdapter(metaclass=ABCMeta):
         return translated_response
 
     @property
-    def drone_life_time(self) -> [int, None]:
+    def drone_minimum_lifetime(self) -> [int, None]:
         try:
-            return self.configuration.drone_life_time
+            return self.configuration.drone_minimum_lifetime
         except AttributeError:
             return None
 

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -66,8 +66,8 @@ class Drone(Pool):
         self._demand = value
 
     @property
-    def drone_life_time(self) -> [int, None]:
-        return self.site_agent.drone_life_time
+    def drone_minimum_lifetime(self) -> [int, None]:
+        return self.site_agent.drone_minimum_lifetime
 
     @property
     def maximum_demand(self) -> float:

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -66,6 +66,10 @@ class Drone(Pool):
         self._demand = value
 
     @property
+    def drone_life_time(self) -> [int, None]:
+        return self.site_agent.drone_life_time
+
+    @property
     def maximum_demand(self) -> float:
         return self.site_agent.machine_meta_data["Cores"]
 

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -87,14 +87,15 @@ class Drone(Pool):
 
     async def run(self):
         while True:
-            await self.state.run(self)
-            await asyncio.sleep(60)
-            if isinstance(self.state, DownState):
+            current_state = self.state
+            await current_state.run(self)
+            if isinstance(current_state, DownState):
                 logging.debug(
                     f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}"
                 )
                 self._demand = 0
                 return
+            await asyncio.sleep(60)
 
     def register_plugins(self, observer: Union[List[Plugin], Plugin]) -> None:
         self._plugins.append(observer)

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -39,11 +39,13 @@ async def check_demand(state_transition, drone: "Drone", current_state: Type[Sta
     return state_transition
 
 
-async def check_lifetime(state_transition, drone: "Drone", current_state: Type[State]):
+async def check_minimum_lifetime(
+    state_transition, drone: "Drone", current_state: Type[State]
+):
     if (
-        drone.drone_life_time
+        drone.drone_minimum_lifetime
         and (datetime.now() - drone.resource_attributes.updated).total_seconds()
-        > drone.drone_life_time
+        > drone.drone_minimum_lifetime
     ):
         raise StopProcessing(last_result=DrainState())
     return state_transition
@@ -151,7 +153,7 @@ class AvailableState(State):
 
     processing_pipeline = [
         check_demand,
-        check_lifetime,
+        check_minimum_lifetime,
         resource_status,
         batchsystem_machine_status,
     ]

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -23,10 +23,10 @@ class TestSiteAgent(TestCase):
         self.site_agent.drone_uuid(uuid="test")
         self.site_adapter.drone_uuid.assert_called_with(uuid="test")
 
-    def test_drone_life_time(self):
-        self.site_adapter.drone_life_time.return_value = None
-        self.assertIsNone(self.site_agent.drone_life_time())
-        self.site_adapter.drone_life_time.assert_called_with()
+    def test_drone_minimum_lifetime(self):
+        self.site_adapter.drone_minimum_lifetime.return_value = None
+        self.assertIsNone(self.site_agent.drone_minimum_lifetime())
+        self.site_adapter.drone_minimum_lifetime.assert_called_with()
 
     def test_handle_exceptions(self):
         self.site_adapter.handle_exceptions.return_value = None

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -23,6 +23,11 @@ class TestSiteAgent(TestCase):
         self.site_agent.drone_uuid(uuid="test")
         self.site_adapter.drone_uuid.assert_called_with(uuid="test")
 
+    def test_drone_life_time(self):
+        self.site_adapter.drone_life_time.return_value = None
+        self.assertIsNone(self.site_agent.drone_life_time())
+        self.site_adapter.drone_life_time.assert_called_with()
+
     def test_handle_exceptions(self):
         self.site_adapter.handle_exceptions.return_value = None
         self.site_agent.handle_exceptions()

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -78,6 +78,12 @@ class TestSiteAdapter(TestCase):
         self.site_adapter._machine_type = "TestFlavour"
         self.assertEqual(self.site_adapter.machine_meta_data, "Test")
 
+    def test_drone_life_time(self):
+        self.assertEqual(self.site_adapter.drone_life_time, None)
+
+        self.site_adapter._configuration = AttributeDict(drone_life_time=10)
+        self.assertEqual(self.site_adapter.drone_life_time, 10)
+
     def test_machine_type(self):
         with self.assertRaises(AttributeError):
             self.site_adapter.machine_type

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -78,11 +78,11 @@ class TestSiteAdapter(TestCase):
         self.site_adapter._machine_type = "TestFlavour"
         self.assertEqual(self.site_adapter.machine_meta_data, "Test")
 
-    def test_drone_life_time(self):
-        self.assertEqual(self.site_adapter.drone_life_time, None)
+    def test_drone_minimum_lifetime(self):
+        self.assertEqual(self.site_adapter.drone_minimum_lifetime, None)
 
-        self.site_adapter._configuration = AttributeDict(drone_life_time=10)
-        self.assertEqual(self.site_adapter.drone_life_time, 10)
+        self.site_adapter._configuration = AttributeDict(drone_minimum_lifetime=10)
+        self.assertEqual(self.site_adapter.drone_minimum_lifetime, 10)
 
     def test_machine_type(self):
         with self.assertRaises(AttributeError):

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -32,7 +32,7 @@ class TestDrone(TestCase):
 
     def setUp(self) -> None:
         self.mock_site_agent.machine_meta_data = AttributeDict(Cores=8)
-        self.mock_site_agent.drone_life_time = None
+        self.mock_site_agent.drone_minimum_lifetime = None
         self.mock_plugin = MagicMock(spec=Plugin)()
         self.mock_plugin.notify.return_value = async_return()
         self.drone = Drone(
@@ -54,9 +54,9 @@ class TestDrone(TestCase):
         self.assertEqual(self.drone.demand, 0)
 
     def test_life_time(self):
-        self.assertIsNone(self.drone.drone_life_time, None)
-        self.mock_site_agent.drone_life_time = 3600
-        self.assertEqual(self.drone.drone_life_time, 3600)
+        self.assertIsNone(self.drone.drone_minimum_lifetime, None)
+        self.mock_site_agent.drone_minimum_lifetime = 3600
+        self.assertEqual(self.drone.drone_minimum_lifetime, 3600)
 
     def test_maximum_demand(self):
         self.assertEqual(self.drone.maximum_demand, 8)

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -1,7 +1,139 @@
-from tardis.resources.drone import Drone
+from ..utilities.utilities import async_return, run_async
 
+from tardis.interfaces.plugin import Plugin
+from tardis.interfaces.state import State
+from tardis.resources.drone import Drone
+from tardis.resources.dronestates import RequestState, DownState
+from tardis.utilities.attributedict import AttributeDict
+
+from logging import DEBUG
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 
 class TestDrone(TestCase):
-    pass
+    mock_batch_system_agent_patcher = None
+    mock_site_agent_patcher = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mock_site_agent_patcher = patch("tardis.agents.siteagent.SiteAgent")
+        cls.mock_site_agent = cls.mock_site_agent_patcher.start()
+
+        cls.mock_batch_system_agent_patcher = patch(
+            "tardis.agents.batchsystemagent.BatchSystemAgent"
+        )
+        cls.mock_batch_system_agent = cls.mock_batch_system_agent_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.mock_batch_system_agent_patcher.stop()
+        cls.mock_site_agent_patcher.stop()
+
+    def setUp(self) -> None:
+        self.mock_site_agent.machine_meta_data = AttributeDict(Cores=8)
+        self.mock_site_agent.drone_life_time = None
+        self.mock_plugin = MagicMock(spec=Plugin)()
+        self.mock_plugin.notify.return_value = async_return()
+        self.drone = Drone(
+            site_agent=self.mock_site_agent,
+            batch_system_agent=self.mock_batch_system_agent,
+        )
+
+    def test_allocation(self):
+        self.assertEqual(self.drone.allocation, 0.0)
+        self.drone._allocation = 1.0
+        self.assertEqual(self.drone.allocation, 1.0)
+
+    def test_batch_system_agent(self):
+        self.assertEqual(self.drone.batch_system_agent, self.mock_batch_system_agent)
+
+    def test_demand(self):
+        self.assertEqual(self.drone.demand, 8)
+        self.drone.demand = 0
+        self.assertEqual(self.drone.demand, 0)
+
+    def test_life_time(self):
+        self.assertIsNone(self.drone.drone_life_time, None)
+        self.mock_site_agent.drone_life_time = 3600
+        self.assertEqual(self.drone.drone_life_time, 3600)
+
+    def test_maximum_demand(self):
+        self.assertEqual(self.drone.maximum_demand, 8)
+        self.mock_site_agent.machine_meta_data = AttributeDict(Cores=4)
+        self.assertEqual(self.drone.maximum_demand, 4)
+
+    def test_supply(self):
+        self.assertEqual(self.drone.supply, 0.0)
+        self.drone._supply = 8.0
+        self.assertEqual(self.drone.supply, 8.0)
+
+    def test_utilisation(self):
+        self.assertEqual(self.drone.utilisation, 0.0)
+        self.drone._utilisation = 8.0
+        self.assertEqual(self.drone.utilisation, 8.0)
+
+    def test_site_agent(self):
+        self.assertEqual(self.drone.site_agent, self.mock_site_agent)
+
+    @patch("tardis.resources.drone.asyncio.sleep", async_return)
+    def test_run(self):
+        mocked_down_state = MagicMock(spec=DownState)
+        mocked_down_state.run.return_value = async_return()
+
+        async def mocked_run(drone):
+            await drone.set_state(mocked_down_state)
+
+        mocked_state = MagicMock(spec=State)
+        mocked_state.run.side_effect = mocked_run
+
+        run_async(self.drone.set_state, mocked_state)
+        self.drone.demand = 8
+        with self.assertLogs(level=DEBUG):
+            run_async(self.drone.run)
+
+        self.assertIsInstance(self.drone.state, DownState)
+        self.assertEqual(self.drone.demand, 0)
+
+        mocked_state.run.assert_called_once()
+        mocked_down_state.run.assert_called_once()
+
+    def test_register_plugins(self):
+        self.assertEqual(self.drone._plugins, [])
+        self.drone.register_plugins(self.mock_plugin)
+        self.assertEqual(self.drone._plugins, [self.mock_plugin])
+
+    def test_removal_plugins(self):
+        self.drone.register_plugins(self.mock_plugin)
+        self.assertEqual(self.drone._plugins, [self.mock_plugin])
+        self.drone.remove_plugins(self.mock_plugin)
+        self.assertEqual(self.drone._plugins, [])
+
+    def test_set_state(self):
+        self.drone.register_plugins(self.mock_plugin)
+        old_update_time_stamp = self.drone.resource_attributes.updated
+        run_async(self.drone.set_state, self.drone._state)
+        self.mock_plugin.notify.assert_not_called()
+        self.assertEqual(self.drone.resource_attributes.updated, old_update_time_stamp)
+
+        new_state = DownState()
+        run_async(self.drone.set_state, new_state)
+        self.mock_plugin.notify.assert_called_with(
+            new_state, self.drone.resource_attributes
+        )
+        self.assertNotEqual(
+            self.drone.resource_attributes.updated, old_update_time_stamp
+        )
+
+    def test_state(self):
+        self.assertEqual(self.drone.state, self.drone._state)
+        self.assertIsInstance(self.drone.state, RequestState)
+
+    def test_notify_plugins(self):
+        self.drone.register_plugins(self.mock_plugin)
+        self.assertEqual(self.drone._plugins, [self.mock_plugin])
+
+        run_async(self.drone.notify_plugins)
+        self.mock_plugin.notify.assert_called_with(
+            self.drone.state, self.drone.resource_attributes
+        )

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -55,7 +55,7 @@ class TestDroneStates(TestCase):
         )
         self.drone.demand = 8.0
         self.drone._supply = 8.0
-        self.drone.drone_life_time = 3600
+        self.drone.drone_minimum_lifetime = 3600
         self.drone.set_state.side_effect = partial(mock_set_state, self.drone)
         self.drone.site_agent.deploy_resource.return_value = async_return(
             return_value=AttributeDict()
@@ -217,7 +217,7 @@ class TestDroneStates(TestCase):
         self.assertEqual(self.drone._supply, 0.0)
 
         # Test draining procedure due to exceeding life time of the drone
-        self.drone.drone_life_time = 1
+        self.drone.drone_minimum_lifetime = 1
         self.drone.state.return_value = AvailableState()
         run_async(self.drone.state.return_value.run, self.drone)
         self.assertIsInstance(self.drone.state, DrainState)


### PR DESCRIPTION
This pull request adds an optionally and per site configurable drone life time to `TARDIS`. The life time is defined as the time the drone is being in `AvailableState`. At the end of life, the drone is set to `DrainState`. In addition, this pull request adds unittests for the `Drone` class and fixes a bug discovered while writting the unittests. 👍 
Discovered bug: In case the Drone is set into `DownState`, its `run` method is never called. 

This pull request fixes #114. It is not affected by #85, since `demand` and `supply` are not set to zero in case the end of life is reached.