### PR TITLE
Enable CI for python3.8 and add support to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,19 @@ language: python
 
 python:
   - "3.6"
-  - "3.6-dev" # 3.6 development branch
-  - "nightly" # currently points to 3.7-dev
-  - "pypy3.5"
+  - "3.7"
+  - "3.8"
+  - "nightly" # currently points to 3.8-dev
+  - "pypy3"
 
 os:
   - linux
 
 matrix:
   allow_failures:
-  - python: "3.6-dev"
   - python: "nightly"
-  - python: "pypy3.5"
+  - python: "pypy3"
   include:
-    - python: 3.7
-      dist: xenial
     - python: 3.7
       name: Style
       dist: xenial

--- a/setup.py
+++ b/setup.py
@@ -8,55 +8,62 @@ package_about = {}
 with open(os.path.join(repo_base_dir, "tardis", "__about__.py")) as about_file:
     exec(about_file.read(), package_about)
 
-with open(os.path.join(repo_base_dir, 'README.md'), 'r') as read_me:
+with open(os.path.join(repo_base_dir, "README.md"), "r") as read_me:
     long_description = read_me.read()
 
-TESTS_REQUIRE = ['aiotools', 'flake8']
+TESTS_REQUIRE = ["aiotools", "flake8"]
 
 setup(
     name=package_about["__package__"],
     version=package_about["__version__"],
     description=package_about["__summary__"],
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url=package_about["__url__"],
     author=package_about["__author__"],
     author_email=package_about["__email__"],
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'Operating System :: OS Independent',
-        'Topic :: System :: Distributed Computing',
-        'Topic :: Scientific/Engineering :: Physics',
-        'Topic :: Utilities',
-        'Framework :: AsyncIO',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "Operating System :: OS Independent",
+        "Topic :: System :: Distributed Computing",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Topic :: Utilities",
+        "Framework :: AsyncIO",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     entry_points={
-        'cobald.config.yaml_constructors': [
-            'TardisPoolFactory = tardis.resources.poolfactory:create_composite_pool',
-        ],
+        "cobald.config.yaml_constructors": [
+            "TardisPoolFactory = tardis.resources.poolfactory:create_composite_pool"
+        ]
     },
     keywords=package_about["__keywords__"],
-    packages=find_packages(exclude=['tests']),
-    install_requires=['aiohttp', 'CloudStackAIO', 'PyYAML',
-                      'AsyncOpenStackClient', 'cobald', 'asyncssh',
-                      'aiotelegraf'],
+    packages=find_packages(exclude=["tests"]),
+    install_requires=[
+        "aiohttp",
+        "CloudStackAIO",
+        "PyYAML",
+        "AsyncOpenStackClient",
+        "cobald",
+        "asyncssh",
+        "aiotelegraf",
+    ],
     extras_require={
-        'docs': ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-contentui"],
-        'test': TESTS_REQUIRE,
-        'contrib': ['flake8', 'flake8-bugbear', 'black'] + TESTS_REQUIRE,
+        "docs": ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-contentui"],
+        "test": TESTS_REQUIRE,
+        "contrib": ["flake8", "flake8-bugbear", "black"] + TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,
     zip_safe=False,
-    test_suite='tests',
+    test_suite="tests",
     project_urls={
-        'Bug Reports': 'https://github.com/matterminers/tardis/issues',
-        'Source': 'https://github.com/materminers/tardis',
+        "Bug Reports": "https://github.com/matterminers/tardis/issues",
+        "Source": "https://github.com/materminers/tardis",
     },
 )


### PR DESCRIPTION
This pull requests enables travis unittests for Python3.8 and adds support to setup.py classifiers.