### PR TITLE
Add configurable drone heartbeat interval

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -31,17 +31,19 @@ Available configuration options
 
 .. container:: left-col
 
-    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | Option                 | Short Description                                                                                                     |  Requirement  |
-    +========================+=======================================================================================================================+===============+
-    | name                   | Name of the site                                                                                                      |  **Required** |
-    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | adapter                | Site adapter to use. Adapter will be auto-imported (class name without Adapter)                                       |  **Required** |
-    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | quota                  | Core quota to be used for this site. Negative values are interpreted as infinity                                      |  **Required** |
-    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
-    | drone_minimum_lifetime | Time in seconds the drone will remain in :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. |  **Optional** |
-    +------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | Option                   | Short Description                                                                                                     |  Requirement  |
+    +==========================+=======================================================================================================================+===============+
+    | name                     | Name of the site                                                                                                      |  **Required** |
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | adapter                  | Site adapter to use. Adapter will be auto-imported (class name without Adapter)                                       |  **Required** |
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | quota                    | Core quota to be used for this site. Negative values are interpreted as infinity                                      |  **Required** |
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | drone_heartbeat_interval | Time in seconds between two consecutive executions of :py:meth:`tardis.resources.drone.run`. Defaults to 60s.         |  **Optional** |
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
+    | drone_minimum_lifetime   | Time in seconds the drone will remain in :py:class:`~tardis.resources.dronestates.AvailableState` before draining it. |  **Optional** |
+    +--------------------------+-----------------------------------------------------------------------------------------------------------------------+---------------+
 
     For each site in the `Sites` configuration block. A site specific configuration block carrying the site name
     has to be added to the configuration as well.
@@ -67,6 +69,7 @@ Available configuration options
           - name: MySiteName_1
             adapter: MyAdapter2Use
             quota: 123
+            drone_heartbeat_interval: 10
             drone_minimum_lifetime: 3600
           - name: MySiteName_2
             adapter: OtherAdapter2Use

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,15 +9,15 @@ CHANGELOG
 [Unreleased] - 2021-03-19
 =========================
 
-Fixed
------
-
-* Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
-
 Added
 -----
 
 * An optional and per site configurable drone heartbeat interval has been added
+
+Fixed
+-----
+
+* Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
 
 [0.5.0] - 2020-12-09
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-03-19, command
+.. Created by changelog.py at 2021-03-22, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-03-19
+[Unreleased] - 2021-03-22
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-03-18, command
+.. Created by changelog.py at 2021-03-19, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-03-18
+[Unreleased] - 2021-03-19
 =========================
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ Fixed
 
 * Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
 
+Added
+-----
+
+* An optional and per site configurable drone heartbeat interval has been added
+
 [0.5.0] - 2020-12-09
 ====================
 

--- a/docs/source/changes/166.add_drone_heartbeat_interval.yaml
+++ b/docs/source/changes/166.add_drone_heartbeat_interval.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: "An optional and per site configurable drone heartbeat interval has been added"
+description: |
+  Add an optional and per site configurable drone heartbeat interval to TARDIS. The heartbeat interval is defined as
+  the time between two consecutive calls of the drones run method. The heartbeat interval defaults to 60s.
+issues:
+- 165
+pull requests:
+- 166

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -32,6 +32,10 @@ class SiteAgent(SiteAdapter):
         return NotImplemented
 
     @property
+    def drone_heartbeat_interval(self) -> int:
+        return self._site_adapter.drone_heartbeat_interval
+
+    @property
     def drone_minimum_lifetime(self) -> int:
         return self._site_adapter.drone_minimum_lifetime
 

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -107,10 +107,13 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def drone_heartbeat_interval(self) -> int:
-        try:
-            return self.site_configuration.drone_heartbeat_interval
-        except AttributeError:
-            return 60
+        """
+        Property that returns the configuration parameter drone_heartbeat_interval.
+        It describes the time between two consecutive updates of the drone status.
+        :return: The heartbeat interval of the drone
+        :rtype: int
+        """
+        return self.site_configuration.drone_heartbeat_interval
 
     @property
     def drone_minimum_lifetime(self) -> [int, None]:

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -22,6 +22,7 @@ class SiteConfigurationModel(BaseModel):
     adapter: str
     quota: Optional[int] = inf
     drone_minimum_lifetime: Optional[conint(gt=0)] = None
+    drone_heartbeat_interval: Optional[conint(ge=0)] = 60
 
     class Config:
         extra = "forbid"
@@ -103,6 +104,13 @@ class SiteAdapter(metaclass=ABCMeta):
             drone_environment["Uuid"] = drone_uuid
 
         return drone_environment
+
+    @property
+    def drone_heartbeat_interval(self) -> int:
+        try:
+            return self.site_configuration.drone_heartbeat_interval
+        except AttributeError:
+            return 60
 
     @property
     def drone_minimum_lifetime(self) -> [int, None]:

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -69,11 +69,11 @@ class Drone(Pool):
         self._demand = value
 
     @property
-    def drone_heartbeat_interval(self) -> int:
+    def heartbeat_interval(self) -> int:
         return self.site_agent.drone_heartbeat_interval
 
     @property
-    def drone_minimum_lifetime(self) -> [int, None]:
+    def minimum_lifetime(self) -> [int, None]:
         return self.site_agent.drone_minimum_lifetime
 
     @property
@@ -102,7 +102,7 @@ class Drone(Pool):
                 )
                 self._demand = 0
                 return
-            await asyncio.sleep(self.drone_heartbeat_interval)
+            await asyncio.sleep(self.heartbeat_interval)
 
     def register_plugins(self, observer: Union[List[Plugin], Plugin]) -> None:
         self._plugins.append(observer)

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -69,6 +69,10 @@ class Drone(Pool):
         self._demand = value
 
     @property
+    def drone_heartbeat_interval(self) -> int:
+        return self.site_agent.drone_heartbeat_interval
+
+    @property
     def drone_minimum_lifetime(self) -> [int, None]:
         return self.site_agent.drone_minimum_lifetime
 
@@ -98,7 +102,7 @@ class Drone(Pool):
                 )
                 self._demand = 0
                 return
-            await asyncio.sleep(60)
+            await asyncio.sleep(self.drone_heartbeat_interval)
 
     def register_plugins(self, observer: Union[List[Plugin], Plugin]) -> None:
         self._plugins.append(observer)

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -45,9 +45,9 @@ async def check_minimum_lifetime(
     state_transition, drone: "Drone", current_state: Type[State]
 ):
     if (
-        drone.drone_minimum_lifetime
+        drone.minimum_lifetime
         and (datetime.now() - drone.resource_attributes.updated).total_seconds()
-        > drone.drone_minimum_lifetime
+        > drone.minimum_lifetime
     ):
         raise StopProcessing(last_result=DrainState())
     return state_transition

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -23,6 +23,11 @@ class TestSiteAgent(TestCase):
         self.site_agent.drone_uuid(uuid="test")
         self.site_adapter.drone_uuid.assert_called_with(uuid="test")
 
+    def test_drone_heartbeat_interval(self):
+        self.site_adapter.drone_heartbeat_interval.return_value = 60
+        self.assertEqual(self.site_agent.drone_heartbeat_interval(), 60)
+        self.site_adapter.drone_heartbeat_interval.assert_called_with()
+
     def test_drone_minimum_lifetime(self):
         self.site_adapter.drone_minimum_lifetime.return_value = None
         self.assertIsNone(self.site_agent.drone_minimum_lifetime())

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -75,6 +75,24 @@ class TestSiteAdapter(TestCase):
                 ),
             )
 
+    def test_drone_heartbeat_interval(self):
+        self.assertEqual(self.site_adapter.drone_heartbeat_interval, 60)
+
+        # lru_cache needs to be cleared before manipulating site configuration
+        # noinspection PyUnresolvedReferences
+        SiteAdapter.site_configuration.fget.cache_clear()
+
+        self.config.Sites[0]["drone_heartbeat_interval"] = 10
+        self.assertEqual(self.site_adapter.drone_heartbeat_interval, 10)
+
+        # noinspection PyUnresolvedReferences
+        SiteAdapter.site_configuration.fget.cache_clear()
+
+        self.config.Sites[0]["drone_heartbeat_interval"] = -1
+        with self.assertRaises(ValidationError):
+            # noinspection PyStatementEffect
+            self.site_adapter.drone_heartbeat_interval
+
     def test_drone_minimum_lifetime(self):
         self.assertEqual(self.site_adapter.drone_minimum_lifetime, None)
 
@@ -194,6 +212,7 @@ class TestSiteAdapter(TestCase):
                 adapter="TestSite",
                 quota=1,
                 drone_minimum_lifetime=None,
+                drone_heartbeat_interval=60,
             ),
         )
 
@@ -209,6 +228,7 @@ class TestSiteAdapter(TestCase):
                 adapter="TestSite",
                 quota=inf,
                 drone_minimum_lifetime=None,
+                drone_heartbeat_interval=60,
             ),
         )
 
@@ -225,6 +245,7 @@ class TestSiteAdapter(TestCase):
                     adapter="TestSite",
                     quota=inf,
                     drone_minimum_lifetime=None,
+                    drone_heartbeat_interval=60,
                 ),
             )
 

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -33,6 +33,7 @@ class TestDrone(TestCase):
     def setUp(self) -> None:
         self.mock_site_agent.machine_meta_data = AttributeDict(Cores=8)
         self.mock_site_agent.drone_minimum_lifetime = None
+        self.mock_site_agent.drone_heartbeat_interval = 60
         self.mock_plugin = MagicMock(spec=Plugin)()
         self.mock_plugin.notify.return_value = async_return()
         self.drone = Drone(
@@ -52,6 +53,11 @@ class TestDrone(TestCase):
         self.assertEqual(self.drone.demand, 8)
         self.drone.demand = 0
         self.assertEqual(self.drone.demand, 0)
+
+    def test_heartbeat_interval(self):
+        self.assertEqual(self.drone.drone_heartbeat_interval, 60)
+        self.mock_site_agent.drone_heartbeat_interval = 10
+        self.assertEqual(self.drone.drone_heartbeat_interval, 10)
 
     def test_life_time(self):
         self.assertIsNone(self.drone.drone_minimum_lifetime, None)

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -55,14 +55,14 @@ class TestDrone(TestCase):
         self.assertEqual(self.drone.demand, 0)
 
     def test_heartbeat_interval(self):
-        self.assertEqual(self.drone.drone_heartbeat_interval, 60)
+        self.assertEqual(self.drone.heartbeat_interval, 60)
         self.mock_site_agent.drone_heartbeat_interval = 10
-        self.assertEqual(self.drone.drone_heartbeat_interval, 10)
+        self.assertEqual(self.drone.heartbeat_interval, 10)
 
     def test_life_time(self):
-        self.assertIsNone(self.drone.drone_minimum_lifetime, None)
+        self.assertIsNone(self.drone.minimum_lifetime, None)
         self.mock_site_agent.drone_minimum_lifetime = 3600
-        self.assertEqual(self.drone.drone_minimum_lifetime, 3600)
+        self.assertEqual(self.drone.minimum_lifetime, 3600)
 
     def test_maximum_demand(self):
         self.assertEqual(self.drone.maximum_demand, 8)

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -83,7 +83,8 @@ class TestDrone(TestCase):
         self.assertEqual(self.drone.site_agent, self.mock_site_agent)
 
     @patch("tardis.resources.drone.asyncio.sleep")
-    def test_run(self, mocked_asyncio_sleep=async_return()):
+    def test_run(self, mocked_asyncio_sleep):
+        mocked_asyncio_sleep.side_effect = async_return
         mocked_down_state = MagicMock(spec=DownState)
         mocked_down_state.run.return_value = async_return()
 

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -55,7 +55,7 @@ class TestDroneStates(TestCase):
         )
         self.drone.demand = 8.0
         self.drone._supply = 8.0
-        self.drone.drone_minimum_lifetime = 3600
+        self.drone.minimum_lifetime = 3600
         self.drone.set_state.side_effect = partial(mock_set_state, self.drone)
         self.drone.site_agent.deploy_resource.return_value = async_return(
             return_value=AttributeDict()
@@ -218,7 +218,7 @@ class TestDroneStates(TestCase):
 
         # Test draining procedure due to exceeding life time of the drone
         self.drone.demand = 8.0
-        self.drone.drone_minimum_lifetime = 1
+        self.drone.minimum_lifetime = 1
         self.drone.state.return_value = AvailableState()
         run_async(self.drone.state.return_value.run, self.drone)
         self.assertIsInstance(self.drone.state, DrainState)


### PR DESCRIPTION
This pull request adds a configurable `drone_heartbeat_interval`, which is currently hardcoded to 60s. The drone heartbeat interval is configurable per site, analogous to the `drone_minimum_lifetime`.  It describes the time between two consecutive executions of the async method `tardis.resources.drone.run()`. 

This pull request fixes #165.