### PR TITLE
Add support for COBalD legacy object initialisation

### DIFF
--- a/docs/source/executors/executors.rst
+++ b/docs/source/executors/executors.rst
@@ -7,9 +7,13 @@ Executors
 .. container:: left-col
 
     All executors can be loaded using YAML tags using the (`!Tag`) syntax. More details are available in the
-    `PyYAML documentation`_
+    `PyYAML documentation`_.
+
+    Alternatively you can also use the legacy `COBalD object initialisation syntax`_ to construct executors.
+    But it is discouraged.
 
     .. _PyYAML documentation: https://pyyaml.org/wiki/PyYAMLDocumentation
+    .. _COBalD object initialisation syntax: https://cobald.readthedocs.io/en/latest/source/daemon/config.html#object-references
 
 Shell Executor
 --------------
@@ -25,6 +29,12 @@ Shell Executor
     .. code-block:: yaml
 
       !ShellExecutor
+
+    .. rubric:: Example configuration (`COBalD` legacy object initialisation)
+
+    .. code-block:: yaml
+
+        __type__: tardis.utilities.executors.shellexecutor.ShellExecutor
 
 SSH Executor
 ------------
@@ -49,3 +59,12 @@ SSH Executor
         client_keys:
           - /opt/tardis/ssh/tardis
 
+    .. rubric:: Example configuration (`COBalD` legacy object initialisation)
+
+    .. code-block:: yaml
+
+        __type__: tardis.utilities.executors.sshexecutor.SSHExecutor
+        host: login.dorie.somewherein.de
+        username: clown
+        client_keys:
+          - /opt/tardis/ssh/tardis

--- a/tests/configuration_t/Sites.yml
+++ b/tests/configuration_t/Sites.yml
@@ -1,8 +1,17 @@
 Sites:
   - name: EXOSCALE
     adapter: CloudStack
+  - name: SLURM
+    adapter: Slurm
 
 EXOSCALE:
   MachineTypeConfiguration:
     Micro:
       user_data: tests/data/exoscale.ini
+SLURM:
+  executor:
+    __type__: tardis.utilities.executors.sshexecutor.SSHExecutor
+    host: somehost.de
+    username: someuser
+    client_keys:
+      - "where the private key is"


### PR DESCRIPTION
This pull requests enables support for the `COBalD` object initialisation syntax described in the [`COBalD` documentation](https://cobald.readthedocs.io/en/latest/source/daemon/config.html#object-references) to construct objects instead of using YAML tags. This fixes the problem described in #118.

```yaml
!SSHExecutor
        host: login.dorie.somewherein.de
        username: clown
        client_keys:
          - /opt/tardis/ssh/tardis
```
is now equivalent to
```yaml
__type__: tardis.utilities.executors.sshexecutor.SSHExecutor
host: login.dorie.somewherein.de
username: clown
client_keys:
  - /opt/tardis/ssh/tardis
```