### PR TITLE
Fix draining of slots having a startd name

### DIFF
--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -81,6 +81,7 @@ class HTCondorAdapter(BatchSystemAdapter):
 
         attributes = dict(
             Machine="Machine",
+            Name="Name",
             State="State",
             Activity="Activity",
             TardisDroneUuid="TardisDroneUuid",
@@ -118,16 +119,16 @@ class HTCondorAdapter(BatchSystemAdapter):
         """
         await self._htcondor_status.update_status()
         try:
-            machine = self._htcondor_status[drone_uuid]["Machine"]
+            slot_name = self._htcondor_status[drone_uuid]["Name"]
         except KeyError:
             return
 
         options_string = htcondor_cmd_option_formatter(self.htcondor_options)
 
         if options_string:
-            cmd = f"condor_drain {options_string} -graceful {machine}"
+            cmd = f"condor_drain {options_string} -graceful {slot_name}"
         else:
-            cmd = f"condor_drain -graceful {machine}"
+            cmd = f"condor_drain -graceful {slot_name}"
 
         try:
             return await async_run_command(cmd)


### PR DESCRIPTION
`TARDIS` supports running more than one `Drone` on the same host. To differentiate the drones, the tardis-uuid has been introduced and will be set as `STARTD_NAME` on the corresponding sites. The HTCondor `Name` in this case is
```
slot1@tardis-uuid@hostname
```

Due to backward compatibility for sites running only one `Drone` per host, `TARDIS` supports also drones without having a `STARTD_NAME`. Leading to
```
slot1@hostname
```
as HTCondor `Name`.

Currently, `TARDIS` drains drones by using just its hostname (HTCondor `Machine`)
```
condor_drain -graceful hostname
```
which does not work in case multiple drones running on the same host. This pull request fixes this bug by using the HTCondor `Name` instead.
```
condor_drain -graceful slot1@tardis-uuid@hostname
```