### PR TITLE
Export tardis environment variable via slurm site adapter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,14 @@
 CHANGELOG
 #########
 
+[Unreleased] - 2020-12-01
+=========================
+
+Added
+-----
+
+* Export tardis environment variable via slurm site adapter
+
 [0.4.0] - 2020-06-03
 ====================
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-12-01
+[Unreleased] - 2020-12-02
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-12-07
+[Unreleased] - 2020-12-08
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2020-12-02
+[Unreleased] - 2020-12-07
 =========================
 
 Added

--- a/docs/source/changes/157.export_tardis_env_via_slurm_site_adapter.yaml
+++ b/docs/source/changes/157.export_tardis_env_via_slurm_site_adapter.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: "Export tardis environment variable via slurm site adapter"
+description: |
+  Export the drone meta data like allocated cores, memory as well as the drone uuid to the actual batch jobs
+  representing the drone. This environment variables are then used to configure the OBS node accordingly.
+  In addition, the drone uuid can be used as STARTD_NAME in the HTCondor OBS in order to uniquely match drones to the
+  underlying resources in the OBS.
+pull requests:
+- 157

--- a/tardis/adapters/batchsystems/fakebatchsystem.py
+++ b/tardis/adapters/batchsystems/fakebatchsystem.py
@@ -1,6 +1,7 @@
-from tardis.configuration.configuration import Configuration
-from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
-from tardis.interfaces.batchsystemadapter import MachineStatus
+from ...configuration.configuration import Configuration
+from ...interfaces.batchsystemadapter import BatchSystemAdapter
+from ...interfaces.batchsystemadapter import MachineStatus
+from ...utilities.attributedict import AttributeDict
 
 
 class FakeBatchSystemAdapter(BatchSystemAdapter):
@@ -99,13 +100,13 @@ class FakeBatchSystemAdapter(BatchSystemAdapter):
             return utilisation
 
     @property
-    def machine_meta_data_translation_mapping(self) -> dict:
+    def machine_meta_data_translation_mapping(self) -> AttributeDict:
         """
         The machine meta data translation mapping is used to translate units of
         the machine meta data in ``TARDIS`` to values expected by the
         FakeBatchSystem adapter.
 
         :return: Machine meta data translation mapping
-        :rtype: dict
+        :rtype: AttributeDict
         """
-        return {"Cores": 1, "Memory": 1, "Disk": 1}
+        return AttributeDict(Cores=1, Memory=1, Disk=1)

--- a/tardis/adapters/batchsystems/fakebatchsystem.py
+++ b/tardis/adapters/batchsystems/fakebatchsystem.py
@@ -97,3 +97,15 @@ class FakeBatchSystemAdapter(BatchSystemAdapter):
             return self.fake_config.utilisation
         else:
             return utilisation
+
+    @property
+    def machine_meta_data_translation_mapping(self) -> dict:
+        """
+        The machine meta data translation mapping is used to translate units of
+        the machine meta data in ``TARDIS`` to values expected by the
+        FakeBatchSystem adapter.
+
+        :return: Machine meta data translation mapping
+        :rtype: dict
+        """
+        return {"Cores": 1, "Memory": 1, "Disk": 1}

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -239,13 +239,13 @@ class HTCondorAdapter(BatchSystemAdapter):
         return min(await self.get_resource_ratios(drone_uuid), default=0.0)
 
     @property
-    def machine_meta_data_translation_mapping(self) -> dict:
+    def machine_meta_data_translation_mapping(self) -> AttributeDict:
         """
         The machine meta data translation mapping is used to translate units of
         the machine meta data in ``TARDIS`` to values expected by the
         HTCondor batch system adapter.
 
         :return: Machine meta data translation mapping
-        :rtype: dict
+        :rtype: AttributeDict
         """
-        return {"Cores": 1, "Memory": 1024, "Disk": 1024 * 1024}
+        return AttributeDict(Cores=1, Memory=1024, Disk=1024 * 1024)

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -237,3 +237,15 @@ class HTCondorAdapter(BatchSystemAdapter):
         :rtype: float
         """
         return min(await self.get_resource_ratios(drone_uuid), default=0.0)
+
+    @property
+    def machine_meta_data_translation_mapping(self) -> dict:
+        """
+        The machine meta data translation mapping is used to translate units of
+        the machine meta data in ``TARDIS`` to values expected by the
+        HTCondor batch system adapter.
+
+        :return: Machine meta data translation mapping
+        :rtype: dict
+        """
+        return {"Cores": 1, "Memory": 1024, "Disk": 1024 * 1024}

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -247,3 +247,15 @@ class SlurmAdapter(BatchSystemAdapter):
         :rtype: float
         """
         return min(await self.get_resource_ratios(drone_uuid), default=0.0)
+
+    @property
+    def machine_meta_data_translation_mapping(self) -> dict:
+        """
+        The machine meta data translation mapping is used to translate units of
+        the machine meta data in ``TARDIS`` to values expected by the
+        Slurm batch system adapter.
+
+        :return: Machine meta data translation mapping
+        :rtype: dict
+        """
+        return {"Cores": 1, "Memory": 1000, "Disk": 1000}

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -249,13 +249,13 @@ class SlurmAdapter(BatchSystemAdapter):
         return min(await self.get_resource_ratios(drone_uuid), default=0.0)
 
     @property
-    def machine_meta_data_translation_mapping(self) -> dict:
+    def machine_meta_data_translation_mapping(self) -> AttributeDict:
         """
         The machine meta data translation mapping is used to translate units of
         the machine meta data in ``TARDIS`` to values expected by the
         Slurm batch system adapter.
 
         :return: Machine meta data translation mapping
-        :rtype: dict
+        :rtype: AttributeDict
         """
-        return {"Cores": 1, "Memory": 1000, "Disk": 1000}
+        return AttributeDict(Cores=1, Memory=1000, Disk=1000)

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -99,7 +99,10 @@ class HTCondorAdapter(SiteAdapter):
         with open(jdl_file, "r") as f:
             jdl_template = Template(f.read())
 
-        drone_environment = self.drone_environment(resource_attributes.drone_uuid)
+        drone_environment = self.drone_environment(
+            resource_attributes.drone_uuid,
+            resource_attributes.machine_meta_data_translation_mapping,
+        )
 
         submit_jdl = jdl_template.substitute(
             drone_environment,

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -114,7 +114,7 @@ class SlurmAdapter(SiteAdapter):
         )
 
         request_command = (
-            "sbatch " f"{sbatch_cmdline_option_string} " f"{self._startup_command}"
+            f"sbatch {sbatch_cmdline_option_string} {self._startup_command}"
         )
 
         result = await self._executor.run_command(request_command)

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -110,7 +110,10 @@ class SlurmAdapter(SiteAdapter):
     ) -> AttributeDict:
 
         sbatch_cmdline_option_string = slurm_cmd_option_formatter(
-            self.sbatch_cmdline_options(resource_attributes.drone_uuid)
+            self.sbatch_cmdline_options(
+                resource_attributes.drone_uuid,
+                resource_attributes.machine_meta_data_translation_mapping,
+            )
         )
 
         request_command = (
@@ -165,7 +168,7 @@ class SlurmAdapter(SiteAdapter):
             {"JobId": resource_attributes.remote_resource_uuid}, **resource_attributes
         )
 
-    def sbatch_cmdline_options(self, drone_uuid):
+    def sbatch_cmdline_options(self, drone_uuid, machine_meta_data_translation_mapping):
         sbatch_options = self.machine_type_configuration.get(
             "SubmitOptions", AttributeDict()
         )
@@ -174,7 +177,9 @@ class SlurmAdapter(SiteAdapter):
 
         drone_environment = ",".join(
             f"TardisDrone{key}={value}"
-            for key, value in self.drone_environment(drone_uuid).items()
+            for key, value in self.drone_environment(
+                drone_uuid, machine_meta_data_translation_mapping
+            ).items()
         )
 
         return AttributeDict(

--- a/tardis/agents/batchsystemagent.py
+++ b/tardis/agents/batchsystemagent.py
@@ -1,5 +1,6 @@
 from ..interfaces.batchsystemadapter import BatchSystemAdapter
 from ..interfaces.batchsystemadapter import MachineStatus
+from ..utilities.attributedict import AttributeDict
 
 
 class BatchSystemAgent(BatchSystemAdapter):
@@ -25,5 +26,5 @@ class BatchSystemAgent(BatchSystemAdapter):
         return await self._batch_system_adapter.get_utilisation(drone_uuid)
 
     @property
-    def machine_meta_data_translation_mapping(self) -> dict:
+    def machine_meta_data_translation_mapping(self) -> AttributeDict:
         return self._batch_system_adapter.machine_meta_data_translation_mapping

--- a/tardis/agents/batchsystemagent.py
+++ b/tardis/agents/batchsystemagent.py
@@ -23,3 +23,7 @@ class BatchSystemAgent(BatchSystemAdapter):
 
     async def get_utilisation(self, drone_uuid: str) -> float:
         return await self._batch_system_adapter.get_utilisation(drone_uuid)
+
+    @property
+    def machine_meta_data_translation_mapping(self) -> dict:
+        return self._batch_system_adapter.machine_meta_data_translation_mapping

--- a/tardis/interfaces/batchsystemadapter.py
+++ b/tardis/interfaces/batchsystemadapter.py
@@ -1,3 +1,5 @@
+from ..utilities.attributedict import AttributeDict
+
 from abc import ABCMeta
 from abc import abstractmethod
 from enum import Enum
@@ -100,13 +102,13 @@ class BatchSystemAdapter(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def machine_meta_data_translation_mapping(self) -> dict:
+    def machine_meta_data_translation_mapping(self) -> AttributeDict:
         """
         The machine meta data translation mapping is used to translate units of
         the machine meta data in ``TARDIS`` as expected by the overlay batch
         system.
 
         :return: machine meta data translation mapping
-        :rtype: dict
+        :rtype: AttributeDict
         """
         raise NotImplementedError

--- a/tardis/interfaces/batchsystemadapter.py
+++ b/tardis/interfaces/batchsystemadapter.py
@@ -11,26 +11,102 @@ class MachineStatus(Enum):
 
 
 class BatchSystemAdapter(metaclass=ABCMeta):
+    """
+    Abstract base class defining the interface for BatchSystemAdapters which handles
+    integration and management of resources in the overlay batch system.
+    """
+
     @abstractmethod
     async def disintegrate_machine(self, drone_uuid: str) -> None:
-        return NotImplemented
+        """
+        Disintegrate a machine from the overlay batch system.
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+                to the host name of the drone.
+            :type drone_uuid: str
+            :return: None
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def drain_machine(self, drone_uuid: str) -> None:
-        return NotImplemented
+        """
+        Drain a machine in the overlay batch system, which means that no new
+        jobs will be accepted
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+            to the host name of the drone.
+        :type drone_uuid: str
+        :return: None
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def integrate_machine(self, drone_uuid: str) -> None:
-        return NotImplemented
+        """
+        Integrate a machine into the overlay batch system.
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+            to the host name of the drone.
+        :type drone_uuid: str
+        :return: None
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def get_allocation(self, drone_uuid: str) -> float:
-        return NotImplemented
+        """
+        Get the allocation of a worker node in the overlay batch system, which is
+        defined as maximum of the ratios of requested over total resources
+        (CPU, Memory, Disk, etc.).
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+            to the host name of the drone.
+        :type drone_uuid: str
+        :return: The allocation of a worker node as described above.
+        :rtype: float
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def get_machine_status(self, drone_uuid: str) -> MachineStatus:
-        return NotImplemented
+        """
+        Get the status of a worker node in the overlay batch system (Available,
+        Draining, Drained, NotAvailable)
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+            to the host name of the drone.
+        :type drone_uuid: str
+        :return: The machine status in HTCondor (Available, Draining, Drained,
+            NotAvailable)
+        :rtype: MachineStatus
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def get_utilisation(self, drone_uuid: str) -> float:
-        return NotImplemented
+        """
+        Get the utilisation of a worker node in the overlay batch system, which
+        is defined as minimum of the ratios of requested over total resources
+        (CPU, Memory, Disk, etc.).
+
+        :param drone_uuid: Uuid of the worker node, for some sites corresponding
+            to the host name of the drone.
+        :type drone_uuid: str
+        :return: The utilisation of a worker node as described above.
+        :rtype: float
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def machine_meta_data_translation_mapping(self) -> dict:
+        """
+        The machine meta data translation mapping is used to translate units of
+        the machine meta data in ``TARDIS`` as expected by the overlay batch
+        system.
+
+        :return: machine meta data translation mapping
+        :rtype: dict
+        """
+        raise NotImplementedError

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -118,7 +118,7 @@ class SiteAdapter(metaclass=ABCMeta):
         return translated_response
 
     def drone_environment(
-        self, drone_uuid: str, meta_data_translation_mapping: dict
+        self, drone_uuid: str, meta_data_translation_mapping: AttributeDict
     ) -> dict:
         """
         Method to get the drone environment to be exported to batch jobs

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -119,14 +119,13 @@ class SiteAdapter(metaclass=ABCMeta):
 
     def drone_environment(
         self, drone_uuid: str, meta_data_translation_mapping: dict = None
-    ):
+    ) -> dict:
         """
         Method to get the drone environment to be exported to batch jobs
         providing the actual resources in the overlay batch system. It
         translates units of drone meta data into a format the overlay
-        batch system is expecting. In addition, the drone_uuid is adding to
-        allow for matching drones to actual resources provided in the overlay
-        batch system.
+        batch system is expecting. Also, the drone_uuid is added  for matching
+        drones to actual resources provided in the overlay batch system.
         :param drone_uuid: The unique id which is assigned to every drone on creation
         :type drone_uuid: str
         :param meta_data_translation_mapping: Mapping used for the meta data translation

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -118,7 +118,7 @@ class SiteAdapter(metaclass=ABCMeta):
         return translated_response
 
     def drone_environment(
-        self, drone_uuid: str, meta_data_translation_mapping: dict = None
+        self, drone_uuid: str, meta_data_translation_mapping: dict
     ) -> dict:
         """
         Method to get the drone environment to be exported to batch jobs
@@ -133,11 +133,6 @@ class SiteAdapter(metaclass=ABCMeta):
         :return: Translated
         :rtype: dict
         """
-        meta_data_translation_mapping = meta_data_translation_mapping or {
-            "Cores": 1,
-            "Memory": 1024,
-            "Disk": 1024,
-        }  # defaults to units expected by HTCondor
         try:
             drone_environment = {
                 key: meta_data_translation_mapping[key] * value

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -3,6 +3,10 @@ from ..utilities.attributedict import AttributeDict
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 
+import logging
+
+logger = logging.getLogger("cobald.runtime.tardis.interfaces.site")
+
 
 class ResourceStatus(Enum):
     """
@@ -214,3 +218,38 @@ class SiteAdapter(metaclass=ABCMeta):
         :rtype: AttributeDict
         """
         raise NotImplementedError
+
+    def drone_environment(
+        self, drone_uuid: str, meta_data_translation_mapping: dict = None
+    ):
+        """
+        Method to get the drone environment to be exported to batch jobs
+        providing the actual resources in the overlay batch system. It
+        translates units of drone meta data into a format the overlay
+        batch system is expecting. In addition, the drone_uuid is adding to
+        allow for matching drones to actual resources provided in the overlay
+        batch system.
+        :param drone_uuid: The unique id which is assigned to every drone on creation
+        :type drone_uuid: str
+        :param meta_data_translation_mapping: Mapping used for the meta data translation
+        :type meta_data_translation_mapping: dict
+        :return: Translated
+        :rtype: dict
+        """
+        meta_data_translation_mapping = meta_data_translation_mapping or {
+            "Cores": 1,
+            "Memory": 1024,
+            "Disk": 1024,
+        }  # defaults to units expected by HTCondor
+        try:
+            drone_environment = {
+                key: meta_data_translation_mapping[key] * value
+                for key, value in self.machine_meta_data.items()
+            }
+        except KeyError as ke:
+            logger.critical(f"drone_environment failed: no translation known for {ke}")
+            raise
+        else:
+            drone_environment["Uuid"] = drone_uuid
+
+        return drone_environment

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -40,6 +40,7 @@ class Drone(Pool):
         self.resource_attributes = AttributeDict(
             site_name=self._site_agent.site_name,
             machine_type=self.site_agent.machine_type,
+            machine_meta_data_translation_mapping=self.batch_system_agent.machine_meta_data_translation_mapping,  # noqa B950
             remote_resource_uuid=remote_resource_uuid,
             created=created or datetime.now(),
             updated=updated or datetime.now(),

--- a/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
+++ b/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
@@ -67,6 +67,6 @@ class TestFakeBatchSystemAdapter(TestCase):
 
     def test_machine_meta_data_translation_map(self):
         self.assertEqual(
-            {"Cores": 1, "Memory": 1, "Disk": 1},
+            AttributeDict(Cores=1, Memory=1, Disk=1),
             self.fake_adapter.machine_meta_data_translation_mapping,
         )

--- a/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
+++ b/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
@@ -64,3 +64,9 @@ class TestFakeBatchSystemAdapter(TestCase):
         self.config.BatchSystem.utilisation = AttributeDict(get_value=lambda: 0.9)
         self.fake_adapter = FakeBatchSystemAdapter()
         self.assertEqual(run_async(self.fake_adapter.get_utilisation, "test-123"), 0.9)
+
+    def test_machine_meta_data_translation_map(self):
+        self.assertEqual(
+            {"Cores": 1, "Memory": 1, "Disk": 1},
+            self.fake_adapter.machine_meta_data_translation_mapping,
+        )

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -255,3 +255,9 @@ class TestHTCondorAdapter(TestCase):
             min([self.cpu_ratio, self.memory_ratio]),
         )
         self.mock_async_run_command.assert_called_with(self.command)
+
+    def test_machine_meta_data_translation_mapping(self):
+        self.assertEqual(
+            {"Cores": 1, "Memory": 1024, "Disk": 1024 * 1024},
+            self.htcondor_adapter.machine_meta_data_translation_mapping,
+        )

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -4,6 +4,7 @@ from tardis.adapters.batchsystems.htcondor import HTCondorAdapter
 from tardis.adapters.batchsystems.htcondor import htcondor_status_updater
 from tardis.interfaces.batchsystemadapter import MachineStatus
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
+from tardis.utilities.attributedict import AttributeDict
 
 from functools import partial
 from shlex import quote
@@ -258,6 +259,6 @@ class TestHTCondorAdapter(TestCase):
 
     def test_machine_meta_data_translation_mapping(self):
         self.assertEqual(
-            {"Cores": 1, "Memory": 1024, "Disk": 1024 * 1024},
+            AttributeDict(Cores=1, Memory=1024, Disk=1024 * 1024),
             self.htcondor_adapter.machine_meta_data_translation_mapping,
         )

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -205,6 +205,6 @@ class TestSlurmAdapter(TestCase):
 
     def test_machine_meta_data_translation(self):
         self.assertEqual(
-            {"Cores": 1, "Memory": 1000, "Disk": 1000},
+            AttributeDict(Cores=1, Memory=1000, Disk=1000),
             self.slurm_adapter.machine_meta_data_translation_mapping,
         )

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -202,3 +202,9 @@ class TestSlurmAdapter(TestCase):
             run_async(self.slurm_adapter.get_utilisation, drone_uuid="not_exists"),
             0.0,
         )
+
+    def test_machine_meta_data_translation(self):
+        self.assertEqual(
+            {"Cores": 1, "Memory": 1000, "Disk": 1000},
+            self.slurm_adapter.machine_meta_data_translation_mapping,
+        )

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -99,11 +99,11 @@ class TestHTCondorSiteAdapter(TestCase):
             self.adapter.deploy_resource,
             AttributeDict(
                 drone_uuid="test-123",
-                machine_meta_data_translation_mapping={
-                    "Cores": 1,
-                    "Memory": 1024,
-                    "Disk": 1024 * 1024,
-                },
+                machine_meta_data_translation_mapping=AttributeDict(
+                    Cores=1,
+                    Memory=1024,
+                    Disk=1024 * 1024,
+                ),
             ),
         )
         self.assertEqual(response.remote_resource_uuid, "1351043")
@@ -125,11 +125,11 @@ class TestHTCondorSiteAdapter(TestCase):
                     self.adapter.deploy_resource,
                     AttributeDict(
                         drone_uuid="test-123",
-                        machine_meta_data_translation_mapping={
-                            "Cores": 1,
-                            "Memory": 1024,
-                            "Disk": 1024 * 1024,
-                        },
+                        machine_meta_data_translation_mapping=AttributeDict(
+                            Cores=1,
+                            Memory=1024,
+                            Disk=1024 * 1024,
+                        ),
                     ),
                 )
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -42,11 +42,11 @@ log = logs/cluster.log
 
 accounting_group=tardis
 
-environment=TardisDroneCores=8;TardisDroneMemory=32768;TardisDroneDisk=163840;TardisDroneUuid=test-123
+environment=TardisDroneCores=8;TardisDroneMemory=32768;TardisDroneDisk=167772160;TardisDroneUuid=test-123
 
 request_cpus=8
 request_memory=32768
-request_disk=163840
+request_disk=167772160
 
 queue 1"""  # noqa: B950
 
@@ -96,7 +96,15 @@ class TestHTCondorSiteAdapter(TestCase):
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
         response = run_async(
-            self.adapter.deploy_resource, AttributeDict(drone_uuid="test-123")
+            self.adapter.deploy_resource,
+            AttributeDict(
+                drone_uuid="test-123",
+                machine_meta_data_translation_mapping={
+                    "Cores": 1,
+                    "Memory": 1024,
+                    "Disk": 1024 * 1024,
+                },
+            ),
         )
         self.assertEqual(response.remote_resource_uuid, "1351043")
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
@@ -114,7 +122,15 @@ class TestHTCondorSiteAdapter(TestCase):
         with self.assertLogs(logging.getLogger(), logging.ERROR):
             with self.assertRaises(KeyError):
                 run_async(
-                    self.adapter.deploy_resource, AttributeDict(drone_uuid="test-123")
+                    self.adapter.deploy_resource,
+                    AttributeDict(
+                        drone_uuid="test-123",
+                        machine_meta_data_translation_mapping={
+                            "Cores": 1,
+                            "Memory": 1024,
+                            "Disk": 1024 * 1024,
+                        },
+                    ),
                 )
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -162,11 +162,11 @@ class TestSlurmAdapter(TestCase):
             resource_attributes=AttributeDict(
                 machine_type="test2large",
                 site_name="TestSite",
-                machine_meta_data_translation_mapping={
-                    "Cores": 1,
-                    "Memory": 1000,
-                    "Disk": 1000,
-                },
+                machine_meta_data_translation_mapping=AttributeDict(
+                    Cores=1,
+                    Memory=1000,
+                    Disk=1000,
+                ),
                 drone_uuid="testsite-1390065",
             ),
         )
@@ -199,11 +199,11 @@ class TestSlurmAdapter(TestCase):
             resource_attributes=AttributeDict(
                 machine_type="test2large",
                 site_name="TestSite",
-                machine_meta_data_translation_mapping={
-                    "Cores": 1,
-                    "Memory": 1000,
-                    "Disk": 1000,
-                },
+                machine_meta_data_translation_mapping=AttributeDict(
+                    Cores=1,
+                    Memory=1000,
+                    Disk=1000,
+                ),
                 drone_uuid="testsite-1390065",
             ),
         )

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -114,7 +114,7 @@ class TestSlurmAdapter(TestCase):
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=20, Memory=62))
+        return AttributeDict(test2large=AttributeDict(Cores=20, Memory=62, Disk=100))
 
     @property
     def machine_type_configuration(self):
@@ -162,6 +162,11 @@ class TestSlurmAdapter(TestCase):
             resource_attributes=AttributeDict(
                 machine_type="test2large",
                 site_name="TestSite",
+                machine_meta_data_translation_mapping={
+                    "Cores": 1,
+                    "Memory": 1000,
+                    "Disk": 1000,
+                },
                 drone_uuid="testsite-1390065",
             ),
         )
@@ -178,7 +183,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=63488,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
@@ -194,12 +199,17 @@ class TestSlurmAdapter(TestCase):
             resource_attributes=AttributeDict(
                 machine_type="test2large",
                 site_name="TestSite",
+                machine_meta_data_translation_mapping={
+                    "Cores": 1,
+                    "Memory": 1000,
+                    "Disk": 1000,
+                },
                 drone_uuid="testsite-1390065",
             ),
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=63488,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -114,7 +114,7 @@ class TestSlurmAdapter(TestCase):
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=20, Memory="62"))
+        return AttributeDict(test2large=AttributeDict(Cores=20, Memory=62))
 
     @property
     def machine_type_configuration(self):
@@ -160,7 +160,9 @@ class TestSlurmAdapter(TestCase):
         returned_resource_attributes = run_async(
             self.slurm_adapter.deploy_resource,
             resource_attributes=AttributeDict(
-                machine_type="test2large", site_name="TestSite"
+                machine_type="test2large",
+                site_name="TestSite",
+                drone_uuid="testsite-1390065",
             ),
         )
 
@@ -176,7 +178,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=63488,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
@@ -190,12 +192,14 @@ class TestSlurmAdapter(TestCase):
         run_async(
             slurm_adapter.deploy_resource,
             resource_attributes=AttributeDict(
-                machine_type="test2large", site_name="TestSite"
+                machine_type="test2large",
+                site_name="TestSite",
+                drone_uuid="testsite-1390065",
             ),
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=63488,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/agents_t/test_batchsystemagent.py
+++ b/tests/agents_t/test_batchsystemagent.py
@@ -4,7 +4,7 @@ from tardis.agents.batchsystemagent import BatchSystemAgent
 from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
 
 from unittest import TestCase
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, PropertyMock
 
 
 class TestBatchSystemAgent(TestCase):
@@ -41,3 +41,19 @@ class TestBatchSystemAgent(TestCase):
         self.batch_system_adapter.get_utilisation.side_effect = async_return
         run_async(self.batch_system_agent.get_utilisation, drone_uuid="test")
         self.batch_system_adapter.get_utilisation.assert_called_with("test")
+
+    def test_machine_meta_data_translation_mapping(self):
+        machine_meta_data_translation_mock = PropertyMock(
+            return_value={"Cores": 1, "Memory": 1024, "Disk": 1024}
+        )
+
+        type(
+            self.batch_system_adapter
+        ).machine_meta_data_translation_mapping = machine_meta_data_translation_mock
+
+        self.assertEqual(
+            {"Cores": 1, "Memory": 1024, "Disk": 1024},
+            self.batch_system_agent.machine_meta_data_translation_mapping,
+        )
+
+        machine_meta_data_translation_mock.assert_called_once_with()

--- a/tests/agents_t/test_batchsystemagent.py
+++ b/tests/agents_t/test_batchsystemagent.py
@@ -2,6 +2,7 @@ from ..utilities.utilities import run_async
 from ..utilities.utilities import async_return
 from tardis.agents.batchsystemagent import BatchSystemAgent
 from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
+from tardis.utilities.attributedict import AttributeDict
 
 from unittest import TestCase
 from unittest.mock import create_autospec, PropertyMock
@@ -44,7 +45,7 @@ class TestBatchSystemAgent(TestCase):
 
     def test_machine_meta_data_translation_mapping(self):
         machine_meta_data_translation_mock = PropertyMock(
-            return_value={"Cores": 1, "Memory": 1024, "Disk": 1024}
+            return_value=AttributeDict(Cores=1, Memory=1024, Disk=1024)
         )
 
         type(
@@ -52,7 +53,7 @@ class TestBatchSystemAgent(TestCase):
         ).machine_meta_data_translation_mapping = machine_meta_data_translation_mock
 
         self.assertEqual(
-            {"Cores": 1, "Memory": 1024, "Disk": 1024},
+            AttributeDict(Cores=1, Memory=1024, Disk=1024),
             self.batch_system_agent.machine_meta_data_translation_mapping,
         )
 

--- a/tests/interfaces_t/test_batchsystemadapter.py
+++ b/tests/interfaces_t/test_batchsystemadapter.py
@@ -1,0 +1,40 @@
+from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
+
+from ..utilities.utilities import run_async
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestBatchSystemAdapter(TestCase):
+    @patch.multiple(BatchSystemAdapter, __abstractmethods__=set())
+    def setUp(self) -> None:
+        self.batch_system_adapter = BatchSystemAdapter()
+
+    def test_disintegrate_machine(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.disintegrate_machine, "test-123")
+
+    def test_drain_machine(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.drain_machine, "test-123")
+
+    def test_integrate_machine(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.integrate_machine, "test-123")
+
+    def test_get_allocation(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.get_allocation, "test-123")
+
+    def test_get_machine_status(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.get_machine_status, "test-123")
+
+    def test_get_utilisation(self):
+        with self.assertRaises(NotImplementedError):
+            run_async(self.batch_system_adapter.get_utilisation, "test-123")
+
+    def test_machine_meta_data_translation_mapping(self):
+        with self.assertRaises(NotImplementedError):
+            self.batch_system_adapter.machine_meta_data_translation_mapping

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -78,6 +78,31 @@ class TestSiteAdapter(TestCase):
         self.site_adapter._machine_type = "TestFlavour"
         self.assertEqual(self.site_adapter.machine_meta_data, "Test")
 
+    def test_drone_environment(self):
+        self.site_adapter._configuration = AttributeDict(
+            MachineMetaData=AttributeDict(
+                test1xxl=AttributeDict(Cores=128, Memory=512, Disk=100)
+            )
+        )
+        self.site_adapter._machine_type = "test1xxl"
+
+        self.assertEqual(
+            {"Cores": 128, "Disk": 102400, "Memory": 524288, "Uuid": "test-123"},
+            self.site_adapter.drone_environment(drone_uuid="test-123"),
+        )
+
+        self.assertEqual(
+            {"Cores": 128, "Memory": 0.5, "Disk": 0.1, "Uuid": "test-123"},
+            self.site_adapter.drone_environment(
+                drone_uuid="test-123",
+                meta_data_translation_mapping={
+                    "Cores": 1,
+                    "Memory": 1.0 / 1024.0,
+                    "Disk": 1.0 / 1000.0,
+                },
+            ),
+        )
+
     def test_drone_minimum_lifetime(self):
         self.assertEqual(self.site_adapter.drone_minimum_lifetime, None)
 

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -87,18 +87,13 @@ class TestSiteAdapter(TestCase):
         self.site_adapter._machine_type = "test1xxl"
 
         self.assertEqual(
-            {"Cores": 128, "Disk": 102400, "Memory": 524288, "Uuid": "test-123"},
-            self.site_adapter.drone_environment(drone_uuid="test-123"),
-        )
-
-        self.assertEqual(
-            {"Cores": 128, "Memory": 0.5, "Disk": 0.1, "Uuid": "test-123"},
+            {"Cores": 128, "Memory": 524288, "Disk": 104857600, "Uuid": "test-123"},
             self.site_adapter.drone_environment(
                 drone_uuid="test-123",
                 meta_data_translation_mapping={
                     "Cores": 1,
-                    "Memory": 1.0 / 1024.0,
-                    "Disk": 1.0 / 1000.0,
+                    "Memory": 1024,
+                    "Disk": 1024 * 1024,
                 },
             ),
         )

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -87,14 +87,14 @@ class TestSiteAdapter(TestCase):
         self.site_adapter._machine_type = "test1xxl"
 
         self.assertEqual(
-            {"Cores": 128, "Memory": 524288, "Disk": 104857600, "Uuid": "test-123"},
+            AttributeDict(Cores=128, Memory=524288, Disk=104857600, Uuid="test-123"),
             self.site_adapter.drone_environment(
                 drone_uuid="test-123",
-                meta_data_translation_mapping={
-                    "Cores": 1,
-                    "Memory": 1024,
-                    "Disk": 1024 * 1024,
-                },
+                meta_data_translation_mapping=AttributeDict(
+                    Cores=1,
+                    Memory=1024,
+                    Disk=1024 * 1024,
+                ),
             ),
         )
 


### PR DESCRIPTION
Dear all,

this pull request adds a feature needed for the RWTH Aachen HPC cluster. 

The RWTH Aachen HPC cluster does not use whole node scheduling as other HPCs do. Thus, it can happen that two different drones represented by a batch job run on the very same node. Currently, the drone to resource matching for resources provided by the `SlurmSiteAdapter` in the OBS is done via the host name of the worker node. That will fail in the case described above.

We already have a solution in place for the TOPAS cluster and thus for the HTCondor Site Adapter. The drone meta data like allocated cores, memory as well as the drone uuid is exported to the actual batch jobs representing the drone. This environment variables are then used to configure the OBS node accordingly. In addition, the drone uuid is used as `STARTD_NAME` in the HTCondor OBS in order to uniquely match drones to the underlying resources in the OBS. See the corresponding HTCondor configuration snippet below.

```
TardisDroneUuid = "$ENV(TardisDroneUuid)"
# Modify STARTD_NAME since multiple drones can run on the same host
STARTD_NAME = $ENV(TardisDroneUuid)

# Limit CPU and Memory to the capacity of the pilot
NUM_CPUS = $ENV(TardisDroneCores)
MEMORY = $ENV(TardisDroneMemory)
```

This pull request exports the environment variables described above also in case the Slurm Site Adapter is used. So, that we can use the same solution also on the RWTH HPC cluster.

Best regards,
Manuel