### PR TITLE
Add rockylinux 8 deployment tests

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'centos8', 'ubuntu20_04', 'ubuntu18_04']
+        os_container: ['centos7', 'centos8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'centos8', 'ubuntu20_04', 'ubuntu18_04']
+        os_container: ['centos7', 'centos8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04']
     container: matterminers/cobald-tardis-deployment-test-env:${{ matrix.os_container }}
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,8 +5,8 @@ Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
-ubdsv <ubdsv@student.kit.edu>
 Max Fischer <maxfischer2781@gmail.com>
+ubdsv <ubdsv@student.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
@@ -1,0 +1,16 @@
+FROM rockylinux/rockylinux:8
+LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
+
+RUN yum -y install epel-release curl && yum clean all
+
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+
+RUN yum -y update \
+    && yum -y install git \
+                      python38 \
+                      gcc \
+                      python38-devel \
+                      nodejs \
+    && yum clean all
+
+SHELL [ "/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c" ]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-06-11, command
+.. Created by changelog.py at 2021-07-05, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-06-11
+[Unreleased] - 2021-07-05
 =========================
 
 Added


### PR DESCRIPTION
This pull requests adds deployment tests for the newly release Rocky Linux 8 distribution, which will supersede Centos 8 in the future.  