### PR TITLE
Disable scheduled docker builds on forks

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docker-builds:
-    if: github.event.schedule && github.repository == 'matterminers/tardis'
+    if: github.event.schedule && github.repository == 'MatterMiners/tardis'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docker-builds:
-    if: github.event.schedule
+    if: github.event.schedule && github.repository == 'matterminers/tardis'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-06-04, command
+.. Created by changelog.py at 2021-06-10, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-06-04
+[Unreleased] - 2021-06-10
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-06-10, command
+.. Created by changelog.py at 2021-06-11, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-06-10
+[Unreleased] - 2021-06-11
 =========================
 
 Added


### PR DESCRIPTION
This pull requests disables the scheduled docker builds on forked repositories, since this leads to errors due to missing credentials and is not intended to run docker builds on forks.