### PR TITLE
Use utilisation as weight in composite pools

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-01-24, command
+.. Created by changelog.py at 2020-02-13, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-01-24
+[Unreleased] - 2020-02-13
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ Fixed
 
 * Fix draining of slots having a startd name
 * Fix the translation of cloud init scripts into base64 encoded strings
+* Use utilisation as weight in composite pools
 * Allow removal of booting drones if demand drops to zero
 * The `CleanupState` is now taking into account the status of the resource for state transitions
 * Improved logging of the `HTCondor` batch system adapter and the status changes of the drones

--- a/docs/source/changes/127.fix_use_utilisation_as_weight_in_composite_pools.yaml
+++ b/docs/source/changes/127.fix_use_utilisation_as_weight_in_composite_pools.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: Use utilisation as weight in composite pools
+pull requests:
+  - 127
+description: |
+  The experience of using `WeightedComposite` pools in production shows that weighting the `demand` of resources by
+  their `supply` is not always the best choice. Weighting the `demand` of resources by `utilisation` is instead more
+  desired, since `COBalD` should increase the best utilised resource.

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Iterable, Optional
 
 from tardis.interfaces.plugin import Plugin
 from tardis.interfaces.state import State
@@ -87,18 +87,18 @@ def create_composite_pool(configuration: str = None) -> WeightedComposite:
             )
         composites.append(
             Standardiser(
-                WeightedComposite(*site_composites),
+                WeightedComposite(*site_composites, weight="utilisation"),
                 maximum=site.quota if site.quota >= 0 else inf,
             )
         )
 
-    return WeightedComposite(*composites)
+    return WeightedComposite(*composites, weight="utilisation")
 
 
 def create_drone(
     site_agent: SiteAgent,
     batch_system_agent: BatchSystemAgent,
-    plugins: Optional[List[Plugin]] = None,
+    plugins: Optional[Iterable[Plugin]] = None,
     remote_resource_uuid=None,
     drone_uuid=None,
     state: State = RequestState(),

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -1,15 +1,19 @@
 from tardis.resources.dronestates import RequestState
 from tardis.resources.poolfactory import create_composite_pool
+from tardis.resources.poolfactory import create_drone
 from tardis.resources.poolfactory import get_drones_to_restore
 from tardis.resources.poolfactory import load_plugins
 from tardis.resources.poolfactory import str_to_state
 from tardis.utilities.attributedict import AttributeDict
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 
 class TestPoolFactory(TestCase):
+    mock_config_patcher = None
+    mock_sqliteregistry_patcher = None
+
     @classmethod
     def setUpClass(cls):
         cls.mock_config_patcher = patch("tardis.resources.poolfactory.Configuration")
@@ -26,10 +30,17 @@ class TestPoolFactory(TestCase):
 
     def setUp(self):
         self.config = self.mock_config.return_value
-        self.config.Sites.name = "TestSite"
+        self.config.Sites = [
+            AttributeDict(name="TestSite", adapter="TestSite", quota=1)
+        ]
+        self.config.TestSite = AttributeDict(
+            MachineTypes=["TestMachineType"],
+            MachineMetaData=AttributeDict(TestMachineType=AttributeDict(Cores=1)),
+        )
         self.config.Plugins = AttributeDict(
             SqliteRegistry=AttributeDict(db_file="test.db")
         )
+        self.config.BatchSystem = AttributeDict(adapter="TestBatchSystem")
         sqlite_registry = self.mock_sqliteregistry.return_value
         sqlite_registry.get_resources.return_value = [{"state": "RequestState"}]
 
@@ -38,6 +49,104 @@ class TestPoolFactory(TestCase):
         converted_test = str_to_state(test)
         self.assertTrue(converted_test[0]["state"], RequestState)
         self.assertEqual(converted_test[0]["drone_uuid"], "test-abc123")
+
+    @patch("tardis.resources.poolfactory.FactoryPool")
+    @patch("tardis.resources.poolfactory.Logger")
+    @patch("tardis.resources.poolfactory.Standardiser")
+    @patch("tardis.resources.poolfactory.WeightedComposite")
+    @patch("tardis.resources.poolfactory.import_module")
+    def test_create_composite(
+        self,
+        mock_import_module,
+        mock_weighted_composite,
+        mock_standardiser,
+        mock_logger,
+        mock_factory_pool,
+    ):
+        mock_batch_system_adapter = AttributeDict(TestBatchSystemAdapter=MagicMock())
+        mock_site_adapter = AttributeDict(TestSiteAdapter=MagicMock())
+
+        mock_import_module.side_effect = [
+            mock_batch_system_adapter,
+            self.mock_sqliteregistry,
+            mock_site_adapter,
+        ]
+
+        self.assertEqual(create_composite_pool(), mock_weighted_composite())
+
+        self.assertEqual(
+            mock_import_module.mock_calls,
+            [
+                call(name="tardis.adapters.batchsystems.testbatchsystem"),
+                call(name="tardis.plugins.sqliteregistry"),
+                call(name="tardis.adapters.sites.testsite"),
+            ],
+        )
+
+        site_name = self.config.Sites[0].name
+        machine_type = getattr(self.config, site_name).MachineTypes[0]
+
+        mock_batch_system_adapter.TestBatchSystemAdapter.assert_called_with()
+        mock_site_adapter.TestSiteAdapter.assert_called_with(
+            machine_type=machine_type, site_name=site_name
+        )
+
+        self.assertEqual(mock_factory_pool.mock_calls, [call(factory=ANY)])
+
+        cpu_cores = getattr(
+            self.config, site_name
+        ).MachineMetaData.TestMachineType.Cores
+
+        self.assertEqual(
+            mock_standardiser.mock_calls,
+            [
+                call(mock_factory_pool(), minimum=cpu_cores, granularity=cpu_cores),
+                call(mock_weighted_composite(), maximum=self.config.Sites[0].quota),
+            ],
+        )
+
+        self.assertEqual(
+            mock_logger.mock_calls,
+            [
+                call(
+                    mock_standardiser(),
+                    name=f"{site_name.lower()}_{machine_type.lower()}",
+                )
+            ],
+        )
+
+        mock_weighted_composite.has_calls(
+            [
+                call(mock_standardiser(), weight="utilisation"),
+                call(mock_weighted_composite(), weight="utilisation"),
+            ]
+        )
+
+    @patch("tardis.resources.poolfactory.Drone")
+    @patch("tardis.resources.poolfactory.BatchSystemAgent")
+    @patch("tardis.resources.poolfactory.SiteAgent")
+    def test_create_drone(self, mock_site_agent, mock_batch_system_agent, mock_drone):
+        self.assertEqual(
+            create_drone(
+                site_agent=mock_site_agent, batch_system_agent=mock_batch_system_agent
+            ),
+            mock_drone(),
+        )
+
+        mock_drone.has_call(
+            [
+                call(
+                    site_agent=mock_site_agent,
+                    batch_system_agent=mock_batch_system_agent,
+                    plugins=None,
+                    remote_resource_uuid=None,
+                    drone_uuid=None,
+                    state=RequestState(),
+                    created=None,
+                    updated=None,
+                )
+            ]
+        )
 
     def test_load_plugins(self):
         self.assertEqual(load_plugins(), {"SqliteRegistry": self.mock_sqliteregistry()})
@@ -49,7 +158,7 @@ class TestPoolFactory(TestCase):
     def test_get_drones_to_restore(self):
         self.assertEqual(
             get_drones_to_restore(
-                plugins={}, site=self.config.Sites, machine_type="TestMachineType"
+                plugins={}, site=self.config.Sites[0], machine_type="TestMachineType"
             ),
             [],
         )
@@ -57,7 +166,7 @@ class TestPoolFactory(TestCase):
         self.assertIsInstance(
             get_drones_to_restore(
                 plugins={"SqliteRegistry": self.mock_sqliteregistry()},
-                site=self.config.Sites,
+                site=self.config.Sites[0],
                 machine_type="TestMachineType",
             )[0]["state"],
             RequestState,


### PR DESCRIPTION
As already described in https://github.com/MatterMiners/cobald/pull/67, the experience of using `WeightedComposite` pools in production shows that weighting by `supply` is not always the best choice. Let's assume that `COBalD` is balancing single core and eight core drones and that single core drones have a worse utilisation than 8 core drones, but single core drones have a higher supply. So, `COBalD` prefers to start single core drones instead of better utilised 8 core drones, due to their higher supply. In this scenario weighting by `utilisation` would be more desired.

This pull request changes the weight used in `TARDIS`s `WeightedComposite`s to `utilisation`.