### PR TITLE
Adding semi-automatized changelogs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
         args:
         -   --py36
 -   repo: https://github.com/Matterminers/dev-tools
-    rev: 4627d34
+    rev: "8757635"
     hooks:
       -  id: contributors
+      -  id: changelog
+         args:
+          - docs/source/changes
+          - compile
+          - --output=docs/source/changelog.rst
+         additional_dependencies:
+          - PyYAML  

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,15 @@
+.. Created by changelog.py at 2020-01-15, command
+   '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+   based on the format of 'https://keepachangelog.com/'
+
+#########
+CHANGELOG
+#########
+
+[Unreleased] - 2020-01-15
+=========================
+
+Fixed
+-----
+
+* Fix draining of slots having a startd name

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-01-15, command
+.. Created by changelog.py at 2020-01-16, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,10 +6,24 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-01-15
+[Unreleased] - 2020-01-16
 =========================
+
+Added
+-----
+
+* Add support for Python 3.8
+* Register pool factory as `COBalD` yaml plugin
+* Add support for COBalD legacy object initialisation
+* The machine name has been added as a default tag in the telegraf monitoring plugin, can be overwritten.
+* An optional and per site configurable drone minimum lifetime has been added
 
 Fixed
 -----
 
 * Fix draining of slots having a startd name
+* Allow removal of booting drones if demand drops to zero
+* The `CleanupState` is now taking into account the status of the resource for state transitions
+* Improved logging of the `HTCondor` batch system adapter and the status changes of the drones
+* Fix the handling of the termination of vanished resources
+* Fix state transitions for jobs retried by HTCondor

--- a/docs/source/changes/100.fix_transition_within_cleanupstate.yaml
+++ b/docs/source/changes/100.fix_transition_within_cleanupstate.yaml
@@ -1,0 +1,7 @@
+category: fixed
+summary: The `CleanupState` is now taking into account the status of the resource for state transitions
+pull requests:
+  - 100
+description: |
+  The `CleanupState` is now taking into account the status of the resource and two missing state transitions have been
+  added to the transistion dictionary.

--- a/docs/source/changes/116.adding_drone_life_time.yaml
+++ b/docs/source/changes/116.adding_drone_life_time.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: An optional and per site configurable drone minimum lifetime has been added
+pull requests:
+  - 116
+issues:
+  - 114
+description: |
+  An optionally and per site configurable drone minimum life time to TARDIS. The minimum life time is defined as the
+  time the drone is being in `AvailableState`. At the end of life, the drone is set to `DrainState`.

--- a/docs/source/changes/119.add_legacy_object_initialisation.yaml
+++ b/docs/source/changes/119.add_legacy_object_initialisation.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: Add support for COBalD legacy object initialisation
+pull requests:
+  - 119
+issues:
+  - 118
+description: |
+  Support for the `COBalD` object initialisation syntax to construct python objects instead of using YAML tags has been
+  enabled.

--- a/docs/source/changes/120.add_python38_support.yaml
+++ b/docs/source/changes/120.add_python38_support.yaml
@@ -1,0 +1,6 @@
+category: added
+summary: Add support for Python 3.8
+pull requests:
+  - 120
+description: |
+  Support for Python3.8 added to setup.py classifiers and travis uniitests for Python3.8 have been enabled.

--- a/docs/source/changes/122.fix_state_transitions_for_retried_jobs.yaml
+++ b/docs/source/changes/122.fix_state_transitions_for_retried_jobs.yaml
@@ -1,0 +1,9 @@
+category: fixed
+summary: Fix state transitions for jobs retried by HTCondor
+pull_requests:
+  - 122
+description: |
+  In case a job is in `DrainingState`, `ShuttingDownState` or `ShutDownState` a transition back to BootingState is
+  currently not covered by `TARDIS`. However, a currently running job can potentially be retried by HTCondor in case of
+  an internal error. Now, retried jobs previously in `DrainingState`, `ShuttingDownState` or `ShutDownState` are removed
+  entirely from the batch queue.

--- a/docs/source/changes/123.fix_draining_slots_w_startd_name.yaml
+++ b/docs/source/changes/123.fix_draining_slots_w_startd_name.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: "Fix draining of slots having a startd name"
+pull requests:
+  - 123
+description: |
+  `TARDIS` supports running more than one Drone on the same host. To differentiate the drones, the `TardisDroneUuid` has
+  been introduced and will be set as `STARTD_NAME` on the corresponding sites. `TARDIS` used to use only the `hostname`
+  when draining resources. This change will take into account the provided `STARTD_NAME` as well.

--- a/docs/source/changes/76.allow_removal_of_booting_drones.yaml
+++ b/docs/source/changes/76.allow_removal_of_booting_drones.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: Allow removal of booting drones if demand drops to zero
+pull requests:
+  - 76
+description: |
+  So far draining of drones in `AvailableState` was supported by `TARDIS`, which works well for cloud providers. Since
+  the queueing time in batch systems can be long, the deletion of queued drones (idle batch jobs) has been enabled as
+  well.

--- a/docs/source/changes/77.telegraf_config_update.yaml
+++ b/docs/source/changes/77.telegraf_config_update.yaml
@@ -1,0 +1,7 @@
+category: added
+summary: The machine name has been added as a default tag in the telegraf monitoring plugin, can be overwritten.
+pull requests:
+  - 77
+description: |
+  The machine name has been added as a default tag in the telegraf monitoring plugin. Can be overwritten by adding
+  `tardis_machine_name` as default tag in the plugin configuration.

--- a/docs/source/changes/78.improve_logging_of_htcondor_batch_adapter.yaml
+++ b/docs/source/changes/78.improve_logging_of_htcondor_batch_adapter.yaml
@@ -1,0 +1,7 @@
+category: fixed
+summary: Improved logging of the `HTCondor` batch system adapter and the status changes of the drones
+pull requests:
+  - 78
+description: |
+  Drone resource attributes to have been addedd to the debug logging of drone status changes. The `condor_status`
+  command has been added to the debug logging of the htcondor batch system adapter.

--- a/docs/source/changes/92.register_pool_factory_as_yaml_plugin.yaml
+++ b/docs/source/changes/92.register_pool_factory_as_yaml_plugin.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: Register pool factory as `COBalD` yaml plugin
+pull requests:
+  - 92
+issues:
+  - 91
+description: |
+  Register the composite pool factory function `create_composite_pool` as `COBalD` yaml plugin, so that it can be loaded
+  via yaml tags in the `COBalD` configuration.

--- a/docs/source/changes/96.fix_handling_of_vanished_resources.yaml
+++ b/docs/source/changes/96.fix_handling_of_vanished_resources.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: Fix the handling of the termination of vanished resources
+pull requests:
+  - 96
+description: |
+  Fix a bug with resources that shut down itself while being idle for 20 minutes, which remained in `CleanUpState`
+  forever, since the `teminate_resource` call keept raising `TardisResourceStatusUpdateFailed`, which led to infinte
+  retries of the `terminate_resource` call.

--- a/docs/source/changes/README.rst
+++ b/docs/source/changes/README.rst
@@ -1,0 +1,33 @@
+Changelog Fragments
+-------------------
+
+This folder contains fragments for the ``dev_tools/change-log.py`` tool to
+create formatted changelogs. Fragments are YAML files that contain meta-data
+and human-readable descriptions of changes. Files are mappings that must contain
+the fields ``category``, ``summary``, and ``description` and optionally the fields
+``pull requests`` and ``issues``; the naming convention of files is
+``<first pull request>.<topic>.yaml``.
+Both ``summary`` and ``description`` fields are interpreted as reStructured Text.
+
+.. code:: YAML
+
+    # file `39.line_format.fixes.yaml`
+    # any of 'added', 'changed', 'fixed', 'deprecated', 'removed', 'security'
+    category: fixed
+    # short description of changes
+    summary: "fixed Line Protocol sending illegal content"
+    # pull requests of this change
+    pull requests:
+      - 39
+      - 44
+    # issues solved by this change
+    issues:
+      - 42
+    # long description of changes
+    description: |
+      The Line Protocol implementation has been extended to remove cases that
+      previously led to illegal output. ``None`` values are
+      forbidden, and strings are escaped in field values, tags, and measurements.
+
+New changes are assigned to the "next" release. Release information is added
+automatically when a release is prepared.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Welcome to the TARDIS documentation!
    executors/executors
    plugins/plugins
    contribute/contribute
+   changelog
    Module Index <api/modules>
 
 .. container:: left-col


### PR DESCRIPTION
This pull requests adds a new pre-commit hook creating a `changelog.rst` embedded in the [readthedocs documentation](https://cobald-tardis.readthedocs.io) of `TARDIS` based on changelog fragements. This almost the same mechanism as already used in `COBalD`. it solves #95 .