### PR TITLE
HTCondor COBalD/TARDIS docker image

### DIFF
--- a/containers/cobald-tardis-htcondor/Dockerfile
+++ b/containers/cobald-tardis-htcondor/Dockerfile
@@ -1,0 +1,29 @@
+FROM centos:7
+LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
+
+ARG SOURCE_BRANCH=master
+ARG SOURCE_REPO_URL=https://github.com/MatterMiners/tardis
+
+RUN rpm --import http://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor
+RUN yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/htcondor-release-current.el7.noarch.rpm
+
+RUN yum -y install epel-release && yum clean all
+
+RUN yum -y update \
+    && yum -y install condor \
+                      git \
+                      python3 \
+                      gcc \
+                      python3-devel \
+    && yum clean all
+
+RUN python3 -m pip install --no-cache-dir "cryptography<3.2"
+RUN python3 -m pip install --no-cache-dir "aiohttp<4.0"
+RUN python3 -m pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH
+
+WORKDIR /srv
+
+COPY cobald.yml /srv/cobald.yml
+
+ENTRYPOINT ["python3", "-m", "cobald.daemon"]
+CMD ["/srv/cobald.yml"]

--- a/containers/cobald-tardis-htcondor/README.md
+++ b/containers/cobald-tardis-htcondor/README.md
@@ -24,7 +24,7 @@ is also true for read-only operations like calling `condor_status`.
 This docker image supports the ID tokens authentication method introduced with the HTCondor 9.0 series. 
 
 In order to use ID tokens add any tokens provided by the operator of the overlay batch system to a `tokens.d` directory
-and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically uses these tokens to authenticate against the pool.
+and bind mount it to `/etc/condor/tokens.d`. HTCondor automatically uses these tokens to authenticate against the pool.
 
 ```bash
 docker run -v $PWD/tokens.d:/etc/condor/tokens.d matterminers/cobald-tardis-htcondor:latest

--- a/containers/cobald-tardis-htcondor/README.md
+++ b/containers/cobald-tardis-htcondor/README.md
@@ -30,7 +30,7 @@ and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically using the
 docker run -v $PWD/tokens.d:/etc/condor/tokens.d matterminers/cobald-tardis-htcondor:latest
 ```
 
-Since `COBald/TARDIS` uses the `condor_status` command, the token added needs the at least the `ALLOW_READ` privilege to 
+Since `COBald/TARDIS` uses the `condor_status` command, the token added needs at least the `ALLOW_READ` privilege to 
 access the HTCondor Collector and to query the status of resources.
 
 In addition, `COBalD/TARDIS` uses the `condor_drain` command to release under utilized resources. Therefore, a second 

--- a/containers/cobald-tardis-htcondor/README.md
+++ b/containers/cobald-tardis-htcondor/README.md
@@ -21,10 +21,10 @@ host-based. The security configuration is now user-based and requires authentica
 is also true for read-only operations like calling `condor_status`.
 
 ### Managing Tokens
-This docker images supports the ID tokens authentication method introduced with the HTCondor 9.0 series. 
+This docker image supports the ID tokens authentication method introduced with the HTCondor 9.0 series. 
 
 In order to use ID tokens add any tokens provided by the operator of the overlay batch system to a `tokens.d` directory
-and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically using them authenticate against the pool.
+and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically uses these tokens to authenticate against the pool.
 
 ```bash
 docker run -v $PWD/tokens.d:/etc/condor/tokens.d matterminers/cobald-tardis-htcondor:latest

--- a/containers/cobald-tardis-htcondor/README.md
+++ b/containers/cobald-tardis-htcondor/README.md
@@ -1,0 +1,39 @@
+# `COBalD/TARDIS` and HTCondor Overlay Batch System Image
+
+This docker image provides a fully configurable `COBalD/TARDIS` installation combined with a HTCondor installation to be
+used to integrate resources into a HTCondor overlay batch system.
+
+## Configure `COBalD/TARDIS`
+
+You can configure `COBalD/TARDIS` as described in the [documentation](https://cobald-tardis.readthedocs.io/en/latest/) 
+and bind mount it into the containers `/srv` directory. The configuration directory must contain a valid `cobald.yml` 
+configuration and depending on the configuration, it will be used to store the persistent state as well as logs of the 
+COBalD/TARDIS installation (see the [documentation](https://cobald-tardis.readthedocs.io/en/latest/) for details). 
+
+```bash
+docker run -v $PWD/configuration:/srv matterminers/cobald-tardis-htcondor:latest
+```
+
+## HTCondor Token Support
+
+Starting with the production release series 9.0 HTCondor introduces a new security configuration, which is no longer 
+host-based. The security configuration is now user-based and requires authentication to access the HTCondor pool. This
+is also true for read-only operations like calling `condor_status`.
+
+### Managing Tokens
+This docker images supports the ID tokens authentication method introduced with the HTCondor 9.0 series. 
+
+In order to use ID tokens add any tokens provided by the operator of the overlay batch system to a `tokens.d` directory
+and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically using them authenticate against the pool.
+
+```bash
+docker run -v $PWD/tokens.d:/etc/condor/tokens.d matterminers/cobald-tardis-htcondor:latest
+```
+
+Since `COBald/TARDIS` uses the `condor_status` command, the token added needs the at least the `ALLOW_READ` privilege to 
+access the HTCondor Collector and to query the status of resources.
+
+In addition, `COBalD/TARDIS` uses the `condor_drain` command to release under utilized resources. Therefore, a second 
+token to access the HTCondor StartD of the Drone is needed.
+
+Usually, both tokens are provided by the operator of the HTCondor overlay batch system.

--- a/containers/cobald-tardis-htcondor/cobald.yml
+++ b/containers/cobald-tardis-htcondor/cobald.yml
@@ -1,11 +1,11 @@
 pipeline:
-  - __type__: cobald.controller.linear.LinearController
+  - !LinearController
     low_utilisation: 0.90
     high_allocation: 0.90
     rate: 1
-  - __type__: cobald.decorator.limiter.Limiter
+  - !Limiter
     minimum: 1
-  - __type__: cobald.decorator.logger.Logger
+  - !Logger
     name: 'changes'
   - __type__: tardis.resources.poolfactory.create_composite_pool
 logging:

--- a/containers/cobald-tardis-htcondor/cobald.yml
+++ b/containers/cobald-tardis-htcondor/cobald.yml
@@ -1,0 +1,66 @@
+pipeline:
+  - __type__: cobald.controller.linear.LinearController
+    low_utilisation: 0.90
+    high_allocation: 0.90
+    rate: 1
+  - __type__: cobald.decorator.limiter.Limiter
+    minimum: 1
+  - __type__: cobald.decorator.logger.Logger
+    name: 'changes'
+  - __type__: tardis.resources.poolfactory.create_composite_pool
+logging:
+  version: 1
+  root:
+      level: DEBUG
+      handlers: [console, file]
+  formatters:
+    precise:
+      format: '%(name)s: %(asctime)s %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
+  handlers:
+    console:
+      class : logging.StreamHandler
+      formatter: precise
+      stream  : ext://sys.stdout
+    file:
+      class : logging.handlers.RotatingFileHandler
+      formatter: precise
+      filename: tardis.log
+      maxBytes: 10485760
+      backupCount: 3
+tardis:
+  Plugins:
+    SqliteRegistry:
+      db_file: drone_registry.db
+  
+  BatchSystem:
+    adapter: FakeBatchSystem
+    allocation: 1.0
+    utilisation: !TardisPeriodicValue
+                 period: 3600
+                 amplitude: 0.5
+                 offset: 0.5
+                 phase: 0.
+    machine_status: Available
+  
+  Sites:
+    - name: Fake
+      adapter: FakeSite
+      quota: 8000 # CPU core quota
+  
+  Fake:
+    api_response_delay: !TardisRandomGauss
+                        mu: 0.1
+                        sigma: 0.01
+    resource_boot_time: !TardisRandomGauss
+                        mu: 60
+                        sigma: 10
+    MachineTypes:
+      - m1.infinity
+    MachineTypeConfiguration:
+      m1.infinity:
+    MachineMetaData:
+      m1.infinity:
+        Cores: 8
+        Memory: 16
+        Disk: 160

--- a/containers/cobald-tardis-htcondor/hooks/build
+++ b/containers/cobald-tardis-htcondor/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+SOURCE_REPO_URL=$(git remote get-url origin)
+SOURCE_REPO_HTTPS_URL=${SOURCE_REPO_URL/git@github.com:/https:\/\/github.com\/}
+docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg SOURCE_REPO_URL=${SOURCE_REPO_HTTPS_URL} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/docs/source/api/tardis.adapters.sites.kubernetes.rst
+++ b/docs/source/api/tardis.adapters.sites.kubernetes.rst
@@ -1,0 +1,7 @@
+tardis.adapters.sites.kubernetes module
+=======================================
+
+.. automodule:: tardis.adapters.sites.kubernetes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.rst
+++ b/docs/source/api/tardis.adapters.sites.rst
@@ -15,6 +15,7 @@ Submodules
    tardis.adapters.sites.cloudstack
    tardis.adapters.sites.fakesite
    tardis.adapters.sites.htcondor
+   tardis.adapters.sites.kubernetes
    tardis.adapters.sites.moab
    tardis.adapters.sites.openstack
    tardis.adapters.sites.slurm

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-03-24, command
+.. Created by changelog.py at 2021-05-25, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-03-24
+[Unreleased] - 2021-05-25
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-05-25, command
+.. Created by changelog.py at 2021-05-26, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-05-25
+[Unreleased] - 2021-05-26
 =========================
 
 Added

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -267,6 +267,58 @@ Running your instance in Docker
 
         This path must contain a valid `cobald.yml` file. The persistent database will then be stored on the local machine.
 
+Running your instance using HTCondor as overlay batch system in Docker
+======================================================================
+
+.. content-tabs:: left-col
+
+    For your convenience and for systems without pre-compiled HTCondor support a ready to use docker container is
+    provided via Dockerhub.
+
+    You can configure ``COBalD``/``TARDIS`` as described in this documentation and bind mount the directory containing
+    the configuration into the containers `/srv` directory.
+
+    .. note::
+
+        This path must contain at least a valid `cobald.yml` file.
+
+.. content-tabs:: right-col
+
+    .. code-block::
+
+        docker run -v $PWD/configuration:/srv matterminers/cobald-tardis-htcondor:latest
+
+
+HTCondor Token Support
+----------------------
+
+.. content-tabs:: left-col
+
+    Starting with the production release series 9.0, HTCondor introduces a new security configuration, which is no
+    longer host-based. The security configuration is now user-based and requires authentication to access the HTCondor
+    pool. This is also true for read-only operations like calling `condor_status`. Therefore, this docker images
+    supports the `IDTOKENS` authentication method introduced with the HTCondor 9.0 series.
+
+    In order to use ID tokens, add any tokens provided by the operator of the overlay batch system to a `tokens.d`
+    directory and bind mount it to `/etc/condor/tokens.d`. HTCondor is automatically using them to authenticate against
+    the pool.
+
+.. content-tabs:: right-col
+
+    .. code-block::
+
+        docker run -v $PWD/configuration:/srv -v $PWD/tokens.d:/etc/condor/tokens.d matterminers/cobald-tardis-htcondor:latest
+
+.. content-tabs:: left-col
+
+    .. note::
+        Since ``COBalD``/``TARDIS`` uses the `condor_status` command, the token added needs at least the `ALLOW_READ`
+        privilege to access the HTCondor Collector and to query the status of resources.
+
+        In addition, ``COBalD``/``TARDIS`` uses the `condor_drain` command to release under utilized resources.
+        Therefore, a second token to access the HTCondor StartD of the Drone is needed.
+
+        Usually, both tokens are provided by the operator of the HTCondor overlay batch system.
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -296,7 +296,7 @@ HTCondor Token Support
 
     Starting with the production release series 9.0, HTCondor introduces a new security configuration, which is no
     longer host-based. The security configuration is now user-based and requires authentication to access the HTCondor
-    pool. This is also true for read-only operations like calling `condor_status`. Therefore, this docker images
+    pool. This is also true for read-only operations such as `condor_status`. Therefore, this docker image
     supports the `IDTOKENS` authentication method introduced with the HTCondor 9.0 series.
 
     In order to use ID tokens, add any tokens provided by the operator of the overlay batch system to a `tokens.d`


### PR DESCRIPTION
This pull request adds a new COBalD/TARDIS docker image that also provides a HTCondor installation. The image is intended to be used to integrate additional resources into a HTCondor overlay batch system on systems without pre-compiled HTCondor support, for example SLES. 