### PR TITLE
Add functionality to provide different startup commands per machine type to SLURM adapter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,9 +5,9 @@ Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Stefan Kroboth <stefan.kroboth@gmail.com>
-R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
+R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <maschnepf@schnepf-net.de>
-Matthias Schnepf <matthias.schnepf@kit.edu>
-Max Fischer <maxfischer2781@gmail.com>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
+Max Fischer <maxfischer2781@gmail.com>
+Matthias Schnepf <matthias.schnepf@kit.edu>

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -376,17 +376,17 @@ Available adapter configuration options
 
 .. content-tabs:: left-col
 
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | Option         | Short Description                                                                 | Requirement     |
-    +================+===================================================================================+=================+
-    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.            |  **Required**   |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | StartUpCommand | The command executed in the batch job.                                            |  **Required**   |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | executor       | The |executor| used to run submission and further calls to the Moab batch system. |  **Optional**   |
-    +                +                                                                                   +                 +
-    |                | Default: ShellExecutor is used!                                                   |                 |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | Option         | Short Description                                                                           | Requirement     |
+    +================+=============================================================================================+=================+
+    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                      |  **Required**   |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | StartUpCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!) |  **Deprecated** |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | executor       | The |executor| used to run submission and further calls to the Moab batch system.           |  **Optional**   |
+    +                +                                                                                             +                 +
+    |                | Default: ShellExecutor is used!                                                             |                 |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
 
 .. content-tabs:: right-col
 
@@ -405,7 +405,6 @@ Available adapter configuration options
             username: billy
             client_keys:
              - /opt/tardis/ssh/tardis
-          StartupCommand: pilot_clean.sh
           StatusUpdate: 2
           MachineTypes:
             - one_day
@@ -414,9 +413,11 @@ Available adapter configuration options
             one_day:
               Walltime: '1440'
               Partition: normal
+              StartupCommand: 'pilot_clean.sh'
             twelve_hours:
               Walltime: '720'
               Partition: normal
+              StartupCommand: 'pilot_clean.sh'
           MachineMetaData:
             one_day:
               Cores: 20

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
-.. Created by changelog.py at 2020-02-26, command
-   '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2020-03-18, command
+   '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-python3.7/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-03-18, command
+.. Created by changelog.py at 2020-03-19, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-python3.7/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,7 +32,7 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-03-18
+[Unreleased] - 2020-03-19
 =========================
 
 Changed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,3 +31,11 @@ Fixed
 * Fix the handling of the termination of vanished resources
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
+
+[Unreleased] - 2020-03-18
+=========================
+
+Changed
+-------
+
+* The SLURM adapter can now be configured to use different startup commands for each machine type.

--- a/docs/source/changes/138_changed_moved_startupcommand_in_machine_type_configuration.yaml
+++ b/docs/source/changes/138_changed_moved_startupcommand_in_machine_type_configuration.yaml
@@ -1,0 +1,9 @@
+category: changed
+summary: The SLURM adapter can now be configured to use different startup commands for each machine type.
+pull requests:
+  - 138
+issues:
+  - 136
+description: |
+  The SLURM adapter can now be configured to use different startup commands for each machine type. The old behaviour of
+  providing one startup command is still supported, but will be deprecated in the next major release 0.4.0.

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -19,6 +19,7 @@ from datetime import datetime
 
 import logging
 import re
+import warnings
 
 
 async def slurm_status_updater(executor):
@@ -48,7 +49,15 @@ class SlurmAdapter(SiteAdapter):
         self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._startup_command = self._configuration.StartupCommand
+
+        try:
+            self._startup_command = self.machine_type_configuration.StartupCommand
+        except AttributeError:
+            warnings.warn(
+                "StartupCommand has been moved to the machine_type_configuration!",
+                DeprecationWarning,
+            )
+            self._startup_command = self._configuration.StartupCommand
 
         self._executor = getattr(self._configuration, "executor", ShellExecutor())
 

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -53,6 +53,8 @@ class SlurmAdapter(SiteAdapter):
         try:
             self._startup_command = self.machine_type_configuration.StartupCommand
         except AttributeError:
+            if not hasattr(self._configuration, "StartupCommand"):
+                raise
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -9,7 +9,7 @@ from ...utilities.utilities import mock_executor_run_command
 from ...utilities.utilities import run_async
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from datetime import datetime, timedelta
 from warnings import filterwarnings
@@ -91,6 +91,14 @@ class TestSlurmAdapter(TestCase):
 
     def setUp(self):
         config = self.mock_config.return_value
+        config.TestSite = MagicMock(
+            spec=[
+                "MachineMetaData",
+                "StatusUpdate",
+                "MachineTypeConfiguration",
+                "executor",
+            ]
+        )
         self.test_site_config = config.TestSite
         self.test_site_config.MachineMetaData = self.machine_meta_data
         self.test_site_config.StatusUpdate = 10
@@ -130,6 +138,11 @@ class TestSlurmAdapter(TestCase):
         # Necessary to avoid annoying message in PyCharm
         filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
         del self.test_site_config.MachineTypeConfiguration.test2large.StartupCommand
+
+        with self.assertRaises(AttributeError):
+            self.slurm_adapter = SlurmAdapter(
+                machine_type="test2large", site_name="TestSite"
+            )
 
         self.test_site_config.StartupCommand = "pilot.sh"
 

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from datetime import datetime, timedelta
+from warnings import filterwarnings
 
 import asyncio
 import logging
@@ -92,7 +93,6 @@ class TestSlurmAdapter(TestCase):
         config = self.mock_config.return_value
         self.test_site_config = config.TestSite
         self.test_site_config.MachineMetaData = self.machine_meta_data
-        self.test_site_config.StartupCommand = "pilot.sh"
         self.test_site_config.StatusUpdate = 10
         self.test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         self.test_site_config.executor = self.mock_executor.return_value
@@ -111,7 +111,9 @@ class TestSlurmAdapter(TestCase):
     @property
     def machine_type_configuration(self):
         return AttributeDict(
-            test2large=AttributeDict(Partition="normal", Walltime="60")
+            test2large=AttributeDict(
+                Partition="normal", StartupCommand="pilot.sh", Walltime="60"
+            )
         )
 
     @property
@@ -123,6 +125,18 @@ class TestSlurmAdapter(TestCase):
             resource_status=ResourceStatus.Booting,
             drone_uuid="testsite-1390065",
         )
+
+    def test_start_up_command_deprecation_warning(self):
+        # Necessary to avoid annoying message in PyCharm
+        filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+        del self.test_site_config.MachineTypeConfiguration.test2large.StartupCommand
+
+        self.test_site_config.StartupCommand = "pilot.sh"
+
+        with self.assertWarns(DeprecationWarning):
+            self.slurm_adapter = SlurmAdapter(
+                machine_type="test2large", site_name="TestSite"
+            )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource(self):


### PR DESCRIPTION
As requested by @wiene in #136, the SLURM adapter can now be configured to use different startup commands for each machine type. The previous behaviour is still supported, but will be deprecated in the next major release 0.4.0