### PR TITLE
Fix installation issue with ancient Centos 7

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,12 +5,12 @@ Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
-Max Fischer <maxfischer2781@gmail.com>
 ubdsv <ubdsv@student.kit.edu>
+Max Fischer <maxfischer2781@gmail.com>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
-PSchuhmacher <leon_schuhmacher@yahoo.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
 rfvc <florian.voncube@gmail.com>
+PSchuhmacher <leon_schuhmacher@yahoo.de>

--- a/containers/cobald-tardis-htcondor/Dockerfile
+++ b/containers/cobald-tardis-htcondor/Dockerfile
@@ -17,8 +17,6 @@ RUN yum -y update \
                       python3-devel \
     && yum clean all
 
-RUN python3 -m pip install --no-cache-dir "cryptography<3.2"
-RUN python3 -m pip install --no-cache-dir "aiohttp<4.0"
 RUN python3 -m pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH
 
 WORKDIR /srv

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-05-26, command
+.. Created by changelog.py at 2021-05-27, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-05-26
+[Unreleased] - 2021-05-27
 =========================
 
 Added

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import os
+import ssl
 
 repo_base_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -12,6 +13,14 @@ with open(os.path.join(repo_base_dir, "README.md"), "r") as read_me:
     long_description = read_me.read()
 
 TESTS_REQUIRE = ["flake8"]
+
+
+def get_cryptography_version():
+    if ssl.OPENSSL_VERSION_INFO < (1, 1, 0):
+        return "cryptography<3.2"  # to support openssl<1.1 (Centos 7)"
+    else:
+        return "cryptography"
+
 
 setup(
     name=package_about["__package__"],
@@ -53,7 +62,9 @@ setup(
     keywords=package_about["__keywords__"],
     packages=find_packages(exclude=["tests"]),
     install_requires=[
-        "aiohttp",
+        "aiohttp<4.0; python_version<'3.7'",  # to support python3.6 (Centos 7)
+        "aiohttp; python_version>='3.7'",
+        get_cryptography_version(),
         "CloudStackAIO",
         "PyYAML",
         "AsyncOpenStackClient",


### PR DESCRIPTION
This pull requests fixes the installation problem on Centos 7 reported in #184. It uses PEP 508 to install an older version of `aiohttp` for Python 3.6 (Most recent version in Centos 7 EPEL). For Python 3.7 and newer the most recent `aiohttp` version is installed. 
Since also `OpenSSL < 1.1.0` is not supported by newer version of the `cryptography` package, it installs and older version, if Python has been compiled with `OpenSSL < 1.1.0`. Otherwise the most recent version is installed.
In addition, it removes the workaround used to build the Centos 7 docker image. 