### PR TITLE
Adjust state transition of released drones in BootingState

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-03-24, command
+.. Created by changelog.py at 2021-03-26, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-03-24
+[Unreleased] - 2021-03-26
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,7 @@ Fixed
 
 * Fixes a bug that get_resource_ratios raised a ValueError
 * Fixes a bug that the drone_minimum_lifetime parameter is not working as described in the documentation
+* Improves race issue during state transition of released drones in `BootingState`
 * Fixes a bug in the HTCondor Site Adapter which leads to wrong requirements when using non HTCondor OBS
 
 [0.5.0] - 2020-12-09

--- a/docs/source/changes/181.fix_htcondor_booting_state_race.yaml
+++ b/docs/source/changes/181.fix_htcondor_booting_state_race.yaml
@@ -1,0 +1,12 @@
+category: fixed
+summary: "Improves race issue during state transition of released drones in `BootingState`"
+description: |
+    Drones are sometimes removed after payload has started running (race issue). Instead of deleting drones in
+    `BootingState`, we would propose to execute a `condor_drain` first. Therefore, we changed the state transistions
+    from `BootingState` -> `CleanupState` by `BootingState`-> `DrainState`. Still we do not catch cases where the drone
+    is still in `BootingState`, while executing `condor_drain` and the `condor_status` update does not happen before
+    the `condor_rm` is executed. So it is just an improvement and not a fix of the race condition.
+pull requests:
+  - 181
+issues:
+  - 172

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -34,10 +34,7 @@ async def batchsystem_machine_status(
 async def check_demand(state_transition, drone: "Drone", current_state: Type[State]):
     if not drone.demand:
         drone._supply = 0.0
-        if current_state in (BootingState,):
-            raise StopProcessing(last_result=CleanupState())  # static state transition
-        else:
-            raise StopProcessing(last_result=DrainState())  # static state transition
+        raise StopProcessing(last_result=DrainState())  # static state transition
     return state_transition
 
 

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -165,7 +165,7 @@ class TestDroneStates(TestCase):
         self.drone.demand = 0.0
         self.drone.state.return_value = BootingState()
         run_async(self.drone.state.return_value.run, self.drone)
-        self.assertIsInstance(self.drone.state, CleanupState)
+        self.assertIsInstance(self.drone.state, DrainState)
         self.assertEqual(self.drone._supply, 0.0)
 
     def test_integrate_state(self):


### PR DESCRIPTION
Drones are sometimes removed after payload has started running (race issue). Instead of deleting drones in `BootingState`, we would propose to execute a `condor_drain` first. Therefore, we changed the state transistions  from `BootingState` -> `CleanupState` by `BootingState`-> `DrainState`. Still we do not catch cases where the drone is still in `BootingState`, while executing `condor_drain` and the `condor_status` update does not happen before  the `condor_rm` is executed. So it is just an improvement and not a fix of the race condition.

This pull request improves race issue mentioned in #172. Please, do not merge yet. These changes need to be tested by @olifre and @wiene first.