### PR TITLE
Fix state transitions and refactoring of the slurm site adapter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-02-13, command
+.. Created by changelog.py at 2020-02-24, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-02-13
+[Unreleased] - 2020-02-24
 =========================
 
 Added
@@ -30,3 +30,4 @@ Fixed
 * Improved logging of the `HTCondor` batch system adapter and the status changes of the drones
 * Fix the handling of the termination of vanished resources
 * Fix state transitions for jobs retried by HTCondor
+* Fix state transitions and refactoring of the SLURM site adapter

--- a/docs/source/changes/128.fix_state_transitions_in_slurm_adapter.yaml
+++ b/docs/source/changes/128.fix_state_transitions_in_slurm_adapter.yaml
@@ -1,0 +1,9 @@
+category: fixed
+summary: Fix state transitions and refactoring of the SLURM site adapter
+pull requests:
+  - 128
+description: |
+  The SLURM site adapter contains now state transition for all possible job states in the SLURM batch system. For some
+  states the transition to `TARDIS` `resources_states` has been corrected leading to an infinite execution of `scancel`
+  to jobs not in the queue anymore. In addtion, `squeue` (jobs in batch queue) instead of the `sacct`
+  (Accounting tool listing also history of jobs) is used in order to minize the number of jobs to keep track of.


### PR DESCRIPTION
This pull requests adds state transitions for all possible job states in the SLURM batch system. For some states the transition to the `TARDIS` `ResourceStatus` has been corrected, since it was leading to an infinite execution of `scancel` to jobs not in the queue anymore. 

In addtion, the site adapter has been refactored to use `squeue` (all jobs currently handled by the batch queue) instead of the `sacct` (Accounting tool listing also history of jobs) in order to minize the number of jobs to keep track of.