### PR TITLE
Fix state transitions for jobs retried by HTCondor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,8 +5,8 @@ Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Stefan Kroboth <stefan.kroboth@gmail.com>
-mschnepf <matthias.schnepf@kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
+mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
 Max Fischer <maxfischer2781@gmail.com>

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -195,6 +195,9 @@ class DrainingState(State):
             MachineStatus.Drained: lambda: DisintegrateState(),
             MachineStatus.NotAvailable: lambda: ShutDownState(),
         },
+        # In case the job is retried by HTCondor, resources can transition to
+        # BootingState again. In this case the job should be removed.
+        ResourceStatus.Booting: lambda: defaultdict(lambda: CleanupState),
         ResourceStatus.Deleted: lambda: defaultdict(lambda: DownState),
         ResourceStatus.Stopped: lambda: defaultdict(lambda: CleanupState),
         ResourceStatus.Error: lambda: defaultdict(lambda: CleanupState),
@@ -219,6 +222,9 @@ class DisintegrateState(State):
 
 class ShutDownState(State):
     transition = {
+        # In case the job is retried by HTCondor, resources can transition to
+        # BootingState again. In this case the job should be removed.
+        ResourceStatus.Booting: lambda: CleanupState(),
         ResourceStatus.Running: lambda: ShuttingDownState(),
         ResourceStatus.Stopped: lambda: CleanupState(),
         ResourceStatus.Deleted: lambda: DownState(),
@@ -249,6 +255,9 @@ class ShutDownState(State):
 
 class ShuttingDownState(State):
     transition = {
+        # In case the job is retried by HTCondor, resources can transition to
+        # BootingState again. In this case the job should be removed.
+        ResourceStatus.Booting: lambda: CleanupState(),
         ResourceStatus.Running: lambda: ShuttingDownState(),
         ResourceStatus.Stopped: lambda: CleanupState(),
         ResourceStatus.Deleted: lambda: DownState(),

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -236,6 +236,7 @@ class TestDroneStates(TestCase):
             (ResourceStatus.Running, MachineStatus.Available, DrainState),
             (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
             (ResourceStatus.Running, MachineStatus.NotAvailable, ShutDownState),
+            (ResourceStatus.Booting, MachineStatus.NotAvailable, CleanupState),
             (ResourceStatus.Deleted, MachineStatus.NotAvailable, DownState),
             (ResourceStatus.Stopped, MachineStatus.NotAvailable, CleanupState),
         ]
@@ -252,6 +253,7 @@ class TestDroneStates(TestCase):
 
     def test_shutdown_state(self):
         matrix = [
+            (ResourceStatus.Booting, None, CleanupState),
             (ResourceStatus.Running, None, ShuttingDownState),
             (ResourceStatus.Stopped, None, CleanupState),
             (ResourceStatus.Deleted, None, DownState),
@@ -291,6 +293,7 @@ class TestDroneStates(TestCase):
 
     def test_shutting_down_state(self):
         matrix = [
+            (ResourceStatus.Booting, None, CleanupState),
             (ResourceStatus.Running, None, ShuttingDownState),
             (ResourceStatus.Stopped, None, CleanupState),
             (ResourceStatus.Deleted, None, DownState),

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -217,6 +217,7 @@ class TestDroneStates(TestCase):
         self.assertEqual(self.drone._supply, 0.0)
 
         # Test draining procedure due to exceeding life time of the drone
+        self.drone.demand = 8.0
         self.drone.drone_minimum_lifetime = 1
         self.drone.state.return_value = AvailableState()
         run_async(self.drone.state.return_value.run, self.drone)


### PR DESCRIPTION
In case a job is in `DrainingState`, `ShuttingDownState` or `ShutDownState` a transition back to `BootingState` is currently not covered by `TARDIS`. However, there is the possibilty, probably due to pre-emption of jobs, that a currently running job gets retried by HTCondor. That means, the job can move to `BootingState` again and causes `TARDIS` to crash.

This pull request fixes this issue and removes such retried jobs previously in `DrainingState`, `ShuttingDownState` or `ShutDownState` from the batch queue.

In addition, the unittest for the drone minimum life time is fixed, that it really tests draining of resources due to reaching the minimum life time.
