### PR TITLE
Fixing rare `ValueError`s in `get_resource_ratios`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-03-22, command
+.. Created by changelog.py at 2021-03-24, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-03-22
+[Unreleased] - 2021-03-24
 =========================
 
 Added
@@ -17,6 +17,7 @@ Added
 Fixed
 -----
 
+* Fixes a bug that get_resource_ratios raised a ValueError
 * Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
 
 [0.5.0] - 2020-12-09

--- a/docs/source/changes/175.fix_resource_ratios.yaml
+++ b/docs/source/changes/175.fix_resource_ratios.yaml
@@ -1,0 +1,10 @@
+category: fixed
+summary: "Fixes a bug that get_resource_ratios raised a ValueError"
+description: |
+    In case one of the resource ratios is `undefined` or even has the value `error`
+    a `ValueError` or `TypeError` could occur. In case one of those errors occurs,
+    an empty list is returned.
+pull requests:
+  - 175
+issues:
+  - 168

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -172,14 +172,13 @@ class HTCondorAdapter(BatchSystemAdapter):
         await self._htcondor_status.update_status()
         try:
             htcondor_status = self._htcondor_status[drone_uuid]
-        except KeyError:
-            return {}
-        else:
             return (
                 float(value)
                 for key, value in htcondor_status.items()
                 if key in self.ratios.keys()
             )
+        except (KeyError, ValueError):
+            return {}
 
     async def get_allocation(self, drone_uuid: str) -> float:
         """

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -172,13 +172,13 @@ class HTCondorAdapter(BatchSystemAdapter):
         await self._htcondor_status.update_status()
         try:
             htcondor_status = self._htcondor_status[drone_uuid]
-            return (
+            return [
                 float(value)
                 for key, value in htcondor_status.items()
                 if key in self.ratios.keys()
-            )
-        except (KeyError, ValueError):
-            return {}
+            ]
+        except (KeyError, ValueError, TypeError):
+            return []
 
     async def get_allocation(self, drone_uuid: str) -> float:
         """

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -153,6 +153,7 @@ class TestHTCondorAdapter(TestCase):
             [self.cpu_ratio, self.memory_ratio],
         )
         self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_async_run_command.reset_mock()
 
         self.assertEqual(
             run_async(
@@ -160,7 +161,7 @@ class TestHTCondorAdapter(TestCase):
             ),
             [],
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_async_run_command.assert_not_called()
         self.mock_async_run_command.reset_mock()
 
         self.assertEqual(
@@ -169,7 +170,7 @@ class TestHTCondorAdapter(TestCase):
             ),
             [],
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_async_run_command.assert_not_called()
         self.mock_async_run_command.reset_mock()
 
         self.assertEqual(

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -57,6 +57,8 @@ class TestHTCondorAdapter(TestCase):
                 f"test_drained\tslot1@test\tDrained\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
                 f"test_owner\tslot1@test\tOwner\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
                 f"test_uuid_plus\tslot1@test_uuid@test\tUnclaimed\tIdle\ttest_uuid\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
+                f"test_undefined\tslot1@test\tUnclaimed\tIdle\tundefined\tundefined\t{self.memory_ratio}",  # noqa: B950
+                f"test_error\tslot1@test\tUnclaimed\tIdle\tundefined\terror\t{self.memory_ratio}",  # noqa: B950
                 "exoscale-26d361290f\tslot1@exoscale-26d361290f\tUnclaimed\tIdle\tundefined\t0.125\t0.125",  # noqa: B950
             ]
         )
@@ -156,7 +158,23 @@ class TestHTCondorAdapter(TestCase):
             run_async(
                 self.htcondor_adapter.get_resource_ratios, drone_uuid="not_exists"
             ),
-            {},
+            [],
+        )
+        self.mock_async_run_command.assert_called_with(self.command)
+
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_resource_ratios, drone_uuid="test_undefined"
+            ),
+            [],
+        )
+        self.mock_async_run_command.assert_called_with(self.command)
+
+        self.assertEqual(
+            run_async(
+                self.htcondor_adapter.get_resource_ratios, drone_uuid="test_error"
+            ),
+            [],
         )
 
     def test_get_resource_ratios_without_options(self):

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -161,6 +161,7 @@ class TestHTCondorAdapter(TestCase):
             [],
         )
         self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_async_run_command.reset_mock()
 
         self.assertEqual(
             run_async(
@@ -169,6 +170,7 @@ class TestHTCondorAdapter(TestCase):
             [],
         )
         self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_async_run_command.reset_mock()
 
         self.assertEqual(
             run_async(


### PR DESCRIPTION
This PR targets #168 and includes `ValueError` and `TypeError` during exception handling. In case those errors are raised, an empty `list` is returned.
This PR includes

* [x] tests as well as the according
* [x] change fragment.

Fixes #168.