### PR TITLE
Add HTCondor JDL example to documentation

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -199,7 +199,8 @@ Available adapter configuration options
     +----------------+-----------------------------------------------------------------------------------+-----------------+
 
     The only available option in the `MachineTypeConfiguration` section is a template jdl used to submit drones to the
-    HTCondor batch system. The template jdl is using the `Python template string`_ syntax.
+    HTCondor batch system. The template jdl is using the `Python template string`_ syntax
+    (see example HTCondor JDL for details).
 
     .. _Python template string: https://docs.python.org/3.4/library/string.html#template-strings
 
@@ -226,6 +227,27 @@ Available adapter configuration options
               Cores: 42
               Memory: 256
               Disk: 840
+
+    .. rubric:: Example HTCondor JDL
+
+    .. code-block::
+
+        executable = start_pilot.sh
+        transfer_input_files = setup_pilot.sh,grid-mapfile
+        output = logs/$$(cluster).$$(process).out
+        error = logs/$$(cluster).$$(process).err
+        log = logs/cluster.log
+
+        accounting_group=tardis
+        x509userproxy = /home/tardis/proxy
+
+        environment=${Environment}
+
+        request_cpus=${Cores}
+        request_memory=${Memory}
+        request_disk=${Disk}
+
+        queue 1
 
 Moab Site Adapter
 -----------------

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -202,6 +202,9 @@ Available adapter configuration options
     HTCondor batch system. The template jdl is using the `Python template string`_ syntax
     (see example HTCondor JDL for details).
 
+    .. Note::
+        The `$(...)` used for HTCondor variables needs to be replaced by `$$(...)` in the JDL.
+
     .. _Python template string: https://docs.python.org/3.4/library/string.html#template-strings
 
 .. content-tabs:: right-col

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-05-14, command
+.. Created by changelog.py at 2020-05-18, command
    '/Users/giffler/.cache/pre-commit/repont7o94ca/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -32,7 +32,7 @@ Fixed
 * Fix state transitions for jobs retried by HTCondor
 * Fix state transitions and refactoring of the SLURM site adapter
 
-[Unreleased] - 2020-05-14
+[Unreleased] - 2020-05-18
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,6 +38,7 @@ Fixed
 Added
 -----
 
+* Added an example HTCondor jdl for the HTCondor site adapter
 * Add ssh connection sharing to `SSHExecutor` in order to re-use existing connection
 
 Changed

--- a/docs/source/changes/151.add_htcondor_example_jdl.yaml
+++ b/docs/source/changes/151.add_htcondor_example_jdl.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: Added an example HTCondor jdl for the HTCondor site adapter
+pull requests:
+  - 151
+issues:
+  - 132
+description: |
+  A example for an HTCondor JDL has been added to the HTCondor site adapter configuration.
+  So, that people new to `TARDIS` have a starting point to use this adapter.


### PR DESCRIPTION
This pull request adds a HTCondor JDL example for the HTCondor site adapter to the documentation. This fixes #132.