### PR TITLE
Enable python3.9 tests on travis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
         args:
-        -   --py36
+        -   --target-version=py36
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.2
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "nightly" # currently points to 3.8-dev
   - "pypy3"
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
-.. Created by changelog.py at 2020-07-08, command
-   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.8/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2020-10-29, command
+   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -227,11 +227,12 @@ class TestMoabAdapter(TestCase):
                 machine_type="test2large", site_name="TestSite"
             ),
         )
-        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(  # noqa: B950
-            seconds=1
-        ) or return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(  # noqa: B950
-            seconds=1
-        ):
+        if (
+            return_resource_attributes.created - expected_resource_attributes.created
+            > timedelta(seconds=1)
+            or return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)  # noqa: B950
+        ):  # noqa: B950
             raise Exception("Creation time or update time wrong!")
         del (
             expected_resource_attributes.created,

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -181,9 +181,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource_w_submit_options(self):
-        self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = AttributeDict(  # noqa: B950
-            long=AttributeDict(gres="tmp:1G")
-        )
+        self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = (
+            AttributeDict(long=AttributeDict(gres="tmp:1G"))
+        )  # noqa: B950
 
         slurm_adapter = SlurmAdapter(machine_type="test2large", site_name="TestSite")
 

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -93,9 +93,9 @@ class TestDroneStates(TestCase):
             self.drone.site_agent.resource_status.return_value = async_return(
                 return_value=AttributeDict(resource_status=resource_status)
             )
-            self.drone.batch_system_agent.get_machine_status.return_value = async_return(  # noqa: B950
-                return_value=machine_status
-            )
+            self.drone.batch_system_agent.get_machine_status.return_value = (
+                async_return(return_value=machine_status)
+            )  # noqa: B950
             self.drone.state.return_value = initial_state
             with self.assertLogs(None, level="DEBUG"):
                 run_async(self.drone.state.return_value.run, self.drone)


### PR DESCRIPTION
Since Python 3.9 has been released recently, I would like to enable Python 3.9 unittests on travis and update pre-commit to use the latest black version otherwise travis is complaining. In addition, I have changed the command line argument for black from the deprecated `--py36` to `--target-version=py36`.