### PR TITLE
Add sbatch command line options

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -437,14 +437,14 @@ Available machine type configuration options
                   C: "intel"
                 long:
                   gres: "gpu:2,mic:1"
-            twelve_hours:
+            six_hours:
               Walltime: '360'
               Partition: normal
               StartupCommand: 'pilot_clean.sh'
               SubmitOptions:
                 long:
                   gres: "gpu:2,mic:1"
-            six_hours:
+            twelve_hours:
               Walltime: '720'
               Partition: normal
               StartupCommand: 'pilot_clean.sh'

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -17,8 +17,8 @@ Site Adapter
     is assumed. Multiple sites are supported by using SequenceNodes.
 
     .. note::
-        Even a minimum lifetime is set, it is not guaranteed that the :py:class:`~tardis.resources.drone.Drone` is not
-        drained due to a dropping demand for it before its minimum lifetime is exceeded.
+        Even if a minimum lifetime is set, it is not guaranteed that the :py:class:`~tardis.resources.drone.Drone` is not
+        drained due to its dropping demand before its minimum lifetime is exceeded.
 
 
 Generic Site Adapter Configuration

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -16,9 +16,9 @@ Site Adapter
     :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. If no value is given, infinite lifetime
     is assumed. Multiple sites are supported by using SequenceNodes.
 
-.. note::
-    Even a minimum lifetime is set, it is not guaranteed that the :py:class:`~tardis.resources.drone.Drone` is not
-    drained due to a dropping demand for it before its minimum lifetime is exceeded.
+    .. note::
+        Even a minimum lifetime is set, it is not guaranteed that the :py:class:`~tardis.resources.drone.Drone` is not
+        drained due to a dropping demand for it before its minimum lifetime is exceeded.
 
 
 Generic Site Adapter Configuration
@@ -389,6 +389,23 @@ Available adapter configuration options
     |                | Default: ShellExecutor is used!                                                             |                 |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
 
+Available machine type configuration options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. content-tabs:: left-col
+
+    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+    | Option         | Short Description                                                                                | Requirement     |
+    +================+==================================================================================================+=================+
+    | Walltime       | Expected walltime of drone                                                                       |  **Required**   |
+    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+    | Partition      | Name of the Slurm partition to run in                                                            |  **Required**   |
+    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+    | StartupCommand | The command to execute at job start                                                              |  **Required**   |
+    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+    | SubmitOptions  | Options to add to the `sbatch` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
+    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+
 .. content-tabs:: right-col
 
     .. rubric:: Example configuration
@@ -415,7 +432,19 @@ Available adapter configuration options
               Walltime: '1440'
               Partition: normal
               StartupCommand: 'pilot_clean.sh'
+              SubmitOptions:
+                short:
+                  C: "intel"
+                long:
+                  gres: "gpu:2,mic:1"
             twelve_hours:
+              Walltime: '360'
+              Partition: normal
+              StartupCommand: 'pilot_clean.sh'
+              SubmitOptions:
+                long:
+                  gres: "gpu:2,mic:1"
+            six_hours:
               Walltime: '720'
               Partition: normal
               StartupCommand: 'pilot_clean.sh'
@@ -428,6 +457,11 @@ Available adapter configuration options
               Cores: 20
               Memory: 62
               Disk: 480
+            six_hours:
+              Cores: 20
+              Memory: 62
+              Disk: 480
+
 
 .. content-tabs:: left-col
 

--- a/docs/source/api/tardis.plugins.prometheusmonitoring.rst
+++ b/docs/source/api/tardis.plugins.prometheusmonitoring.rst
@@ -1,0 +1,7 @@
+tardis.plugins.prometheusmonitoring module
+==========================================
+
+.. automodule:: tardis.plugins.prometheusmonitoring
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.plugins.rst
+++ b/docs/source/api/tardis.plugins.rst
@@ -11,5 +11,6 @@ Submodules
 
 .. toctree::
 
+   tardis.plugins.prometheusmonitoring
    tardis.plugins.sqliteregistry
    tardis.plugins.telegrafmonitoring

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-05-14, command
+.. Created by changelog.py at 2020-05-15, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,7 +32,7 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-05-14
+[Unreleased] - 2020-05-15
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,6 +38,7 @@ Fixed
 Added
 -----
 
+* Enable support for `sbatch` command line options in the Slurm site adapter
 * Add ssh connection sharing to `SSHExecutor` in order to re-use existing connection
 
 Changed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,3 +1,4 @@
+.. Created by changelog.py at 2020-05-15, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-05-25, command
+.. Created by changelog.py at 2020-06-03, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,14 +32,14 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-05-25
+[Unreleased] - 2020-06-03
 =========================
 
 Added
 -----
 
-* Enable support for `sbatch` command line options in the Slurm site adapter
 * Added an example HTCondor jdl for the HTCondor site adapter
+* Enable support for `sbatch` command line options in the Slurm site adapter
 * Add ssh connection sharing to `SSHExecutor` in order to re-use existing connection
 
 Changed

--- a/docs/source/changes/150.enable_sbatch_cmdline_options.yaml
+++ b/docs/source/changes/150.enable_sbatch_cmdline_options.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: "Enable support for `sbatch` command line options in the Slurm site adapter"
+pull requests:
+  - 150
+issues:
+  - 147
+description: |
+  `sbatch` command line option can now be added to the `MachineTypeConfiguration` of the
+  Slurm site adapter. `short` and `long` option are supported via yaml MappingNodes.

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -11,6 +11,7 @@ from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.utils import htcondor_csv_parser
+from ...utilities.utils import slurm_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -61,6 +62,10 @@ class SlurmAdapter(SiteAdapter):
             )
             self._startup_command = self._configuration.StartupCommand
 
+        self._sbatch_cmdline_option_string = slurm_cmd_option_formatter(
+            self.sbatch_cmdline_options
+        )
+
         self._executor = getattr(self._configuration, "executor", ShellExecutor())
 
         self._slurm_status = AsyncCacheMap(
@@ -105,17 +110,16 @@ class SlurmAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
+
         request_command = (
-            f"sbatch -p {self.machine_type_configuration.Partition} "
-            f"-N 1 -n {self.machine_meta_data.Cores} "
-            f"--mem={self.machine_meta_data.Memory}gb "
-            f"-t {self.machine_type_configuration.Walltime} "
-            f"--export=SLURM_Walltime="
-            f"{self.machine_type_configuration.Walltime} "
+            "sbatch "
+            f"{self._sbatch_cmdline_option_string} "
             f"{self._startup_command}"
         )
+
         result = await self._executor.run_command(request_command)
-        logging.debug(f"{self.site_name} sbatch returned {result}")
+        logging.debug(f"{self.site_name} {request_command} returned {result}")
+
         pattern = re.compile(r"^Submitted batch job (\d*)", flags=re.MULTILINE)
         remote_resource_uuid = int(pattern.findall(result.stdout)[0])
         resource_attributes.update(
@@ -161,6 +165,27 @@ class SlurmAdapter(SiteAdapter):
         )
         return self.handle_response(
             {"JobId": resource_attributes.remote_resource_uuid}, **resource_attributes
+        )
+
+    @property
+    def sbatch_cmdline_options(self):
+        sbatch_options = self.machine_type_configuration.get(
+            "SubmitOptions", AttributeDict()
+        )
+
+        return AttributeDict(
+            short=AttributeDict(
+                **sbatch_options.get("short", AttributeDict()),
+                p=self.machine_type_configuration.Partition,
+                N=1,
+                n=self.machine_meta_data.Cores,
+                t=self.machine_type_configuration.Walltime,
+            ),
+            long=AttributeDict(
+                **sbatch_options.get("long", AttributeDict()),
+                mem=f"{self.machine_meta_data.Memory}gb",
+                export=f"SLURM_Walltime={self.machine_type_configuration.Walltime}",
+            ),
         )
 
     async def stop_resource(self, resource_attributes: AttributeDict):

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -1,12 +1,17 @@
+from .attributedict import AttributeDict
 from .executors.shellexecutor import ShellExecutor
 from ..exceptions.executorexceptions import CommandExecutionFailure
+from ..interfaces.executor import Executor
 
 from io import StringIO
+from typing import List, Tuple
 
 import csv
 
 
-async def async_run_command(cmd, shell_executor=ShellExecutor()):
+async def async_run_command(
+    cmd: str, shell_executor: Executor = ShellExecutor()
+) -> str:
     try:
         response = await shell_executor.run_command(cmd)
     except CommandExecutionFailure as ef:
@@ -22,7 +27,7 @@ async def async_run_command(cmd, shell_executor=ShellExecutor()):
         return response.stdout
 
 
-def cmd_option_formatter(options, prefix, separator):
+def cmd_option_formatter(options: AttributeDict, prefix: str, separator: str) -> str:
     options = (
         f"{prefix}{name}{separator}{value}" if value is not None else f"{prefix}{name}"
         for name, value in options.items()
@@ -31,11 +36,16 @@ def cmd_option_formatter(options, prefix, separator):
     return " ".join(options)
 
 
-def htcondor_cmd_option_formatter(options):
+def htcondor_cmd_option_formatter(options: AttributeDict) -> str:
     return cmd_option_formatter(options, prefix="-", separator=" ")
 
 
-def htcondor_csv_parser(htcondor_input, fieldnames, delimiter="\t", replacements=None):
+def htcondor_csv_parser(
+    htcondor_input: str,
+    fieldnames: [List, Tuple],
+    delimiter: str = "\t",
+    replacements: dict = None,
+):
     replacements = replacements or {}
     with StringIO(htcondor_input) as csv_input:
         cvs_reader = csv.DictReader(
@@ -48,7 +58,7 @@ def htcondor_csv_parser(htcondor_input, fieldnames, delimiter="\t", replacements
             }
 
 
-def slurm_cmd_option_formatter(options):
+def slurm_cmd_option_formatter(options: AttributeDict) -> str:
     option_prefix = dict(short="-", long="--")
     option_separator = dict(short=" ", long="=")
 

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -176,7 +176,26 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 --mem=62gb -t 60 --export=SLURM_Walltime=60 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60 pilot.sh"  # noqa: B950
+        )
+
+    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    def test_deploy_resource_w_submit_options(self):
+        self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = AttributeDict(  # noqa: B950
+            long=AttributeDict(gres="tmp:1G")
+        )
+
+        slurm_adapter = SlurmAdapter(machine_type="test2large", site_name="TestSite")
+
+        run_async(
+            slurm_adapter.deploy_resource,
+            resource_attributes=AttributeDict(
+                machine_type="test2large", site_name="TestSite"
+            ),
+        )
+
+        self.mock_executor.return_value.run_command.assert_called_with(
+            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60 pilot.sh"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,6 +1,9 @@
+from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.utils import async_run_command
 from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import htcondor_csv_parser
+from tardis.utilities.utils import slurm_cmd_option_formatter
+
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from ..utilities.utilities import run_async
@@ -21,10 +24,15 @@ class TestAsyncRunCommand(TestCase):
 
 class TestHTCondorCMDOptionFormatter(TestCase):
     def test_htcondor_cmd_option_formatter(self):
-        options = {"pool": "my-htcondor.local", "test": None}
-        options_string = htcondor_cmd_option_formatter(options)
+        options = AttributeDict(pool="my-htcondor.local", test=None)
+        option_string = htcondor_cmd_option_formatter(options)
 
-        self.assertEqual(options_string, "-pool my-htcondor.local -test")
+        self.assertEqual(option_string, "-pool my-htcondor.local -test")
+
+        options = AttributeDict()
+        option_string = htcondor_cmd_option_formatter(options)
+
+        self.assertEqual(option_string, "")
 
 
 class TestHTCondorCSVParser(TestCase):
@@ -62,4 +70,32 @@ class TestHTCondorCSVParser(TestCase):
                 Test1=None,
                 Test2=None,
             ),
+        )
+
+
+class TestSlurmCMDOptionFormatter(TestCase):
+    def test_slurm_cmd_option_formatter(self):
+        options = AttributeDict()
+        option_string = slurm_cmd_option_formatter(options)
+
+        self.assertEqual(option_string, "")
+
+        options = AttributeDict(short=AttributeDict(foo="bar", test=None))
+        option_string = slurm_cmd_option_formatter(options)
+
+        self.assertEqual(option_string, "-foo bar -test")
+
+        options = AttributeDict(long=AttributeDict(foo="bar", test=None))
+        option_string = slurm_cmd_option_formatter(options)
+
+        self.assertEqual(option_string, "--foo=bar --test")
+
+        options = AttributeDict(
+            short=AttributeDict(foo="bar", test=None),
+            long=AttributeDict(foo_long="bar_long", test_long=None),
+        )
+        option_string = slurm_cmd_option_formatter(options)
+
+        self.assertEqual(
+            option_string, "-foo bar -test --foo_long=bar_long --test_long"
         )


### PR DESCRIPTION
This pull requests enables support for `sbatch` command line options in the Slurm site adapter as requested in #147. Command line options can be specified per `MachineTypeConfiguration`. `short` as well as `long` options are supported. `SubmitOptions` are optional. 

```yaml
MachineTypeConfiguration:
  my_machine_type:
    SubmitOptions:
      short:
        C: "intel"
      long:
        gres: "gpu:2,mic:1"
```
This translates to `sbatch -C intel --gres=gpu:2,mic:1`.