### PR TITLE
Add functionality to provide different startup commands per machine type to Moab adapter

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -241,17 +241,17 @@ Available adapter configuration options
 
 .. content-tabs:: left-col
 
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | Option         | Short Description                                                                 | Requirement     |
-    +================+===================================================================================+=================+
-    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.            |  **Required**   |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | StartupCommand | The command executed in the batch job.                                            |  **Required**   |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
-    | executor       | The |executor| used to run submission and further calls to the Moab batch system. |  **Optional**   |
-    +                +                                                                                   +                 +
-    |                | Default: ShellExecutor is used!                                                   |                 |
-    +----------------+-----------------------------------------------------------------------------------+-----------------+
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | Option         | Short Description                                                                           | Requirement     |
+    +================+=============================================================================================+=================+
+    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                      |  **Required**   |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | StartupCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!) |  **Deprecated** |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | executor       | The |executor| used to run submission and further calls to the Moab batch system.           |  **Optional**   |
+    +                +                                                                                             +                 +
+    |                | Default: ShellExecutor is used!                                                             |                 |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
 
     The available options in the `MachineTypeConfiguration` section are the expected `WallTime` of the placeholder jobs and
     the requested `NodeType`. For details see the Moab documentation.
@@ -273,7 +273,6 @@ Available adapter configuration options
             username: clown
             client_keys:
               - /opt/tardis/ssh/tardis
-          StartupCommand: startVM.py
           StatusUpdate: 2
           MachineTypes:
             - singularity_d2.large
@@ -282,9 +281,11 @@ Available adapter configuration options
             singularity_d2.large:
               Walltime: '02:00:00:00'
               NodeType: '1:ppn=20'
+              StartupCommand: startVM.py
             singularity_d1.large:
               Walltime: '01:00:00:00'
               NodeType: '1:ppn=20'
+              StartupCommand: startVM.py
           MachineMetaData:
             singularity_d2.large:
               Cores: 20

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,10 +32,11 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
+
 [Unreleased] - 2020-03-19
-=========================
 
 Changed
 -------
 
 * The SLURM adapter can now be configured to use different startup commands for each machine type.
+* The Moab adapter can now be configured to use different startup commands for each machine type.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,8 +32,8 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-
 [Unreleased] - 2020-03-19
+=========================
 
 Changed
 -------

--- a/docs/source/changes/139_changed_moved_startupcommand_in_machine_type_configuration_moab.yaml
+++ b/docs/source/changes/139_changed_moved_startupcommand_in_machine_type_configuration_moab.yaml
@@ -1,0 +1,7 @@
+category: changed
+summary: The Moab adapter can now be configured to use different startup commands for each machine type.
+pull requests:
+  - 139
+description: |
+  The Moab adapter can now be configured to use different startup commands for each machine type. The old behaviour of
+  providing one startup command is still supported, but will be deprecated in the next major release 0.4.0.

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -54,6 +54,8 @@ class MoabAdapter(SiteAdapter):
         try:
             self._startup_command = self.machine_type_configuration.StartupCommand
         except AttributeError:
+            if not hasattr(self._configuration, "StartupCommand"):
+                raise
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import asyncssh
 import logging
 import re
+import warnings
 from xml.dom import minidom
 
 
@@ -49,7 +50,15 @@ class MoabAdapter(SiteAdapter):
         self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._startup_command = self._configuration.StartupCommand
+
+        try:
+            self._startup_command = self.machine_type_configuration.StartupCommand
+        except AttributeError:
+            warnings.warn(
+                "StartupCommand has been moved to the machine_type_configuration!",
+                DeprecationWarning,
+            )
+            self._startup_command = self._configuration.StartupCommand
 
         self._executor = getattr(self._configuration, "executor", ShellExecutor())
 

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -9,7 +9,7 @@ from tests.utilities.utilities import mock_executor_run_command
 from tests.utilities.utilities import run_async
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from datetime import datetime, timedelta
 from warnings import filterwarnings
@@ -96,6 +96,14 @@ class TestMoabAdapter(TestCase):
 
     def setUp(self):
         config = self.mock_config.return_value
+        config.TestSite = MagicMock(
+            spec=[
+                "MachineMetaData",
+                "StatusUpdate",
+                "MachineTypeConfiguration",
+                "executor",
+            ]
+        )
         self.test_site_config = config.TestSite
         self.test_site_config.MachineMetaData = self.machine_meta_data
         self.test_site_config.StatusUpdate = 10
@@ -139,6 +147,11 @@ class TestMoabAdapter(TestCase):
         # Necessary to avoid annoying message in PyCharm
         filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
         del self.test_site_config.MachineTypeConfiguration.test2large.StartupCommand
+
+        with self.assertRaises(AttributeError):
+            self.moab_adapter = MoabAdapter(
+                machine_type="test2large", site_name="TestSite"
+            )
 
         self.test_site_config.StartupCommand = "startVM.py"
 


### PR DESCRIPTION
To make it similar to the SLURM adapter that gets this feature in #138, this pull request adjust the Moab adapter accordingly. The Moab adapter can now be configured to use different startup commands for each machine type. The previous behaviour is still supported, but will be deprecated in the next major release 0.4.0