### PR TITLE
Catch ConnectionResetError in SSHExecutor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,9 +5,9 @@ Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Stefan Kroboth <stefan.kroboth@gmail.com>
-mschnepf <matthias.schnepf@kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
+mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
-Peter Wienemann <peter.wienemann@uni-bonn.de>
-Max Fischer <maxfischer2781@gmail.com>
 Matthias Schnepf <matthias.schnepf@kit.edu>
+Max Fischer <maxfischer2781@gmail.com>
+Peter Wienemann <peter.wienemann@uni-bonn.de>

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -12,35 +12,34 @@ class SSHExecutor(Executor):
         self._parameters = parameters
 
     async def run_command(self, command, stdin_input=None):
-        async with asyncssh.connect(**self._parameters) as conn:
-            try:
+        try:
+            async with asyncssh.connect(**self._parameters) as conn:
                 response = await conn.run(
                     command, check=True, input=stdin_input and stdin_input.encode()
                 )
-            except asyncssh.ProcessError as pe:
-                raise CommandExecutionFailure(
-                    message=f"Run command {command} via SSHExecutor failed",
-                    exit_code=pe.exit_status,
-                    stdin=stdin_input,
-                    stdout=pe.stdout,
-                    stderr=pe.stderr,
-                ) from pe
-            except (
-                ConnectionResetError,
-                asyncssh.misc.DisconnectError,
-                asyncssh.misc.ConnectionLost,
-                BrokenPipeError,
-            ) as ce:
-                raise CommandExecutionFailure(
-                    message=f"Could not run command {command} due to SSH failure: {ce}",
-                    exit_code=255,
-                    stdout="",
-                    stderr="SSH failure",
-                ) from ce
-
-            else:
-                return AttributeDict(
-                    stdout=response.stdout,
-                    stderr=response.stderr,
-                    exit_code=response.exit_status,
-                )
+        except asyncssh.ProcessError as pe:
+            raise CommandExecutionFailure(
+                message=f"Run command {command} via SSHExecutor failed",
+                exit_code=pe.exit_status,
+                stdin=stdin_input,
+                stdout=pe.stdout,
+                stderr=pe.stderr,
+            ) from pe
+        except (
+            ConnectionResetError,
+            asyncssh.misc.DisconnectError,
+            asyncssh.misc.ConnectionLost,
+            BrokenPipeError,
+        ) as ce:
+            raise CommandExecutionFailure(
+                message=f"Could not run command {command} due to SSH failure: {ce}",
+                exit_code=255,
+                stdout="",
+                stderr="SSH failure",
+            ) from ce
+        else:
+            return AttributeDict(
+                stdout=response.stdout,
+                stderr=response.stderr,
+                exit_code=response.exit_status,
+            )


### PR DESCRIPTION
This pull request fixes incorrect exception handling of the ``SSHExecutor``. Previously, exceptions were only handled after establishing the connection. The change broadens this to also cover opening and closing the connection.

Fixes #133.
