### PR TITLE
Allow users to specify additional parameters for Moabs msub command

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -266,19 +266,19 @@ Available adapter configuration options
 
 .. content-tabs:: left-col
 
-    +----------------+---------------------------------------------------------------------------------------------+-----------------+
-    | Option         | Short Description                                                                           | Requirement     |
-    +================+=============================================================================================+=================+
-    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                      |  **Required**   |
-    +----------------+---------------------------------------------------------------------------------------------+-----------------+
-    | StartupCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!) |  **Deprecated** |
-    +----------------+---------------------------------------------------------------------------------------------+-----------------+
-    | executor       | The |executor| used to run submission and further calls to the Moab batch system.           |  **Optional**   |
-    +                +                                                                                             +                 +
-    |                | Default: ShellExecutor is used!                                                             |                 |
-    +----------------+---------------------------------------------------------------------------------------------+-----------------+
-    | SubmitOptions  | Email list for the -M flag of Moabs msub command                                            |  **Optional**   |
-    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
+    | Option         | Short Description                                                                              | Requirement     |
+    +================+================================================================================================+=================+
+    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                         |  **Required**   |
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
+    | StartupCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!)    |  **Deprecated** |
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
+    | executor       | The |executor| used to run submission and further calls to the Moab batch system.              |  **Optional**   |
+    +                +                                                                                                +                 +
+    |                | Default: ShellExecutor is used!                                                                |                 |
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
+    | SubmitOptions  | Options to add to the `msub` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
 
     The available options in the `MachineTypeConfiguration` section are the expected `WallTime` of the placeholder jobs and
     the requested `NodeType`. For details see the Moab documentation.

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -277,6 +277,8 @@ Available adapter configuration options
     +                +                                                                                             +                 +
     |                | Default: ShellExecutor is used!                                                             |                 |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | Email          | Email list for the -M flag of Moabs msub command                                            |  **Optional**   |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
 
     The available options in the `MachineTypeConfiguration` section are the expected `WallTime` of the placeholder jobs and
     the requested `NodeType`. For details see the Moab documentation.

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -277,7 +277,7 @@ Available adapter configuration options
     +                +                                                                                             +                 +
     |                | Default: ShellExecutor is used!                                                             |                 |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
-    | Email          | Email list for the -M flag of Moabs msub command                                            |  **Optional**   |
+    | SubmitOptions  | Email list for the -M flag of Moabs msub command                                            |  **Optional**   |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
 
     The available options in the `MachineTypeConfiguration` section are the expected `WallTime` of the placeholder jobs and
@@ -309,6 +309,11 @@ Available adapter configuration options
               Walltime: '02:00:00:00'
               NodeType: '1:ppn=20'
               StartupCommand: startVM.py
+              SubmitOptions:
+                short:
+                  M: "someone@somewhere.com"
+                long:
+                  timeout: 60
             singularity_d1.large:
               Walltime: '01:00:00:00'
               NodeType: '1:ppn=20'

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -11,7 +11,7 @@ from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
 from ...utilities.utils import async_run_command
-from ...utilities.utils import scheduler_cmd_option_formatter
+from ...utilities.utils import submit_cmd_option_formatter
 from ...utilities.utils import csv_parser
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
@@ -31,7 +31,7 @@ async def slurm_status_updater(
     :rtype: dict
     """
 
-    options_string = scheduler_cmd_option_formatter(options)
+    options_string = submit_cmd_option_formatter(options)
 
     attributes_string = ",".join([str(x) for x in attributes.values()])
 

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -11,7 +11,7 @@ from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
 from ...utilities.utils import async_run_command
-from ...utilities.utils import slurm_cmd_option_formatter
+from ...utilities.utils import scheduler_cmd_option_formatter
 from ...utilities.utils import csv_parser
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
@@ -31,7 +31,7 @@ async def slurm_status_updater(
     :rtype: dict
     """
 
-    options_string = slurm_cmd_option_formatter(options)
+    options_string = scheduler_cmd_option_formatter(options)
 
     attributes_string = ",".join([str(x) for x in attributes.values()])
 

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -121,9 +121,7 @@ class MoabAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        request_command = (
-            f"msub -j oe -m p {self.msub_cmdline_options()} {self._startup_command}"
-        )
+        request_command = f"msub {self.msub_cmdline_options()} {self._startup_command}"
         result = await self._executor.run_command(request_command)
         logger.debug(f"{self.site_name} servers create returned {result}")
 
@@ -220,6 +218,8 @@ class MoabAdapter(SiteAdapter):
             AttributeDict(
                 short=AttributeDict(
                     **sbatch_options.get("short", AttributeDict()),
+                    j="oe",
+                    m="p",
                     l=f"walltime={walltime},mem={mem}gb,nodes={node_type}",
                 ),
                 long=AttributeDict(

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -10,7 +10,7 @@ from ...utilities.attributedict import AttributeDict
 from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
-from ...utilities.utils import scheduler_cmd_option_formatter
+from ...utilities.utils import submit_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -213,7 +213,7 @@ class MoabAdapter(SiteAdapter):
         return await self.terminate_resource(resource_attributes)
 
     def msub_cmdline_options(self):
-        cmd_string = scheduler_cmd_option_formatter(
+        cmd_string = submit_cmd_option_formatter(
             self.machine_type_configuration.get("SubmitOptions", AttributeDict())
         )
         # Add trailing space at end if not already present

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -66,6 +66,8 @@ class MoabAdapter(SiteAdapter):
 
         self._executor = getattr(self._configuration, "executor", ShellExecutor())
 
+        self._email = getattr(self._configuration, "Email", None)
+
         self._moab_status = AsyncCacheMap(
             update_coroutine=partial(moab_status_updater, self._executor),
             max_age=self._configuration.StatusUpdate * 60,
@@ -120,9 +122,10 @@ class MoabAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
+        email = f"-M {self._email} " if self._email is not None else ""
         request_command = (
-            f"msub -j oe -m p -l "
-            f"walltime={self.machine_type_configuration.Walltime},"
+            f"msub -j oe -m p {email}"
+            f"-l walltime={self.machine_type_configuration.Walltime},"
             f"mem={self.machine_meta_data.Memory}gb,"
             f"nodes={self.machine_type_configuration.NodeType} "
             f"{self._startup_command}"

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -11,7 +11,7 @@ from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.utils import csv_parser
-from ...utilities.utils import slurm_cmd_option_formatter
+from ...utilities.utils import scheduler_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -109,7 +109,7 @@ class SlurmAdapter(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
 
-        sbatch_cmdline_option_string = slurm_cmd_option_formatter(
+        sbatch_cmdline_option_string = scheduler_cmd_option_formatter(
             self.sbatch_cmdline_options(
                 resource_attributes.drone_uuid,
                 resource_attributes.machine_meta_data_translation_mapping,

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -11,7 +11,7 @@ from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.utils import csv_parser
-from ...utilities.utils import scheduler_cmd_option_formatter
+from ...utilities.utils import submit_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -109,7 +109,7 @@ class SlurmAdapter(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
 
-        sbatch_cmdline_option_string = scheduler_cmd_option_formatter(
+        sbatch_cmdline_option_string = submit_cmd_option_formatter(
             self.sbatch_cmdline_options(
                 resource_attributes.drone_uuid,
                 resource_attributes.machine_meta_data_translation_mapping,

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -103,3 +103,11 @@ def slurm_cmd_option_formatter(options: AttributeDict) -> str:
             option_string += tmp_option_string
 
     return option_string
+
+
+def moab_cmd_option_formatter(options: AttributeDict) -> str:
+    cmd_string = slurm_cmd_option_formatter(options)
+    # Add trailing space at end if not already present
+    if cmd_string != "" and not cmd_string.endswith(" "):
+        cmd_string += " "
+    return cmd_string

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -98,10 +98,9 @@ def submit_cmd_option_formatter(options: AttributeDict) -> str:
         except AttributeError:
             pass
         else:
-            # add additional space between short and long options if there are long
-            # options
-            if option_string and "long" in options and options["long"] != {}:
+            # add additional space between short and long options
+            if option_string:
                 option_string += " "
             option_string += tmp_option_string
 
-    return option_string
+    return option_string.strip()

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -82,7 +82,7 @@ def csv_parser(
             }
 
 
-def scheduler_cmd_option_formatter(options: AttributeDict) -> str:
+def submit_cmd_option_formatter(options: AttributeDict) -> str:
     option_prefix = dict(short="-", long="--")
     option_separator = dict(short=" ", long="=")
 

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -82,7 +82,7 @@ def csv_parser(
             }
 
 
-def slurm_cmd_option_formatter(options: AttributeDict) -> str:
+def scheduler_cmd_option_formatter(options: AttributeDict) -> str:
     option_prefix = dict(short="-", long="--")
     option_separator = dict(short=" ", long="=")
 
@@ -103,11 +103,3 @@ def slurm_cmd_option_formatter(options: AttributeDict) -> str:
             option_string += tmp_option_string
 
     return option_string
-
-
-def moab_cmd_option_formatter(options: AttributeDict) -> str:
-    cmd_string = slurm_cmd_option_formatter(options)
-    # Add trailing space at end if not already present
-    if cmd_string != "" and not cmd_string.endswith(" "):
-        cmd_string += " "
-    return cmd_string

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -98,7 +98,9 @@ def submit_cmd_option_formatter(options: AttributeDict) -> str:
         except AttributeError:
             pass
         else:
-            if option_string:  # add additional space between short and long options
+            # add additional space between short and long options if there are long
+            # options
+            if option_string and "long" in options and options["long"] != {}:
                 option_string += " "
             option_string += tmp_option_string
 

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -157,6 +157,7 @@ class TestMoabAdapter(TestCase):
                 "StatusUpdate",
                 "MachineTypeConfiguration",
                 "executor",
+                "Email",
             ]
         )
         self.test_site_config = config.TestSite
@@ -164,8 +165,31 @@ class TestMoabAdapter(TestCase):
         self.test_site_config.StatusUpdate = 10
         self.test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         self.test_site_config.executor = self.mock_executor.return_value
+        self.test_site_config.Email = None
 
         self.moab_adapter = MoabAdapter(machine_type="test2large", site_name="TestSite")
+
+        config.TestSiteEmail = MagicMock(
+            spec=[
+                "MachineMetaData",
+                "StatusUpdate",
+                "MachineTypeConfiguration",
+                "executor",
+                "Email",
+            ]
+        )
+        self.test_site_config_email = config.TestSiteEmail
+        self.test_site_config_email.MachineMetaData = self.machine_meta_data
+        self.test_site_config_email.StatusUpdate = 10
+        self.test_site_config_email.MachineTypeConfiguration = (
+            self.machine_type_configuration
+        )
+        self.test_site_config_email.executor = self.mock_executor.return_value
+        self.test_site_config_email.Email = "someone@somewhere.com"
+
+        self.moab_adapter_email = MoabAdapter(
+            machine_type="test2large", site_name="TestSiteEmail"
+        )
 
     def tearDown(self):
         pass
@@ -227,11 +251,10 @@ class TestMoabAdapter(TestCase):
                 machine_type="test2large", site_name="TestSite"
             ),
         )
-        if (
-            return_resource_attributes.created - expected_resource_attributes.created
-            > timedelta(seconds=1)
-            or return_resource_attributes.updated - expected_resource_attributes.updated
-            > timedelta(seconds=1)
+        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(
+            seconds=1
+        ) or return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(
+            seconds=1
         ):
             raise Exception("Creation time or update time wrong!")
         del (
@@ -243,6 +266,18 @@ class TestMoabAdapter(TestCase):
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
         self.mock_executor.return_value.run_command.assert_called_with(
             "msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py"  # noqa: B950
+        )
+
+    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    def test_deploy_resource_email(self):
+        run_async(
+            self.moab_adapter_email.deploy_resource,
+            resource_attributes=AttributeDict(
+                machine_type="test2large", site_name="TestSiteEmail"
+            ),
+        )
+        self.mock_executor.return_value.run_command.assert_called_with(
+            "msub -j oe -m p -M someone@somewhere.com -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -227,10 +227,11 @@ class TestMoabAdapter(TestCase):
                 machine_type="test2large", site_name="TestSite"
             ),
         )
-        if return_resource_attributes.created - expected_resource_attributes.created > timedelta(
-            seconds=1
-        ) or return_resource_attributes.updated - expected_resource_attributes.updated > timedelta(
-            seconds=1
+        if (
+            return_resource_attributes.created - expected_resource_attributes.created
+            > timedelta(seconds=1)
+            or return_resource_attributes.updated - expected_resource_attributes.updated
+            > timedelta(seconds=1)
         ):
             raise Exception("Creation time or update time wrong!")
         del (
@@ -246,9 +247,11 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource_w_submit_options(self):
-        self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = AttributeDict(
-            short=AttributeDict(M="someone@somewhere.com"),
-            long=AttributeDict(timeout=60),
+        self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = (
+            AttributeDict(
+                short=AttributeDict(M="someone@somewhere.com"),
+                long=AttributeDict(timeout=60),
+            )
         )
 
         moab_adapter = MoabAdapter(machine_type="test2large", site_name="TestSite")
@@ -256,7 +259,8 @@ class TestMoabAdapter(TestCase):
         run_async(
             moab_adapter.deploy_resource,
             resource_attributes=AttributeDict(
-                machine_type="test2large", site_name="TestSite",
+                machine_type="test2large",
+                site_name="TestSite",
             ),
         )
         self.mock_executor.return_value.run_command.assert_called_with(

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -264,7 +264,7 @@ class TestMoabAdapter(TestCase):
             ),
         )
         self.mock_executor.return_value.run_command.assert_called_with(
-            "msub -j oe -m p -M someone@somewhere.com -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 --timeout=60 startVM.py"  # noqa: B950
+            "msub -M someone@somewhere.com -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 --timeout=60 startVM.py"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -264,7 +264,7 @@ class TestMoabAdapter(TestCase):
             ),
         )
         self.mock_executor.return_value.run_command.assert_called_with(
-            "msub -j oe -m p -M someone@somewhere.com --timeout=60 -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py"  # noqa: B950
+            "msub -j oe -m p -M someone@somewhere.com -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 --timeout=60 startVM.py"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -2,7 +2,7 @@ from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.utils import async_run_command
 from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import csv_parser
-from tardis.utilities.utils import slurm_cmd_option_formatter
+from tardis.utilities.utils import scheduler_cmd_option_formatter
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from ..utilities.utilities import run_async
@@ -114,19 +114,19 @@ class TestCSVParser(TestCase):
 
 
 class TestSlurmCMDOptionFormatter(TestCase):
-    def test_slurm_cmd_option_formatter(self):
+    def test_scheduler_cmd_option_formatter(self):
         options = AttributeDict()
-        option_string = slurm_cmd_option_formatter(options)
+        option_string = scheduler_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "")
 
         options = AttributeDict(short=AttributeDict(foo="bar", test=None))
-        option_string = slurm_cmd_option_formatter(options)
+        option_string = scheduler_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "-foo bar -test")
 
         options = AttributeDict(long=AttributeDict(foo="bar", test=None))
-        option_string = slurm_cmd_option_formatter(options)
+        option_string = scheduler_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "--foo=bar --test")
 
@@ -134,7 +134,7 @@ class TestSlurmCMDOptionFormatter(TestCase):
             short=AttributeDict(foo="bar", test=None),
             long=AttributeDict(foo_long="bar_long", test_long=None),
         )
-        option_string = slurm_cmd_option_formatter(options)
+        option_string = scheduler_cmd_option_formatter(options)
 
         self.assertEqual(
             option_string, "-foo bar -test --foo_long=bar_long --test_long"

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -2,7 +2,7 @@ from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.utils import async_run_command
 from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import csv_parser
-from tardis.utilities.utils import scheduler_cmd_option_formatter
+from tardis.utilities.utils import submit_cmd_option_formatter
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from ..utilities.utilities import run_async
@@ -114,19 +114,19 @@ class TestCSVParser(TestCase):
 
 
 class TestSlurmCMDOptionFormatter(TestCase):
-    def test_scheduler_cmd_option_formatter(self):
+    def test_submit_cmd_option_formatter(self):
         options = AttributeDict()
-        option_string = scheduler_cmd_option_formatter(options)
+        option_string = submit_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "")
 
         options = AttributeDict(short=AttributeDict(foo="bar", test=None))
-        option_string = scheduler_cmd_option_formatter(options)
+        option_string = submit_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "-foo bar -test")
 
         options = AttributeDict(long=AttributeDict(foo="bar", test=None))
-        option_string = scheduler_cmd_option_formatter(options)
+        option_string = submit_cmd_option_formatter(options)
 
         self.assertEqual(option_string, "--foo=bar --test")
 
@@ -134,7 +134,7 @@ class TestSlurmCMDOptionFormatter(TestCase):
             short=AttributeDict(foo="bar", test=None),
             long=AttributeDict(foo_long="bar_long", test_long=None),
         )
-        option_string = scheduler_cmd_option_formatter(options)
+        option_string = submit_cmd_option_formatter(options)
 
         self.assertEqual(
             option_string, "-foo bar -test --foo_long=bar_long --test_long"


### PR DESCRIPTION
Even if `-m p` is set in the Moab msub command, emails are for some reason still sent when a job is canceled. This exposes the `-M` command line option of msub to the user via the site configuration, which allows to route those emails to an alternative email address. 