### PR TITLE
Fix slurm obs documentation

### DIFF
--- a/docs/source/adapters/batchsystem.rst
+++ b/docs/source/adapters/batchsystem.rst
@@ -151,7 +151,13 @@ SLURM Batch System Adapter
 
 .. content-tabs:: left-col
 
-    Additional options for the ``sinfo`` call can be added by using the ``options`` option.
+    Additional arguments for the ``sinfo`` call can be appended by adding the ``options`` MappingNode. This supports
+    both ``long`` and ``short`` arguments.
+
+    .. Note::
+
+        The alignment of colons in the examples to the right is a simple coincidence and for parsing ``yaml`` only the
+        indentation is crucial.
 
 .. content-tabs:: right-col
 

--- a/docs/source/adapters/batchsystem.rst
+++ b/docs/source/adapters/batchsystem.rst
@@ -160,24 +160,33 @@ SLURM Batch System Adapter
     .. code-block:: yaml
 
         options:
-          partition: express
+          long:
+            partition: express
 
-    translates into ``sinfo ... --partition express``.
+    translates into ``sinfo ... --partition=express`` and
+
+    .. code-block:: yaml
+
+        options:
+          short:
+            p: express
+
+    to ``sinfo ... -p express``.
 
 Available configuration options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. content-tabs:: left-col
 
-    +----------------+-------------------------------------------------------------------+-----------------+
-    | Option         | Short Description                                                 | Requirement     |
-    +================+===================================================================+=================+
-    | adapter        | Name of the adapter (Slurm)                                       |  **Required**   |
-    +----------------+-------------------------------------------------------------------+-----------------+
-    | max_age        | Maximum age of the cached ``sinfo`` information in minutes        |  **Required**   |
-    +----------------+-------------------------------------------------------------------+-----------------+
-    | options        | Additional command line options to add to the ``sinfo`` command   |  **Optional**   |
-    +----------------+-------------------------------------------------------------------+-----------------+
+    +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
+    | Option         | Short Description                                                                                                         | Requirement     |
+    +================+===========================================================================================================================+=================+
+    | adapter        | Name of the adapter (Slurm)                                                                                               |  **Required**   |
+    +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
+    | max_age        | Maximum age of the cached ``sinfo`` information in minutes                                                                |  **Required**   |
+    +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
+    | options        | Additional command line options to add to the ``sinfo`` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
+    +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
 
 .. content-tabs:: right-col
 
@@ -189,6 +198,7 @@ Available configuration options
             adapter: Slurm
             max_age: 1
             options:
+              long:
                 partition: express
 
 .. content-tabs:: left-col

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-08, command
+.. Created by changelog.py at 2021-07-12, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-08
+[Unreleased] - 2021-07-12
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-05, command
+.. Created by changelog.py at 2021-07-08, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-05
+[Unreleased] - 2021-07-08
 =========================
 
 Added

--- a/tardis/interfaces/batchsystemadapter.py
+++ b/tardis/interfaces/batchsystemadapter.py
@@ -25,8 +25,8 @@ class BatchSystemAdapter(metaclass=ABCMeta):
 
         :param drone_uuid: Uuid of the worker node, for some sites corresponding
                 to the host name of the drone.
-            :type drone_uuid: str
-            :return: None
+        :type drone_uuid: str
+        :return: None
         """
         raise NotImplementedError
 


### PR DESCRIPTION
According to the [documentation](https://cobald-tardis.readthedocs.io/en/latest/adapters/batchsystem.html#id2) additonal options to the `sinfo` call can be specified the following way:

```yaml
BatchSystem:
  adapter: Slurm
  max_age: 1
  options:
    partition: express
```

however actually 

```yaml
BatchSystem:
  adapter: Slurm
  max_age: 1
  options:
     long:
       partition: express
```

is the right way to use additional options for the `sinfo` call. 

This pull request fixes #194 and additonally a docstring indentation warning.

