### PR TITLE
Fix two typos in site adapter documention

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -246,7 +246,7 @@ Available adapter configuration options
     +================+===================================================================================+=================+
     | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.            |  **Required**   |
     +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | StartUpCommand | The command executed in the batch job.                                            |  **Required**   |
+    | StartupCommand | The command executed in the batch job.                                            |  **Required**   |
     +----------------+-----------------------------------------------------------------------------------+-----------------+
     | executor       | The |executor| used to run submission and further calls to the Moab batch system. |  **Optional**   |
     +                +                                                                                   +                 +
@@ -415,7 +415,7 @@ Available adapter configuration options
               Walltime: '1440'
               Partition: normal
             twelve_hours:
-              Walltime: '600'
+              Walltime: '720'
               Partition: normal
           MachineMetaData:
             one_day:


### PR DESCRIPTION
The first one leads to 
```
cobald.daemon.config.mapping.ConfigurationError: invalid configuration element
```
errors if it is copied into the configuration file.

The second one is just an inconsistency with respect to the machine type name.