### PR TITLE
Use `COBalD` log channels for logging in `TARDIS`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-05-14, command
+.. Created by changelog.py at 2020-05-15, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,7 +32,7 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-05-14
+[Unreleased] - 2020-05-15
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-05-18, command
+.. Created by changelog.py at 2020-05-25, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,7 +32,7 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-05-18
+[Unreleased] - 2020-05-25
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,5 +43,6 @@ Added
 Changed
 -------
 
+* Added log channels and adjusted log levels according to the conventions in `COBalD` documentation
 * The Moab adapter can now be configured to use different startup commands for each machine type.
 * The SLURM adapter can now be configured to use different startup commands for each machine type.

--- a/docs/source/changes/146.improve_logging.yaml
+++ b/docs/source/changes/146.improve_logging.yaml
@@ -1,0 +1,9 @@
+category: changed
+summary: Added log channels and adjusted log levels according to the conventions in `COBalD` documentation
+pull requests:
+  - 146
+issues:
+  - 137
+description: |
+  Added log channels and adjusted log levels according to the conventions in the `COBalD` documentation.
+  This will improve the user's ability to filter log messages according their needs.

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -13,6 +13,8 @@ from shlex import quote
 from typing import Iterable
 import logging
 
+logger = logging.getLogger("cobald.runtime.tardis.adapters.batchsystem.htcondor")
+
 
 async def htcondor_status_updater(
     options: AttributeDict, attributes: AttributeDict
@@ -31,6 +33,7 @@ async def htcondor_status_updater(
     :return: Dictionary containing the output of the ``condor_status`` command
     :rtype: dict
     """
+
     attributes_string = f'-af:t {" ".join(attributes.values())}'
 
     options_string = htcondor_cmd_option_formatter(options)
@@ -43,7 +46,7 @@ async def htcondor_status_updater(
     htcondor_status = {}
 
     try:
-        logging.debug(f"HTCondor status update is running. Command: {cmd}")
+        logger.debug(f"HTCondor status update is running. Command: {cmd}")
         condor_status = await async_run_command(cmd)
         for row in htcondor_csv_parser(
             htcondor_input=condor_status,
@@ -55,11 +58,11 @@ async def htcondor_status_updater(
             htcondor_status[status_key] = row
 
     except CommandExecutionFailure as cef:
-        logging.error("condor_status could not be executed!")
-        logging.error(str(cef))
+        logger.error("condor_status could not be executed!")
+        logger.error(str(cef))
         raise
     else:
-        logging.debug("HTCondor status update finished.")
+        logger.debug("HTCondor status update finished.")
         return htcondor_status
 
 
@@ -136,8 +139,8 @@ class HTCondorAdapter(BatchSystemAdapter):
             if cef.exit_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp  # noqa: B950
-                logging.debug(f"Draining failed with: {str(cef)}")
-                logging.debug(
+                logger.info(f"Draining failed with: {str(cef)}")
+                logger.info(
                     f"Probably drone {drone_uuid} is not available or already drained."
                 )
                 return

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -58,8 +58,7 @@ async def htcondor_status_updater(
             htcondor_status[status_key] = row
 
     except CommandExecutionFailure as cef:
-        logger.error("condor_status could not be executed!")
-        logger.error(str(cef))
+        logger.warning(f"condor_status could not be executed due to {cef}!")
         raise
     else:
         logger.debug("HTCondor status update finished.")
@@ -139,11 +138,12 @@ class HTCondorAdapter(BatchSystemAdapter):
             if cef.exit_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp  # noqa: B950
-                logger.info(f"Draining failed with: {str(cef)}")
-                logger.info(
-                    f"Probably drone {drone_uuid} is not available or already drained."
+                logger.warning(
+                    f"Draining failed with: {str(cef)}. Probably drone {drone_uuid}"
+                    " is not available or already drained."
                 )
                 return
+            logger.critical(f"Draining failed with: {str(cef)}.")
             raise cef
 
     async def integrate_machine(self, drone_uuid: str) -> None:

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -18,6 +18,8 @@ from string import Template
 import logging
 import re
 
+logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.htcondor")
+
 
 async def htcondor_queue_updater(executor):
     attributes = dict(
@@ -30,7 +32,7 @@ async def htcondor_queue_updater(executor):
     try:
         condor_queue = await executor.run_command(queue_command)
     except CommandExecutionFailure as cf:
-        logging.error(f"htcondor_queue_update failed: {cf}")
+        logger.error(f"htcondor_queue_update failed: {cf}")
         raise
     else:
         for row in htcondor_csv_parser(
@@ -105,7 +107,7 @@ class HTCondorAdapter(SiteAdapter):
                 for key, value in self.machine_meta_data.items()
             }
         except KeyError as ke:
-            logging.error(f"deploy_resource failed: no translation known for {ke}")
+            logger.error(f"deploy_resource failed: no translation known for {ke}")
             raise
         else:
             translated_meta_data["Uuid"] = resource_attributes.drone_uuid

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -32,7 +32,7 @@ async def htcondor_queue_updater(executor):
     try:
         condor_queue = await executor.run_command(queue_command)
     except CommandExecutionFailure as cf:
-        logger.error(f"htcondor_queue_update failed: {cf}")
+        logger.warning(f"htcondor_queue_update failed: {cf}")
         raise
     else:
         for row in htcondor_csv_parser(
@@ -107,7 +107,7 @@ class HTCondorAdapter(SiteAdapter):
                 for key, value in self.machine_meta_data.items()
             }
         except KeyError as ke:
-            logger.error(f"deploy_resource failed: no translation known for {ke}")
+            logger.critical(f"deploy_resource failed: no translation known for {ke}")
             raise
         else:
             translated_meta_data["Uuid"] = resource_attributes.drone_uuid

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -207,7 +207,7 @@ class MoabAdapter(SiteAdapter):
         )
 
     async def stop_resource(self, resource_attributes: AttributeDict):
-        logger.info("MOAB jobs cannot be stopped gracefully. Terminating instead.")
+        logger.debug("MOAB jobs cannot be stopped gracefully. Terminating instead.")
         return await self.terminate_resource(resource_attributes)
 
     @contextmanager

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -22,10 +22,12 @@ import re
 import warnings
 from xml.dom import minidom
 
+logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.moab")
+
 
 async def moab_status_updater(executor):
     cmd = "showq --xml -w user=$(whoami) && showq -c --xml -w user=$(whoami)"
-    logging.debug("Moab status update is running.")
+    logger.debug("Moab status update is running.")
     response = await executor.run_command(cmd)
     # combine two XML outputs to one
     xml_output = minidom.parseString(
@@ -41,7 +43,7 @@ async def moab_status_updater(executor):
                 "JobID": line.attributes["JobID"].value,
                 "State": line.attributes["State"].value,
             }
-    logging.debug("Moab status update completed")
+    logger.debug("Moab status update completed")
     return moab_resource_status
 
 
@@ -126,7 +128,7 @@ class MoabAdapter(SiteAdapter):
             f"{self._startup_command}"
         )
         result = await self._executor.run_command(request_command)
-        logging.debug(f"{self.site_name} servers create returned {result}")
+        logger.debug(f"{self.site_name} servers create returned {result}")
 
         remote_resource_uuid = int(result.stdout)
         resource_attributes.update(
@@ -172,7 +174,7 @@ class MoabAdapter(SiteAdapter):
                     "JobID": resource_attributes.remote_resource_uuid,
                     "State": "Completed",
                 }
-        logging.debug(f"{self.site_name} has status {resource_status}.")
+        logger.debug(f"{self.site_name} has status {resource_status}.")
         resource_attributes.update(updated=datetime.now())
         return convert_to_attribute_dict(
             {**resource_attributes, **self.handle_response(resource_status)}
@@ -184,7 +186,7 @@ class MoabAdapter(SiteAdapter):
             response = await self._executor.run_command(request_command)
         except CommandExecutionFailure as cf:
             if cf.exit_code == 1:
-                logging.debug(
+                logger.warning(
                     f"{self.site_name} servers terminate returned {cf.stdout}"
                 )
                 remote_resource_uuid = self.check_remote_resource_uuid(
@@ -195,7 +197,7 @@ class MoabAdapter(SiteAdapter):
             else:
                 raise cf
         else:
-            logging.debug(f"{self.site_name} servers terminate returned {response}")
+            logger.debug(f"{self.site_name} servers terminate returned {response}")
             remote_resource_uuid = self.check_remote_resource_uuid(
                 resource_attributes, r"^job \'(\d*)\' cancelled", response.stdout
             )
@@ -205,7 +207,7 @@ class MoabAdapter(SiteAdapter):
         )
 
     async def stop_resource(self, resource_attributes: AttributeDict):
-        logging.debug("MOAB jobs cannot be stopped gracefully. Terminating instead.")
+        logger.info("MOAB jobs cannot be stopped gracefully. Terminating instead.")
         return await self.terminate_resource(resource_attributes)
 
     @contextmanager
@@ -215,7 +217,7 @@ class MoabAdapter(SiteAdapter):
         except TimeoutError as te:
             raise TardisTimeout from te
         except asyncssh.Error as exc:
-            logging.info("SSH connection failed: " + str(exc))
+            logger.warning("SSH connection failed: " + str(exc))
             raise TardisResourceStatusUpdateFailed
         except IndexError as ide:
             raise TardisResourceStatusUpdateFailed from ide

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -34,7 +34,7 @@ async def slurm_status_updater(executor):
     try:
         slurm_status = await executor.run_command(cmd)
     except CommandExecutionFailure as cf:
-        logger.error(f"Slurm status update has failed due to {cf}.")
+        logger.warning(f"Slurm status update has failed due to {cf}.")
         raise
     else:
         for row in htcondor_csv_parser(

--- a/tardis/plugins/prometheusmonitoring.py
+++ b/tardis/plugins/prometheusmonitoring.py
@@ -7,6 +7,8 @@ from ..utilities.attributedict import AttributeDict
 import logging
 from aioprometheus import Service, Gauge
 
+logger = logging.getLogger("cobald.runtime.tardis.plugins.prometheusmonitoring")
+
 
 class PrometheusMonitoring(Plugin):
     """
@@ -15,10 +17,6 @@ class PrometheusMonitoring(Plugin):
     """
 
     def __init__(self):
-        self.logger = logging.getLogger(
-            "cobald.runtime.tardis.plugins.prometheusmonitoring"
-        )
-        self.logger.setLevel(logging.DEBUG)
         config = Configuration().Plugins.PrometheusMonitoring
 
         self._port = config.port
@@ -43,7 +41,7 @@ class PrometheusMonitoring(Plugin):
 
     async def start(self):
         await self._svr.start(addr=self._addr, port=self._port)
-        self.logger.debug(f"Serving Prometheus metrics on {self._svr.metrics_url}")
+        logger.debug(f"Serving Prometheus metrics on {self._svr.metrics_url}")
         self._svr_started = True
 
     async def notify(self, state: State, resource_attributes: AttributeDict) -> None:
@@ -60,9 +58,7 @@ class PrometheusMonitoring(Plugin):
         if not self._svr_started:
             await self.start()
 
-        self.logger.debug(
-            f"Drone: {str(resource_attributes)} has changed state to {state}"
-        )
+        logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
 
         if resource_attributes.drone_uuid in self._drones:
             old_status = self._drones[resource_attributes.drone_uuid]

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -8,6 +8,8 @@ import asyncio
 import logging
 import sqlite3
 
+logger = logging.getLogger("cobald.runtime.tardis.plugins.sqliteregistry")
+
 
 class SqliteRegistry(Plugin):
     def __init__(self):
@@ -17,8 +19,6 @@ class SqliteRegistry(Plugin):
         of this module is recommended in order to recover the last state of
         TARDIS in case the service has to be restarted.
         """
-        self.logger = logging.getLogger("sqliteregistry")
-        self.logger.setLevel(logging.DEBUG)
         configuration = Configuration()
         self._db_file = configuration.Plugins.SqliteRegistry.db_file
         self._deploy_db_schema()
@@ -113,7 +113,7 @@ class SqliteRegistry(Plugin):
             }
             cursor = connection.cursor()
             cursor.execute(sql_query, bind_parameters)
-            logging.debug(f"{sql_query},{bind_parameters} executed")
+            logger.debug(f"{sql_query},{bind_parameters} executed")
             return cursor.fetchall()
 
     def get_resources(self, site_name: str, machine_type: str):
@@ -144,9 +144,7 @@ class SqliteRegistry(Plugin):
 
     async def notify(self, state: State, resource_attributes: AttributeDict) -> None:
         state = str(state)
-        self.logger.debug(
-            f"Drone: {str(resource_attributes)} has changed state to {state}"
-        )
+        logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
         bind_parameters = dict(state=state)
         bind_parameters.update(resource_attributes)
         await self._dispatch_on_state.get(state, self.update_resource)(bind_parameters)

--- a/tardis/plugins/telegrafmonitoring.py
+++ b/tardis/plugins/telegrafmonitoring.py
@@ -8,6 +8,8 @@ from datetime import datetime
 import logging
 import platform
 
+logger = logging.getLogger("cobald.runtime.tardis.plugins.telegrafmonitoring")
+
 
 class TelegrafMonitoring(Plugin):
     """
@@ -17,8 +19,6 @@ class TelegrafMonitoring(Plugin):
     """
 
     def __init__(self):
-        self.logger = logging.getLogger("telegrafmonitoring")
-        self.logger.setLevel(logging.DEBUG)
         config = Configuration().Plugins.TelegrafMonitoring
 
         host = config.host
@@ -40,9 +40,7 @@ class TelegrafMonitoring(Plugin):
         :type resource_attributes: AttributeDict
         :return: None
         """
-        self.logger.debug(
-            f"Drone: {str(resource_attributes)} has changed state to {state}"
-        )
+        logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
         await self.client.connect()
         data = dict(
             state=str(state),

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -16,6 +16,8 @@ import asyncio
 import logging
 import uuid
 
+logger = logging.getLogger("cobald.runtime.tardis.resources.drone")
+
 
 @service(flavour=asyncio)
 class Drone(Pool):
@@ -30,7 +32,6 @@ class Drone(Pool):
         created: float = None,
         updated: float = None,
     ):
-        self.logger = logging.getLogger("cobald.runtime.tardis.resources.drone")
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
         self._plugins = plugins or []
@@ -91,7 +92,7 @@ class Drone(Pool):
             current_state = self.state
             await current_state.run(self)
             if isinstance(current_state, DownState):
-                self.logger.debug(
+                logger.debug(
                     f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}"
                 )
                 self._demand = 0

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -30,6 +30,7 @@ class Drone(Pool):
         created: float = None,
         updated: float = None,
     ):
+        self.logger = logging.getLogger("cobald.runtime.tardis.resources.drone")
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
         self._plugins = plugins or []
@@ -90,7 +91,7 @@ class Drone(Pool):
             current_state = self.state
             await current_state.run(self)
             if isinstance(current_state, DownState):
-                logging.debug(
+                self.logger.debug(
                     f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}"
                 )
                 self._demand = 0

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -58,7 +58,7 @@ async def resource_status(state_transition, drone: "Drone", current_state: Type[
         drone.resource_attributes.update(
             await drone.site_agent.resource_status(drone.resource_attributes)
         )
-        logger.info(f"Resource attributes: {drone.resource_attributes}")
+        logger.debug(f"Resource attributes: {drone.resource_attributes}")
     except (TardisAuthError, TardisTimeout, TardisResourceStatusUpdateFailed):
         #  Retry to get current state of the resource
         raise StopProcessing(last_result=current_state())
@@ -271,7 +271,7 @@ class ShuttingDownState(State):
     async def run(cls, drone: "Drone"):
         logger.info(f"Drone {drone.resource_attributes} in ShuttingDownState")
         logger.debug(
-            f"Checking Status of VM with ID "
+            f"Checking Status of drone with ID "
             f"{drone.resource_attributes.remote_resource_uuid}"
         )
         await drone.set_state(await cls.run_processing_pipeline(drone))

--- a/tardis/utilities/asynccachemap.py
+++ b/tardis/utilities/asynccachemap.py
@@ -7,6 +7,8 @@ import asyncio
 import logging
 import json
 
+logger = logging.getLogger("cobald.runtime.tardis.utilities.asynccachemap")
+
 
 class AsyncCacheMap(Mapping):
     def __init__(self, update_coroutine, max_age: int = 60 * 15):
@@ -36,11 +38,11 @@ class AsyncCacheMap(Mapping):
                 try:
                     data = await self._update_coroutine()
                 except json.decoder.JSONDecodeError as je:
-                    logging.error(
+                    logger.error(
                         f"AsyncMap update_status failed: Could not decode json {je}"
                     )
                 except CommandExecutionFailure as cf:
-                    logging.error(f"AsyncMap update_status failed: {cf}")
+                    logger.error(f"AsyncMap update_status failed: {cf}")
                 else:
                     self._data = data
                     self._last_update = current_time

--- a/tardis/utilities/asynccachemap.py
+++ b/tardis/utilities/asynccachemap.py
@@ -38,11 +38,11 @@ class AsyncCacheMap(Mapping):
                 try:
                     data = await self._update_coroutine()
                 except json.decoder.JSONDecodeError as je:
-                    logger.error(
+                    logger.warning(
                         f"AsyncMap update_status failed: Could not decode json {je}"
                     )
                 except CommandExecutionFailure as cf:
-                    logger.error(f"AsyncMap update_status failed: {cf}")
+                    logger.warning(f"AsyncMap update_status failed: {cf}")
                 else:
                     self._data = data
                     self._last_update = current_time

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -10,6 +10,8 @@ from shlex import quote
 from unittest.mock import patch
 from unittest import TestCase
 
+import logging
+
 
 class TestHTCondorAdapter(TestCase):
     @classmethod

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -100,7 +100,7 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = CommandExecutionFailure(
             message="Does not exists", exit_code=1, stderr="Does not exists"
         )
-        with self.assertLogs(level="WARNING"):
+        with self.assertLogs(level=logging.WARNING):
             self.assertIsNone(
                 run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
             )
@@ -109,7 +109,7 @@ class TestHTCondorAdapter(TestCase):
             message="Unhandled error", exit_code=2, stderr="Unhandled error"
         )
         with self.assertRaises(CommandExecutionFailure):
-            with self.assertLogs(level="CRITICAL"):
+            with self.assertLogs(level=logging.CRITICAL):
                 self.assertIsNone(
                     run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
                 )
@@ -219,7 +219,7 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = CommandExecutionFailure(
             message="Test", exit_code=123, stderr="Test"
         )
-        with self.assertLogs(level="WARNING"):
+        with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
                 attributes = {
                     "Machine": "Machine",

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -100,17 +100,19 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = CommandExecutionFailure(
             message="Does not exists", exit_code=1, stderr="Does not exists"
         )
-        self.assertIsNone(
-            run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
-        )
+        with self.assertLogs(level="WARNING"):
+            self.assertIsNone(
+                run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+            )
 
         self.mock_async_run_command.side_effect = CommandExecutionFailure(
             message="Unhandled error", exit_code=2, stderr="Unhandled error"
         )
         with self.assertRaises(CommandExecutionFailure):
-            self.assertIsNone(
-                run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
-            )
+            with self.assertLogs(level="CRITICAL"):
+                self.assertIsNone(
+                    run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+                )
 
         self.mock_async_run_command.side_effect = None
 
@@ -217,7 +219,7 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = CommandExecutionFailure(
             message="Test", exit_code=123, stderr="Test"
         )
-        with self.assertLogs(level="ERROR"):
+        with self.assertLogs(level="WARNING"):
             with self.assertRaises(CommandExecutionFailure):
                 attributes = {
                     "Machine": "Machine",

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -15,6 +15,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import asyncio
+import logging
 
 
 class TestCloudStackAdapter(TestCase):
@@ -157,8 +158,9 @@ class TestCloudStackAdapter(TestCase):
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
             with self.assertRaises(to_catch):
-                with self.cloudstack_adapter.handle_exceptions():
-                    raise to_raise
+                with self.assertLogs(level=logging.WARNING):
+                    with self.cloudstack_adapter.handle_exceptions():
+                        raise to_raise
 
         matrix = [
             (

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -185,7 +185,7 @@ class TestHTCondorSiteAdapter(TestCase):
     )
     def test_resource_status_raise_future(self):
         future_timestamp = datetime.now() + timedelta(minutes=1)
-        with self.assertLogs(logging.getLogger(), logging.ERROR):
+        with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(TardisResourceStatusUpdateFailed):
                 run_async(
                     self.adapter.resource_status,
@@ -207,7 +207,7 @@ class TestHTCondorSiteAdapter(TestCase):
         self.adapter._htcondor_queue._last_update = datetime.now() - timedelta(
             minutes=11
         )
-        with self.assertLogs(logging.getLogger(), logging.ERROR):
+        with self.assertLogs(level=logging.WARNING):
             response = run_async(
                 self.adapter.resource_status,
                 AttributeDict(remote_resource_uuid="1351043", created=past_timestamp),

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -16,6 +16,7 @@ from warnings import filterwarnings
 
 import asyncio
 import asyncssh
+import logging
 
 __all__ = ["TestMoabAdapter"]
 
@@ -349,10 +350,11 @@ class TestMoabAdapter(TestCase):
         expected_resource_attributes.update(
             updated=datetime.now(), resource_status=ResourceStatus.Stopped
         )
-        return_resource_attributes = run_async(
-            self.moab_adapter.terminate_resource,
-            resource_attributes=self.resource_attributes,
-        )
+        with self.assertLogs(level=logging.WARNING):
+            return_resource_attributes = run_async(
+                self.moab_adapter.terminate_resource,
+                resource_attributes=self.resource_attributes,
+            )
         self.assertEqual(
             return_resource_attributes["resource_status"], ResourceStatus.Stopped
         )
@@ -407,8 +409,9 @@ class TestMoabAdapter(TestCase):
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
             with self.assertRaises(to_catch):
-                with self.moab_adapter.handle_exceptions():
-                    raise to_raise
+                with self.assertLogs(level=logging.WARNING):
+                    with self.moab_adapter.handle_exceptions():
+                        raise to_raise
 
         matrix = [
             (asyncio.TimeoutError(), TardisTimeout),

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import asyncio
+import logging
 
 
 class TestOpenStackAdapter(TestCase):
@@ -163,8 +164,9 @@ class TestOpenStackAdapter(TestCase):
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
             with self.assertRaises(to_catch):
-                with self.openstack_adapter.handle_exceptions():
-                    raise to_raise
+                with self.assertLogs(level=logging.WARNING):
+                    with self.openstack_adapter.handle_exceptions():
+                        raise to_raise
 
         matrix = [
             (asyncio.TimeoutError(), TardisTimeout),

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -341,7 +341,7 @@ class TestSlurmAdapter(TestCase):
             "1390065": {"JobId": "1390065", "Host": "fh2n1552", "State": "RUNNING"}
         }
 
-        with self.assertLogs(logging.getLogger(), logging.ERROR):
+        with self.assertLogs(level=logging.WARNING):
             response = run_async(
                 self.slurm_adapter.resource_status,
                 AttributeDict(remote_resource_uuid="1390065"),
@@ -386,8 +386,9 @@ class TestSlurmAdapter(TestCase):
     def test_exception_handling(self):
         def test_exception_handling(to_raise, to_catch):
             with self.assertRaises(to_catch):
-                with self.slurm_adapter.handle_exceptions():
-                    raise to_raise
+                with self.assertLogs(level=logging.WARNING):
+                    with self.slurm_adapter.handle_exceptions():
+                        raise to_raise
 
         matrix = [
             (asyncio.TimeoutError(), TardisTimeout),

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -314,6 +314,8 @@ class TestDroneStates(TestCase):
 
         self.run_the_matrix(matrix, initial_state=CleanupState)
 
+        log_channel = "cobald.runtime.tardis.resources.dronestates"
+
         with self.assertLogs(level=logging.WARNING) as msg:
             self.run_side_effects(
                 CleanupState(),
@@ -324,7 +326,7 @@ class TestDroneStates(TestCase):
             self.assertEqual(
                 msg.output,
                 [
-                    "WARNING:root:Calling terminate_resource failed for"
+                    f"WARNING:{log_channel}:Calling terminate_resource failed for"
                     " drone test-923ABF. Drone crashed!"
                 ],
             )
@@ -339,7 +341,7 @@ class TestDroneStates(TestCase):
             self.assertEqual(
                 msg.output,
                 [
-                    "WARNING:root:Calling terminate_resource failed for"
+                    f"WARNING:{log_channel}:Calling terminate_resource failed for"
                     " drone test-923ABF. Will retry later!"
                 ],
             )

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -55,12 +55,12 @@ class TestAsyncCacheMap(TestCase):
             self.assertEqual(value, self.test_data.get(key))
 
     def test_json_failing_update(self):
-        with self.assertLogs(logging.getLogger(), logging.WARNING):
+        with self.assertLogs(level=logging.WARNING):
             run_async(self.json_failing_async_cache_map.update_status)
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 
     def test_command_failing_update(self):
-        with self.assertLogs(logging.getLogger(), logging.WARNING):
+        with self.assertLogs(level=logging.WARNING):
             run_async(self.json_failing_async_cache_map.update_status)
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -55,12 +55,12 @@ class TestAsyncCacheMap(TestCase):
             self.assertEqual(value, self.test_data.get(key))
 
     def test_json_failing_update(self):
-        with self.assertLogs(logging.getLogger(), logging.ERROR):
+        with self.assertLogs(logging.getLogger(), logging.WARNING):
             run_async(self.json_failing_async_cache_map.update_status)
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 
     def test_command_failing_update(self):
-        with self.assertLogs(logging.getLogger(), logging.ERROR):
+        with self.assertLogs(logging.getLogger(), logging.WARNING):
             run_async(self.json_failing_async_cache_map.update_status)
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 


### PR DESCRIPTION
This pull request introduces logging channels as suggested in [`COBalD`s documentation](https://cobald.readthedocs.io/en/latest/source/daemon/logging.html#logging-channels) and #137 correspondingly. This will improve the user's ability to filter log messages according their needs. 