### PR TITLE
Internally use MB as unit to request new resources in SLURM site adapter

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install dependencies on ${{ matrix.os_container }}
         run: |
           python3 -m pip install --upgrade pip
-          pip install .[contrib]
-          pip install coverage codecov
+          python3 -m pip install .[contrib]
+          python3 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.os_container }}
         run: |
           coverage run -m unittest -v
@@ -58,8 +58,8 @@ jobs:
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
           python3 -m pip install --upgrade pip
-          pip install .[contrib]
-          pip install coverage codecov
+          python3 -m pip install .[contrib]
+          python3 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
           coverage run -m unittest -v

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-14, command
+.. Created by changelog.py at 2021-07-15, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-14
+[Unreleased] - 2021-07-15
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-12, command
+.. Created by changelog.py at 2021-07-13, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-12
+[Unreleased] - 2021-07-13
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-13, command
+.. Created by changelog.py at 2021-07-14, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-13
+[Unreleased] - 2021-07-14
 =========================
 
 Added

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -174,7 +174,9 @@ class SlurmAdapter(SiteAdapter):
         walltime = self.machine_type_configuration.Walltime
 
         drone_environment = ",".join(
-            f"TardisDrone{key}={value}"
+            f"TardisDrone{key}={int(value)}"
+            if isinstance(value, float)
+            else f"TardisDrone{key}={value}"
             for key, value in self.drone_environment(
                 drone_uuid, machine_meta_data_translation_mapping
             ).items()
@@ -190,6 +192,9 @@ class SlurmAdapter(SiteAdapter):
             ),
             long=AttributeDict(
                 **sbatch_options.get("long", AttributeDict()),
+                # slurm does not accept floating point variables for memory,
+                # therefore use internally megabytes and convert it to an integer
+                # to allow for request i.e. 2.5 GB in the machine meta data
                 mem=f"{int(self.machine_meta_data.Memory * 1000)}mb",
                 export=f"SLURM_Walltime={walltime},{drone_environment}",
             ),

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -190,7 +190,7 @@ class SlurmAdapter(SiteAdapter):
             ),
             long=AttributeDict(
                 **sbatch_options.get("long", AttributeDict()),
-                mem=f"{self.machine_meta_data.Memory}gb",
+                mem=f"{int(self.machine_meta_data.Memory * 1000)}mb",
                 export=f"SLURM_Walltime={walltime},{drone_environment}",
             ),
         )

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -191,8 +191,10 @@ class SlurmAdapter(SiteAdapter):
                 **sbatch_options.get("long", AttributeDict()),
                 # slurm does not accept floating point variables for memory,
                 # therefore use internally megabytes and convert it to an integer
-                # to allow for request i.e. 2.5 GB in the machine meta data
-                mem=f"{int(self.machine_meta_data.Memory * 1000)}mb",
+                # to allow for request i.e. 2.5 GB in the machine meta data. According
+                # to http://cern.ch/go/x7p8 SLURM is using factors of 1024 to convert
+                # between memory units
+                mem=f"{int(self.machine_meta_data.Memory * 1024)}mb",
                 export=f"SLURM_Walltime={walltime},{drone_environment}",
             ),
         )

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -9,8 +9,7 @@ from ...utilities.attributedict import AttributeDict
 from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
-from ...utilities.utils import csv_parser
-from ...utilities.utils import submit_cmd_option_formatter
+from ...utilities.utils import convert_to, csv_parser, submit_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -174,9 +173,7 @@ class SlurmAdapter(SiteAdapter):
         walltime = self.machine_type_configuration.Walltime
 
         drone_environment = ",".join(
-            f"TardisDrone{key}={int(value)}"
-            if isinstance(value, float)
-            else f"TardisDrone{key}={value}"
+            f"TardisDrone{key}={convert_to(value, int, value)}"
             for key, value in self.drone_environment(
                 drone_uuid, machine_meta_data_translation_mapping
             ).items()

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -4,7 +4,7 @@ from ..exceptions.executorexceptions import CommandExecutionFailure
 from ..interfaces.executor import Executor
 
 from io import StringIO
-from typing import List, Tuple
+from typing import Any, List, Tuple, Type
 
 import csv
 import logging
@@ -131,3 +131,10 @@ def submit_cmd_option_formatter(options: AttributeDict) -> str:
             option_string += tmp_option_string
 
     return option_string.strip()
+
+
+def convert_to(value: Any, convert_to_type: Type, default: Any = None):
+    try:
+        return convert_to_type(value)
+    except ValueError:
+        return default

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -4,7 +4,8 @@ from ..exceptions.executorexceptions import CommandExecutionFailure
 from ..interfaces.executor import Executor
 
 from io import StringIO
-from typing import Any, List, Tuple, Type
+from typing import Any, Callable, List, TypeVar, Tuple
+
 
 import csv
 import logging
@@ -133,7 +134,13 @@ def submit_cmd_option_formatter(options: AttributeDict) -> str:
     return option_string.strip()
 
 
-def convert_to(value: Any, convert_to_type: Type, default: Any = None):
+T = TypeVar("T")
+sentinel = object()
+
+
+def convert_to(
+    value: Any, convert_to_type: Callable[[Any], T], default: Any = sentinel
+) -> T:
     try:
         return convert_to_type(value)
     except ValueError:

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -157,18 +157,20 @@ class TestSlurmAdapter(TestCase):
         expected_resource_attributes.update(
             created=datetime.now(), updated=datetime.now()
         )
-        returned_resource_attributes = run_async(
-            self.slurm_adapter.deploy_resource,
-            resource_attributes=AttributeDict(
-                machine_type="test2large",
-                site_name="TestSite",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1000,
-                    Disk=1000,
-                ),
-                drone_uuid="testsite-1390065",
+
+        resource_attributes = AttributeDict(
+            machine_type="test2large",
+            site_name="TestSite",
+            obs_machine_meta_data_translation_mapping=AttributeDict(
+                Cores=1,
+                Memory=1000,
+                Disk=1000,
             ),
+            drone_uuid="testsite-1390065",
+        )
+
+        returned_resource_attributes = run_async(
+            self.slurm_adapter.deploy_resource, resource_attributes
         )
 
         self.assertLess(
@@ -184,6 +186,26 @@ class TestSlurmAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.assert_called_with(
             "sbatch -p normal -N 1 -n 20 -t 60 --mem=62000mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+        )
+
+        self.mock_executor.reset_mock()
+
+        self.test_site_config.MachineMetaData.test2large.Memory = 2.5
+
+        run_async(self.slurm_adapter.deploy_resource, resource_attributes)
+
+        self.mock_executor.return_value.run_command.assert_called_with(
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2500mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2500,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+        )
+
+        self.mock_executor.reset_mock()
+
+        self.test_site_config.MachineMetaData.test2large.Memory = 2.546372129
+
+        run_async(self.slurm_adapter.deploy_resource, resource_attributes)
+
+        self.mock_executor.return_value.run_command.assert_called_with(
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2546mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2546,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -183,7 +183,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62000mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
@@ -209,7 +209,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62gb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62000mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -163,8 +163,8 @@ class TestSlurmAdapter(TestCase):
             site_name="TestSite",
             obs_machine_meta_data_translation_mapping=AttributeDict(
                 Cores=1,
-                Memory=1000,
-                Disk=1000,
+                Memory=1024,
+                Disk=1024,
             ),
             drone_uuid="testsite-1390065",
         )
@@ -185,7 +185,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=62000mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=63488mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=63488,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
         self.mock_executor.reset_mock()
@@ -195,7 +195,7 @@ class TestSlurmAdapter(TestCase):
         run_async(self.slurm_adapter.deploy_resource, resource_attributes)
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2500mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2500,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2560mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2560,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
         self.mock_executor.reset_mock()
@@ -205,7 +205,7 @@ class TestSlurmAdapter(TestCase):
         run_async(self.slurm_adapter.deploy_resource, resource_attributes)
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2546mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2546,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --mem=2607mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2607,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
@@ -231,7 +231,7 @@ class TestSlurmAdapter(TestCase):
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=62000mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
+            "sbatch -p normal -N 1 -n 20 -t 60 --gres=tmp:1G --mem=63488mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=62000,TardisDroneDisk=100000,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
     def test_machine_meta_data(self):


### PR DESCRIPTION
This pull request change the internal used unit to request memory using the SLURM site adapter to Megabytes. Externally memory is still handled in Gigabytes in `TARDIS`. This was necessary since the SLURM workload manager does not accept floating point variable to its `--mem` argument as reported in #196.

Currently the following command is used to submit a drone requesting 2.5 GB memory in the SLURM workload manager:
```
sbatch --mem=2.5gb ...
``` 
which fails.

After the update the following command is used:

```
sbatch --mem=2500mb
```
which will succeed.

This pull request changes only the internal behaviour and not the external handling of memory requests in `TARDIS` and it fixes #196.