### PR TITLE
Migrate development env to python3.8

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,7 +8,7 @@ Rene Caspart <rene.caspart@cern.ch>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
-Matthias Schnepf <matthias.schnepf@kit.edu>
-Max Fischer <maxfischer2781@gmail.com>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
+Max Fischer <maxfischer2781@gmail.com>
+Matthias Schnepf <matthias.schnepf@kit.edu>
 rfvc <florian.voncube@gmail.com>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
-.. Created by changelog.py at 2020-06-03, command
-   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2020-07-08, command
+   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.8/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -7,20 +7,23 @@ from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from functools import partial
 from shlex import quote
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from unittest import TestCase
 
 import logging
 
 
 class TestHTCondorAdapter(TestCase):
+    mock_config_patcher = None
+    mock_async_run_command_patcher = None
+
     @classmethod
     def setUpClass(cls):
         cls.mock_config_patcher = patch(
             "tardis.adapters.batchsystems.htcondor.Configuration"
         )
         cls.mock_async_run_command_patcher = patch(
-            "tardis.adapters.batchsystems.htcondor.async_run_command"
+            "tardis.adapters.batchsystems.htcondor.async_run_command", new=MagicMock()
         )
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_async_run_command = cls.mock_async_run_command_patcher.start()

--- a/tests/configuration_t/test_utilities.py
+++ b/tests/configuration_t/test_utilities.py
@@ -6,7 +6,7 @@ import yaml
 
 
 @enable_yaml_load("!TestDummy")  # noqa: B903
-class TestDummy(object):
+class TestDummy(object):  # noqa: B903
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs


### PR DESCRIPTION
While moving my development environment to python3.8 I noticed the following problems during unittesting. 

- New versions of `flake8` report B903 not in line https://github.com/MatterMiners/tardis/blob/279d868ed1abdc9f8d506d1d3be9a19cf83f7bb1/tests/configuration_t/test_utilities.py#L8 but in line https://github.com/MatterMiners/tardis/blob/279d868ed1abdc9f8d506d1d3be9a19cf83f7bb1/tests/configuration_t/test_utilities.py#L9 instead. Therefore, the `#noqa B903` is now present in both lines.

- python3.8 introduced `AsyncMocks`, which are now default for mocking coroutines. However, we are still manually wrapping around this, due to backward compatibilty. Therefore, the default behaviour has been adjusted in line https://github.com/MatterMiners/tardis/blob/cd639e8cdf9fe56d5f53526f459392904a414437/tests/adapters_t/batchsystems_t/test_htcondor.py#L26
