### PR TITLE
Fix drone lifetime

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,10 +5,12 @@ Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
+ubdsv <ubdsv@student.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
-Peter Wienemann <peter.wienemann@uni-bonn.de>
-Max Fischer <maxfischer2781@gmail.com>
-Matthias Schnepf <matthias.schnepf@kit.edu>
 rfvc <florian.voncube@gmail.com>
+Matthias Schnepf <matthias.schnepf@kit.edu>
+PSchuhmacher <leon_schuhmacher@yahoo.de>
+Max Fischer <maxfischer2781@gmail.com>
+Peter Wienemann <peter.wienemann@uni-bonn.de>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,18 @@
-.. Created by changelog.py at 2021-03-17, command
+.. Created by changelog.py at 2021-03-18, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
+
+[Unreleased] - 2021-03-18
+=========================
+
+Fixed
+-----
+
+* Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
 
 [0.5.0] - 2020-12-09
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-02-20, command
+.. Created by changelog.py at 2021-03-17, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-02-12, command
+.. Created by changelog.py at 2021-02-20, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changes/169.fix_drone_lifetime.yaml
+++ b/docs/source/changes/169.fix_drone_lifetime.yaml
@@ -1,0 +1,11 @@
+category: fixed
+summary: "Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation"
+description: |
+    The `drone_minimum_lifetime` parameter is not working as expected and described in the documentation.
+    `drone_minimum_lifetime` is meant to be a generic site parameter. However the code is trying to look it up in the
+    site adapter specific section of the configuration. Since default values are applied if the parameter is not
+    present, it remains probably unnoted by users.
+pull requests:
+  - 169
+issues:
+  - 167

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "elasticsearch",
         "aioprometheus",
         "kubernetes_asyncio",
+        "pydantic",
     ],
     extras_require={
         "docs": ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-contentui"],

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -1,4 +1,3 @@
-from tardis.configuration.configuration import Configuration
 from tardis.exceptions.tardisexceptions import TardisTimeout
 from tardis.exceptions.tardisexceptions import TardisError
 from tardis.exceptions.tardisexceptions import TardisQuotaExceeded
@@ -25,15 +24,15 @@ logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.cloudstack")
 
 class CloudStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
-        self.cloud_stack_client = CloudStack(
-            end_point=self._configuration.end_point,
-            api_key=self._configuration.api_key,
-            api_secret=self._configuration.api_secret,
-            event_loop=runtime._meta_runner.runners[asyncio].event_loop,
-        )
         self._machine_type = machine_type
         self._site_name = site_name
+
+        self.cloud_stack_client = CloudStack(
+            end_point=self.configuration.end_point,
+            api_key=self.configuration.api_key,
+            api_secret=self.configuration.api_secret,
+            event_loop=runtime._meta_runner.runners[asyncio].event_loop,
+        )
 
         key_translator = StaticMapping(
             remote_resource_uuid="id", drone_uuid="name", resource_status="state"

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -1,4 +1,3 @@
-from ...configuration.configuration import Configuration
 from ...exceptions.tardisexceptions import TardisError
 from ...interfaces.siteadapter import ResourceStatus
 from ...interfaces.siteadapter import SiteAdapter
@@ -16,11 +15,10 @@ import asyncio
 
 class FakeSiteAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str) -> None:
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._api_response_delay = self._configuration.api_response_delay
-        self._resource_boot_time = self._configuration.resource_boot_time
+        self._api_response_delay = self.configuration.api_response_delay
+        self._resource_boot_time = self.configuration.resource_boot_time
 
         key_translator = StaticMapping(
             remote_resource_uuid="remote_resource_uuid",

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,4 +1,3 @@
-from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...exceptions.tardisexceptions import TardisError
 from ...exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
@@ -60,10 +59,9 @@ htcondor_status_codes = {
 
 class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
-        self._executor = getattr(self._configuration, "executor", ShellExecutor())
+        self._executor = getattr(self.configuration, "executor", ShellExecutor())
 
         key_translator = StaticMapping(
             remote_resource_uuid="ClusterId",
@@ -89,7 +87,7 @@ class HTCondorAdapter(SiteAdapter):
 
         self._htcondor_queue = AsyncCacheMap(
             update_coroutine=partial(htcondor_queue_updater, self._executor),
-            max_age=self._configuration.max_age * 60,
+            max_age=self.configuration.max_age * 60,
         )
 
     async def deploy_resource(

--- a/tardis/adapters/sites/kubernetes.py
+++ b/tardis/adapters/sites/kubernetes.py
@@ -1,6 +1,5 @@
 from kubernetes_asyncio import client as k8s_client
 from kubernetes_asyncio.client.rest import ApiException as K8SApiException
-from ...configuration.configuration import Configuration
 from ...exceptions.tardisexceptions import TardisError
 from ...interfaces.siteadapter import SiteAdapter
 from ...interfaces.siteadapter import ResourceStatus
@@ -14,7 +13,6 @@ from contextlib import contextmanager
 
 class KubernetesAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
         key_translator = StaticMapping(
@@ -43,8 +41,8 @@ class KubernetesAdapter(SiteAdapter):
     def client(self) -> k8s_client.AppsV1Api:
         if self._client is None:
             a_configuration = k8s_client.Configuration(
-                host=self._configuration.host,
-                api_key={"authorization": self._configuration.token},
+                host=self.configuration.host,
+                api_key={"authorization": self.configuration.token},
             )
             a_configuration.api_key_prefix["authorization"] = "Bearer"
             a_configuration.verify_ssl = False

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -1,4 +1,3 @@
-from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...exceptions.tardisexceptions import TardisError
 from ...exceptions.tardisexceptions import TardisTimeout
@@ -50,26 +49,25 @@ async def moab_status_updater(executor):
 
 class MoabAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
 
         try:
             self._startup_command = self.machine_type_configuration.StartupCommand
         except AttributeError:
-            if not hasattr(self._configuration, "StartupCommand"):
+            if not hasattr(self.configuration, "StartupCommand"):
                 raise
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,
             )
-            self._startup_command = self._configuration.StartupCommand
+            self._startup_command = self.configuration.StartupCommand
 
-        self._executor = getattr(self._configuration, "executor", ShellExecutor())
+        self._executor = getattr(self.configuration, "executor", ShellExecutor())
 
         self._moab_status = AsyncCacheMap(
             update_coroutine=partial(moab_status_updater, self._executor),
-            max_age=self._configuration.StatusUpdate * 60,
+            max_age=self.configuration.StatusUpdate * 60,
         )
         key_translator = StaticMapping(
             remote_resource_uuid="JobID", resource_status="State"

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -4,7 +4,7 @@ from simple_rest_client.exceptions import AuthError
 from simple_rest_client.exceptions import ClientError
 from aiohttp import ClientConnectionError
 from aiohttp import ContentTypeError
-from tardis.configuration.configuration import Configuration
+
 from tardis.exceptions.tardisexceptions import TardisAuthError
 from tardis.exceptions.tardisexceptions import TardisDroneCrashed
 from tardis.exceptions.tardisexceptions import TardisError
@@ -27,17 +27,16 @@ logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.openstack")
 
 class OpenStackAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
 
         auth = AuthPassword(
-            auth_url=self._configuration.auth_url,
-            username=self._configuration.username,
-            password=self._configuration.password,
-            project_name=self._configuration.project_name,
-            user_domain_name=self._configuration.user_domain_name,
-            project_domain_name=self._configuration.project_domain_name,
+            auth_url=self.configuration.auth_url,
+            username=self.configuration.username,
+            password=self.configuration.password,
+            project_name=self.configuration.project_name,
+            user_domain_name=self.configuration.user_domain_name,
+            project_domain_name=self.configuration.project_domain_name,
         )
 
         self.nova = NovaClient(session=auth)

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -1,4 +1,3 @@
-from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...exceptions.tardisexceptions import TardisError
 from ...exceptions.tardisexceptions import TardisTimeout
@@ -49,26 +48,25 @@ async def slurm_status_updater(executor):
 
 class SlurmAdapter(SiteAdapter):
     def __init__(self, machine_type: str, site_name: str):
-        self._configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type
         self._site_name = site_name
 
         try:
             self._startup_command = self.machine_type_configuration.StartupCommand
         except AttributeError:
-            if not hasattr(self._configuration, "StartupCommand"):
+            if not hasattr(self.configuration, "StartupCommand"):
                 raise
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,
             )
-            self._startup_command = self._configuration.StartupCommand
+            self._startup_command = self.configuration.StartupCommand
 
-        self._executor = getattr(self._configuration, "executor", ShellExecutor())
+        self._executor = getattr(self.configuration, "executor", ShellExecutor())
 
         self._slurm_status = AsyncCacheMap(
             update_coroutine=partial(slurm_status_updater, self._executor),
-            max_age=self._configuration.StatusUpdate * 60,
+            max_age=self.configuration.StatusUpdate * 60,
         )
 
         key_translator = StaticMapping(

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -14,6 +14,10 @@ logger = logging.getLogger("cobald.runtime.tardis.interfaces.site")
 
 
 class SiteConfigurationModel(BaseModel):
+    """
+    pydantic BaseModel for the input validation of the generic site configuration
+    """
+
     name: str
     adapter: str
     quota: Optional[int] = inf
@@ -102,10 +106,14 @@ class SiteAdapter(metaclass=ABCMeta):
 
     @property
     def drone_minimum_lifetime(self) -> [int, None]:
-        try:
-            return self.site_configuration.drone_minimum_lifetime
-        except AttributeError:
-            return None
+        """
+        Property that returns the configuration parameter drone_minimum_lifetime.
+        It describes the minimum lifetime before a drone is automatically going
+        into draining mode.
+        :return: The minimum lifetime of the drone
+        :rtype: int, None
+        """
+        return self.site_configuration.drone_minimum_lifetime
 
     def drone_uuid(self, uuid: str) -> str:
         """
@@ -221,6 +229,20 @@ class SiteAdapter(metaclass=ABCMeta):
     @property
     @cache
     def site_configuration(self) -> AttributeDict:
+        """
+        Property that returns the generic site configuration. This corresponds
+        to the Sites section in the yaml configuration. For example:
+        .. code-block::
+
+            Sites:
+              - name: MySiteName_1
+                adapter: MyAdapter2Use
+                quota: 123
+                drone_minimum_lifetime: 3600
+
+        :return: The generic site configuration
+        :rtype: AttributeDict
+        """
         for site_configuration in Configuration().Sites:
             if site_configuration.name == self.site_name:
                 return AttributeDict(

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -4,7 +4,7 @@ from ..utilities.attributedict import AttributeDict
 from abc import ABCMeta, abstractmethod
 from cobald.utility.primitives import infinity as inf
 from enum import Enum
-from functools import cache
+from functools import lru_cache
 from pydantic import BaseModel, conint, validator
 from typing import Optional
 
@@ -227,7 +227,7 @@ class SiteAdapter(metaclass=ABCMeta):
         raise NotImplementedError
 
     @property
-    @cache
+    @lru_cache(maxsize=None)
     def site_configuration(self) -> AttributeDict:
         """
         Property that returns the generic site configuration. This corresponds

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -1,7 +1,9 @@
+from ..configuration.configuration import Configuration
 from ..utilities.attributedict import AttributeDict
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
+from functools import cache
 
 import logging
 
@@ -30,18 +32,11 @@ class SiteAdapter(metaclass=ABCMeta):
     @property
     def configuration(self) -> AttributeDict:
         """
-        Property to provide access to configuration of the actual
-        implementation of the SiteAdapter.
-        :return: returns the configuration of the Site Adapter
+        Property to provide access to SiteAdapter specific configuration.
+        :return: returns the Site Adapte specific configuration
         :rtype: AttributeDict
         """
-        try:
-            # noinspection PyUnresolvedReferences
-            return self._configuration
-        except AttributeError as ae:
-            raise AttributeError(
-                f"Class {self.__class__.__name__} must have an '_configuration' instance variable"  # noqa
-            ) from ae
+        return getattr(Configuration(), self.site_name)
 
     @abstractmethod
     async def deploy_resource(
@@ -58,6 +53,42 @@ class SiteAdapter(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def drone_environment(
+        self, drone_uuid: str, meta_data_translation_mapping: AttributeDict
+    ) -> dict:
+        """
+        Method to get the drone environment to be exported to batch jobs
+        providing the actual resources in the overlay batch system. It
+        translates units of drone meta data into a format the overlay
+        batch system is expecting. Also, the drone_uuid is added  for matching
+        drones to actual resources provided in the overlay batch system.
+        :param drone_uuid: The unique id which is assigned to every drone on creation
+        :type drone_uuid: str
+        :param meta_data_translation_mapping: Mapping used for the meta data translation
+        :type meta_data_translation_mapping: dict
+        :return: Translated
+        :rtype: dict
+        """
+        try:
+            drone_environment = {
+                key: meta_data_translation_mapping[key] * value
+                for key, value in self.machine_meta_data.items()
+            }
+        except KeyError as ke:
+            logger.critical(f"drone_environment failed: no translation known for {ke}")
+            raise
+        else:
+            drone_environment["Uuid"] = drone_uuid
+
+        return drone_environment
+
+    @property
+    def drone_minimum_lifetime(self) -> [int, None]:
+        try:
+            return self.site_configuration.drone_minimum_lifetime
+        except AttributeError:
+            return None
+
     def drone_uuid(self, uuid: str) -> str:
         """
         Returns the drone uuid consisting of the lower case site name and the
@@ -70,6 +101,13 @@ class SiteAdapter(metaclass=ABCMeta):
         :rtype: str
         """
         return f"{self.site_name.lower()}-{uuid}"
+
+    @property
+    @cache
+    def site_configuration(self) -> AttributeDict:
+        for site in Configuration().Sites:
+            if site.name == self.site_name:
+                return site
 
     @abstractmethod
     def handle_exceptions(self):
@@ -116,42 +154,6 @@ class SiteAdapter(metaclass=ABCMeta):
             translated_response[key] = value
 
         return translated_response
-
-    def drone_environment(
-        self, drone_uuid: str, meta_data_translation_mapping: AttributeDict
-    ) -> dict:
-        """
-        Method to get the drone environment to be exported to batch jobs
-        providing the actual resources in the overlay batch system. It
-        translates units of drone meta data into a format the overlay
-        batch system is expecting. Also, the drone_uuid is added  for matching
-        drones to actual resources provided in the overlay batch system.
-        :param drone_uuid: The unique id which is assigned to every drone on creation
-        :type drone_uuid: str
-        :param meta_data_translation_mapping: Mapping used for the meta data translation
-        :type meta_data_translation_mapping: dict
-        :return: Translated
-        :rtype: dict
-        """
-        try:
-            drone_environment = {
-                key: meta_data_translation_mapping[key] * value
-                for key, value in self.machine_meta_data.items()
-            }
-        except KeyError as ke:
-            logger.critical(f"drone_environment failed: no translation known for {ke}")
-            raise
-        else:
-            drone_environment["Uuid"] = drone_uuid
-
-        return drone_environment
-
-    @property
-    def drone_minimum_lifetime(self) -> [int, None]:
-        try:
-            return self.configuration.drone_minimum_lifetime
-        except AttributeError:
-            return None
 
     @property
     def machine_meta_data(self) -> AttributeDict:

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -55,7 +55,7 @@ class SiteAdapter(metaclass=ABCMeta):
     def configuration(self) -> AttributeDict:
         """
         Property to provide access to SiteAdapter specific configuration.
-        :return: returns the Site Adapte specific configuration
+        :return: returns the Site Adapter specific configuration
         :rtype: AttributeDict
         """
         return getattr(Configuration(), self.site_name)

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -227,7 +227,7 @@ class SiteAdapter(metaclass=ABCMeta):
         raise NotImplementedError
 
     @property
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=16)
     def site_configuration(self) -> AttributeDict:
         """
         Property that returns the generic site configuration. This corresponds

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -21,9 +21,7 @@ import logging
 class TestCloudStackAdapter(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch(
-            "tardis.adapters.sites.cloudstack.Configuration"
-        )
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_cloudstack_api_patcher = patch(
             "tardis.adapters.sites.cloudstack.CloudStack"

--- a/tests/adapters_t/sites_t/test_fakesite.py
+++ b/tests/adapters_t/sites_t/test_fakesite.py
@@ -16,7 +16,7 @@ class TestFakeSiteAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch("tardis.adapters.sites.fakesite.Configuration")
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
 
     @classmethod

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -57,7 +57,7 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch("tardis.adapters.sites.htcondor.Configuration")
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_executor_patcher = patch(
             "tardis.adapters.sites.htcondor.ShellExecutor"

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -19,9 +19,7 @@ class TestKubernetesStackAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch(
-            "tardis.adapters.sites.kubernetes.Configuration"
-        )
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_kubernetes_api_patcher = patch(
             "tardis.adapters.sites.kubernetes.k8s_client.AppsV1Api"

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -137,9 +137,12 @@ TEST_RESOURCE_STATE_TRANSLATION_RESPONSE = "\n\n".join(
 
 
 class TestMoabAdapter(TestCase):
+    mock_config_patcher = None
+    mock_executor_patcher = None
+
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch("tardis.adapters.sites.moab.Configuration")
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_executor_patcher = patch("tardis.adapters.sites.moab.ShellExecutor")
         cls.mock_executor = cls.mock_executor_patcher.start()

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -22,9 +22,12 @@ import logging
 
 
 class TestOpenStackAdapter(TestCase):
+    mock_config_patcher = None
+    mock_openstack_api_patcher = None
+
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch("tardis.adapters.sites.openstack.Configuration")
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_openstack_api_patcher = patch(
             "tardis.adapters.sites.openstack.NovaClient"

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -79,7 +79,7 @@ class TestSlurmAdapter(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mock_config_patcher = patch("tardis.adapters.sites.slurm.Configuration")
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
         cls.mock_config = cls.mock_config_patcher.start()
         cls.mock_executor_patcher = patch("tardis.adapters.sites.slurm.ShellExecutor")
         cls.mock_executor = cls.mock_executor_patcher.start()

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -6,85 +6,49 @@ from ..utilities.utilities import run_async
 from unittest import TestCase
 from unittest.mock import patch
 
+import logging
+
 
 class TestSiteAdapter(TestCase):
+    mock_config_patcher = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
+        cls.mock_config = cls.mock_config_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_config_patcher.stop()
+
     @patch.multiple(SiteAdapter, __abstractmethods__=set())
     def setUp(self) -> None:
+        self.config = self.mock_config.return_value
+        self.config.Sites = [
+            AttributeDict(name="TestSite", adapter="TestSite", quota=1)
+        ]
+        self.config.TestSite = AttributeDict(
+            MachineTypes=["TestMachineType"],
+            MachineMetaData=AttributeDict(
+                TestMachineType=AttributeDict(Cores=128, Memory=512, Disk=100)
+            ),
+            MachineTypeConfiguration=AttributeDict(
+                TestMachineType=AttributeDict(test_id="abc123")
+            ),
+        )
         self.site_adapter = SiteAdapter()
+        self.site_adapter._site_name = "TestSite"
+        self.site_adapter._machine_type = "TestMachineType"
 
     def test_configuration(self):
-        with self.assertRaises(AttributeError):
-            self.site_adapter.configuration
-
-        self.site_adapter._configuration = "Test"
-        self.assertEqual(self.site_adapter.configuration, "Test")
+        self.assertEqual(self.site_adapter.configuration, self.config.TestSite)
 
     def test_deploy_resource(self):
         with self.assertRaises(NotImplementedError):
             run_async(self.site_adapter.deploy_resource, dict())
 
-    def test_handle_exception(self):
-        with self.assertRaises(NotImplementedError):
-            self.site_adapter.handle_exceptions()
-
-    def test_handle_response_matching(self):
-        test_response = {"test": 123}
-        test_key_translator = {"new_test": "test"}
-        test_translator_functions = {"test": str}
-        self.assertEqual(
-            self.site_adapter.handle_response(
-                test_response,
-                test_key_translator,
-                test_translator_functions,
-                additional="test123",
-            ),
-            AttributeDict(new_test="123", additional="test123"),
-        )
-
-    def test_handle_response_non_matching_with_additional(self):
-        test_response = {"other_test": 123}
-        test_key_translator = {"new_test": "test"}
-        test_translator_functions = {"test": str}
-
-        self.assertEqual(
-            self.site_adapter.handle_response(
-                test_response,
-                test_key_translator,
-                test_translator_functions,
-                additional="test123",
-            ),
-            AttributeDict(additional="test123"),
-        )
-
-    def test_handle_response_non_matching_wo_additional(self):
-        test_response = {"other_test": 123}
-        test_key_translator = {"new_test": "test"}
-        test_translator_functions = {"test": str}
-
-        self.assertEqual(
-            self.site_adapter.handle_response(
-                test_response, test_key_translator, test_translator_functions
-            ),
-            AttributeDict(),
-        )
-
-    def test_machine_meta_data(self):
-        with self.assertRaises(AttributeError):
-            self.site_adapter.machine_meta_data
-
-        self.site_adapter._configuration = AttributeDict(
-            MachineMetaData=AttributeDict(TestFlavour="Test")
-        )
-        self.site_adapter._machine_type = "TestFlavour"
-        self.assertEqual(self.site_adapter.machine_meta_data, "Test")
-
     def test_drone_environment(self):
-        self.site_adapter._configuration = AttributeDict(
-            MachineMetaData=AttributeDict(
-                test1xxl=AttributeDict(Cores=128, Memory=512, Disk=100)
-            )
-        )
-        self.site_adapter._machine_type = "test1xxl"
+        self.site_adapter._machine_type = "TestMachineType"
 
         self.assertEqual(
             AttributeDict(Cores=128, Memory=524288, Disk=104857600, Uuid="test-123"),
@@ -98,24 +62,117 @@ class TestSiteAdapter(TestCase):
             ),
         )
 
+        with self.assertLogs(
+            logger="cobald.runtime.tardis.interfaces.site", level=logging.CRITICAL
+        ), self.assertRaises(KeyError):
+            self.site_adapter.drone_environment(
+                drone_uuid="test-123",
+                meta_data_translation_mapping=AttributeDict(
+                    Memory=1024,
+                    Disk=1024 * 1024,
+                ),
+            )
+
     def test_drone_minimum_lifetime(self):
         self.assertEqual(self.site_adapter.drone_minimum_lifetime, None)
 
-        self.site_adapter._configuration = AttributeDict(drone_minimum_lifetime=10)
+        self.config.Sites[0]["drone_minimum_lifetime"] = 10
         self.assertEqual(self.site_adapter.drone_minimum_lifetime, 10)
 
+    def test_drone_uuid(self):
+        self.assertEqual(
+            "testsite-test123", self.site_adapter.drone_uuid(uuid="test123")
+        )
+
+    def test_site_configuration(self):
+        self.assertEqual(self.site_adapter.site_configuration, self.config.Sites[0])
+
+    def test_handle_exception(self):
+        with self.assertRaises(NotImplementedError):
+            self.site_adapter.handle_exceptions()
+
+    def test_handle_response_matching(self):
+        test_response = {"test": 123}
+        test_key_translator = {"new_test": "test"}
+        test_translator_functions = {"test": str}
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response, test_key_translator, test_translator_functions
+            ),
+            AttributeDict(new_test="123"),
+        )
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response,
+                test_key_translator,
+                test_translator_functions,
+                additional="test123",
+            ),
+            AttributeDict(new_test="123", additional="test123"),
+        )
+
+    def test_handle_response_non_matching(self):
+        test_response = {"other_test": 123}
+        test_key_translator = {"new_test": "test"}
+        test_translator_functions = {"test": str}
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response, test_key_translator, test_translator_functions
+            ),
+            AttributeDict(),
+        )
+
+        self.assertEqual(
+            self.site_adapter.handle_response(
+                test_response,
+                test_key_translator,
+                test_translator_functions,
+                additional="test123",
+            ),
+            AttributeDict(additional="test123"),
+        )
+
+    def test_machine_meta_data(self):
+        self.assertEqual(
+            self.site_adapter.machine_meta_data,
+            AttributeDict(Cores=128, Memory=512, Disk=100),
+        )
+
+        del self.site_adapter._machine_type
+
+        with self.assertRaises(AttributeError):
+            self.site_adapter.machine_meta_data
+
     def test_machine_type(self):
+        self.assertEqual(self.site_adapter.machine_type, "TestMachineType")
+
+        del self.site_adapter._machine_type
+
         with self.assertRaises(AttributeError):
             self.site_adapter.machine_type
 
-        self.site_adapter._machine_type = "TestFlavour"
-        self.assertEqual(self.site_adapter.machine_type, "TestFlavour")
+    def test_machine_type_configuration(self):
+        self.assertEqual(
+            self.site_adapter.machine_type_configuration,
+            AttributeDict(test_id="abc123"),
+        )
+
+        del self.site_adapter._machine_type
+
+        with self.assertRaises(AttributeError):
+            self.site_adapter.machine_type_configuration
 
     def test_resource_status(self):
         with self.assertRaises(NotImplementedError):
             run_async(self.site_adapter.resource_status, dict())
 
     def test_site_name(self):
+        self.assertEqual(self.site_adapter.site_name, "TestSite")
+        del self.site_adapter._site_name
+
         with self.assertRaises(AttributeError):
             self.site_adapter.site_name
 


### PR DESCRIPTION
This pull request fixes the bug that the drone_minimum_lifetime parameter is not working as expected and described in the documentation as described in #167.

This pull request includes:
- [x] Add a new property `self.site_configuration` to the site adapter interface
- [x] Replace `self._configuration` by `self.configuration` in all site adapters
- [x] Get configuration directly from the Bork in the interface class
- [x] Adjust all unitttest to properly check that the mechanism is indeed working as expected
- [x] Add pydantic validation for the generic configuration as proof of concept

Fixes #167 