### PR TITLE
Fix automated docker builds

### DIFF
--- a/containers/cobald-tardis/Dockerfile
+++ b/containers/cobald-tardis/Dockerfile
@@ -1,14 +1,14 @@
 FROM python:3.8-alpine
 MAINTAINER Manuel Giffels <giffels@gmail.com>
 ARG SOURCE_BRANCH=master
-ARG SOURCE_REPO=https://github.com/MatterMiners/tardis
+ARG SOURCE_REPO_URL=https://github.com/MatterMiners/tardis
 
 RUN apk add --no-cache --virtual .build_deps \
              build-base \
              openssl-dev \
              libffi-dev \
              git \
-    && pip install --no-cache-dir git+$SOURCE_REPO@$SOURCE_BRANCH \
+    && pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH \
     && apk del --no-network .build_deps
 
 WORKDIR /srv

--- a/containers/cobald-tardis/hooks/build
+++ b/containers/cobald-tardis/hooks/build
@@ -1,3 +1,4 @@
 #!/bin/bash
-
-docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg SOURCE_REPO=$(git remote get-url origin) -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+SOURCE_REPO_URL=$(git remote get-url origin)
+SOURCE_REPO_HTTPS_URL=${SOURCE_REPO_URL/git@github.com:/https:\/\/github.com\/}
+docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg SOURCE_REPO_URL=${SOURCE_REPO_HTTPS_URL} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-12-02, command
+.. Created by changelog.py at 2020-12-08, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 


### PR DESCRIPTION
Unfortunatly, the automated docker builds are currently broken for upstream repositories. 
The reason is that dockerhub clones the upstream repository via ssh using a deploy key, while forked repositories are cloned via https. The current build hook assumes that the repository is always cloned via https.

This pull request fixes this issue by introducing an automated conversion of the git+ssh url into the corresponding https url in the build hook, so that `pip install` inside the container can always rely on the https url to install the `TARDIS` package.

Thanks and best regards,
Manuel