### PR TITLE
Adding rust and cargo as build dependencies

### DIFF
--- a/containers/cobald-tardis/Dockerfile
+++ b/containers/cobald-tardis/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache --virtual .build_deps \
              openssl-dev \
              libffi-dev \
              git \
+             rust \
+             cargo \
     && pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH \
     && apk del --no-network .build_deps
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2020-12-09, command
+.. Created by changelog.py at 2021-02-12, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 


### PR DESCRIPTION
This pull request fixes latest docker build issues due to the dependency of the cryptography package on rust and cargo. 

See https://github.com/pyca/cryptography/issues/5771 for details!