### PR TITLE
Support executors in Slurm and HTCondor batch system adapters

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,6 @@ R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
+PSchuhmacher <leon_schuhmacher@yahoo.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
 rfvc <florian.voncube@gmail.com>
-PSchuhmacher <leon_schuhmacher@yahoo.de>

--- a/docs/source/adapters/batchsystem.rst
+++ b/docs/source/adapters/batchsystem.rst
@@ -108,6 +108,10 @@ Available configuration options
     +----------------+-------------------------------------------------------------------------+-----------------+
     | options        | Additional command line options to add to the ``condor_status`` command |  **Optional**   |
     +----------------+-------------------------------------------------------------------------+-----------------+
+    | executor       | The |executor| used to run commands of the batch system.                |  **Optional**   |
+    +                +                                                                         +                 +
+    |                | Default: ShellExecutor is used!                                         |                 |
+    +----------------+-------------------------------------------------------------------------+-----------------+
 
 .. content-tabs:: right-col
 
@@ -192,6 +196,10 @@ Available configuration options
     | max_age        | Maximum age of the cached ``sinfo`` information in minutes                                                                |  **Required**   |
     +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
     | options        | Additional command line options to add to the ``sinfo`` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
+    +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
+    | executor       | The |executor| used to run commands of the batch system.                                                                  |  **Optional**   |
+    +                +                                                                                                                           +                 +
+    |                | Default: ShellExecutor is used!                                                                                           |                 |
     +----------------+---------------------------------------------------------------------------------------------------------------------------+-----------------+
 
 .. content-tabs:: right-col

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -138,7 +138,7 @@ class HTCondorAdapter(BatchSystemAdapter):
             cmd = f"condor_drain -graceful {slot_name}"
 
         try:
-            return await self._executor.run_command(cmd)
+            await self._executor.run_command(cmd)
         except CommandExecutionFailure as cef:
             if cef.exit_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone

--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -2,7 +2,7 @@ from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
-from ...utilities.utils import async_run_command
+from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.utils import htcondor_cmd_option_formatter
 from ...utilities.utils import csv_parser
 from ...utilities.asynccachemap import AsyncCacheMap
@@ -17,7 +17,7 @@ logger = logging.getLogger("cobald.runtime.tardis.adapters.batchsystem.htcondor"
 
 
 async def htcondor_status_updater(
-    options: AttributeDict, attributes: AttributeDict
+    options: AttributeDict, attributes: AttributeDict, executor=ShellExecutor
 ) -> dict:
     """
     Helper function to call ``condor_status -af`` asynchronously and to translate
@@ -47,9 +47,9 @@ async def htcondor_status_updater(
 
     try:
         logger.debug(f"HTCondor status update is running. Command: {cmd}")
-        condor_status = await async_run_command(cmd)
+        condor_status = await executor.run_command(cmd)
         for row in csv_parser(
-            input_csv=condor_status,
+            input_csv=condor_status.stdout,
             fieldnames=tuple(attributes.keys()),
             delimiter="\t",
             replacements=dict(undefined=None),
@@ -75,6 +75,7 @@ class HTCondorAdapter(BatchSystemAdapter):
     def __init__(self):
         config = Configuration()
         self.ratios = config.BatchSystem.ratios
+        self._executor = getattr(config.BatchSystem, "executor", ShellExecutor())
 
         try:
             self.htcondor_options = config.BatchSystem.options
@@ -93,7 +94,10 @@ class HTCondorAdapter(BatchSystemAdapter):
 
         self._htcondor_status = AsyncCacheMap(
             update_coroutine=partial(
-                htcondor_status_updater, self.htcondor_options, attributes
+                htcondor_status_updater,
+                self.htcondor_options,
+                attributes,
+                self._executor,
             ),
             max_age=config.BatchSystem.max_age * 60,
         )
@@ -133,7 +137,7 @@ class HTCondorAdapter(BatchSystemAdapter):
             cmd = f"condor_drain -graceful {slot_name}"
 
         try:
-            return await async_run_command(cmd)
+            return await self._executor.run_command(cmd)
         except CommandExecutionFailure as cef:
             if cef.exit_code == 1:
                 # exit code 1: HTCondor can't connect to StartD of Drone

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -11,7 +11,6 @@ from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
 from ...interfaces.executor import Executor
-from ...utilities.utils import async_run_command
 from ...utilities.utils import submit_cmd_option_formatter
 from ...utilities.utils import csv_parser
 from ...utilities.executors.shellexecutor import ShellExecutor
@@ -46,9 +45,9 @@ async def slurm_status_updater(
 
     try:
         logging.debug(f"SLURM status update is running. Command: {cmd}")
-        status = await async_run_command(cmd, executor)
+        status = await executor.run_command(cmd)
         for row in csv_parser(
-            input_csv=status,
+            input_csv=status.stdout,
             fieldnames=tuple(attributes.keys()),
             delimiter=" ",
             replacements=dict(undefined=None),
@@ -134,7 +133,7 @@ class SlurmAdapter(BatchSystemAdapter):
 
         cmd = f"scontrol update NodeName={machine} State=DRAIN Reason='COBalD/TARDIS'"
 
-        return await async_run_command(cmd, self._executor)
+        return await self._executor.run_command(cmd)
 
     async def integrate_machine(self, drone_uuid: str) -> None:
         """

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -10,15 +10,15 @@ from ...configuration.configuration import Configuration
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.batchsystemadapter import BatchSystemAdapter
 from ...interfaces.batchsystemadapter import MachineStatus
-from ...utilities.utils import async_run_command
 from ...utilities.utils import submit_cmd_option_formatter
 from ...utilities.utils import csv_parser
+from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
 
 
 async def slurm_status_updater(
-    options: AttributeDict, attributes: AttributeDict
+    options: AttributeDict, attributes: AttributeDict, executor=ShellExecutor()
 ) -> dict:
     """
     Slurm status update.
@@ -44,9 +44,9 @@ async def slurm_status_updater(
 
     try:
         logging.debug(f"SLURM status update is running. Command: {cmd}")
-        status = await async_run_command(cmd)
+        status = await executor.run_command(cmd)
         for row in csv_parser(
-            input_csv=status,
+            input_csv=status.stdout,
             fieldnames=tuple(attributes.keys()),
             delimiter=" ",
             replacements=dict(undefined=None),
@@ -64,7 +64,7 @@ async def slurm_status_updater(
 
     except CommandExecutionFailure as ex:
         logging.warning(f"SLURM's sinfo could not be executed! {str(ex)}")
-        raise
+        raise ex
     else:
         logging.debug("SLURM status update finished.")
         return slurm_status
@@ -79,6 +79,7 @@ class SlurmAdapter(BatchSystemAdapter):
 
     def __init__(self):
         config = Configuration()
+        self._executor = getattr(config.BatchSystem, "executor", ShellExecutor())
 
         try:
             self.slurm_options = config.BatchSystem.options
@@ -96,7 +97,7 @@ class SlurmAdapter(BatchSystemAdapter):
 
         self._slurm_status = AsyncCacheMap(
             update_coroutine=partial(
-                slurm_status_updater, self.slurm_options, attributes
+                slurm_status_updater, self.slurm_options, attributes, self._executor
             ),
             max_age=config.BatchSystem.max_age * 60,
         )
@@ -131,7 +132,7 @@ class SlurmAdapter(BatchSystemAdapter):
 
         cmd = f"scontrol update NodeName={machine} State=DRAIN Reason='COBalD/TARDIS'"
 
-        return await async_run_command(cmd)
+        return self._executor.run_command(cmd)
 
     async def integrate_machine(self, drone_uuid: str) -> None:
         """

--- a/tardis/adapters/batchsystems/slurm.py
+++ b/tardis/adapters/batchsystems/slurm.py
@@ -133,7 +133,7 @@ class SlurmAdapter(BatchSystemAdapter):
 
         cmd = f"scontrol update NodeName={machine} State=DRAIN Reason='COBalD/TARDIS'"
 
-        return await self._executor.run_command(cmd)
+        await self._executor.run_command(cmd)
 
     async def integrate_machine(self, drone_uuid: str) -> None:
         """

--- a/tardis/utilities/executors/shellexecutor.py
+++ b/tardis/utilities/executors/shellexecutor.py
@@ -24,7 +24,17 @@ class ShellExecutor(Executor):
         )
         exit_code = sub_process.returncode
 
-        if exit_code:
+        # Potentially due to a Python bug, if waitpid(0) is called somewhere else,
+        # the message "WARNING:asyncio:Unknown child process pid 2960761,
+        # will report returncode 255 appears"
+        # However the command succeeded
+        if not exit_code or exit_code == 255:
+            return AttributeDict(
+                stdout=stdout.decode().strip(),
+                stderr=stderr.decode().strip(),
+                exit_code=exit_code,
+            )
+        else:
             raise CommandExecutionFailure(
                 message=f"Run command {command} via ShellExecutor failed",
                 exit_code=exit_code,
@@ -32,9 +42,3 @@ class ShellExecutor(Executor):
                 stderr=stderr.decode().strip(),
                 stdin=stdin_input,
             )
-
-        return AttributeDict(
-            stdout=stdout.decode().strip(),
-            stderr=stderr.decode().strip(),
-            exit_code=exit_code,
-        )

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -1,7 +1,4 @@
 from .attributedict import AttributeDict
-from .executors.shellexecutor import ShellExecutor
-from ..exceptions.executorexceptions import CommandExecutionFailure
-from ..interfaces.executor import Executor
 
 from io import StringIO
 from typing import List, Tuple
@@ -10,24 +7,6 @@ import csv
 import logging
 
 logger = logging.getLogger("cobald.runtime.tardis.utilities.utils")
-
-
-async def async_run_command(
-    cmd: str, shell_executor: Executor = ShellExecutor()
-) -> str:
-    try:
-        response = await shell_executor.run_command(cmd)
-    except CommandExecutionFailure as ef:
-        # Potentially due to a Python bug, if waitpid(0) is called somewhere else,
-        # the message "WARNING:asyncio:Unknown child process pid 2960761,
-        # will report returncode 255 appears"
-        # However the command succeeded
-
-        if ef.exit_code == 255:
-            return ef.stdout
-        raise
-    else:
-        return response.stdout
 
 
 def cmd_option_formatter(options: AttributeDict, prefix: str, separator: str) -> str:

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -39,7 +39,7 @@ class TestHTCondorAdapter(TestCase):
             "tardis.adapters.batchsystems.htcondor.Configuration"
         )
         cls.mock_executor_patcher = patch(
-            "tardis.adapters.batchsystems.slurm.ShellExecutor"
+            "tardis.adapters.batchsystems.htcondor.ShellExecutor"
         )
         cls.mock_executor = cls.mock_executor_patcher.start()
         cls.mock_config = cls.mock_config_patcher.start()
@@ -130,7 +130,7 @@ class TestHTCondorAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.side_effect = None
 
-    @mock_executor_run_command(stdout=CONDOR_RETURN)
+    #  @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
         self.htcondor_adapter = HTCondorAdapter()

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -1,5 +1,5 @@
-from tests.utilities.utilities import async_return
 from tests.utilities.utilities import run_async
+from tests.utilities.utilities import mock_executor_run_command
 from tardis.adapters.batchsystems.htcondor import HTCondorAdapter
 from tardis.adapters.batchsystems.htcondor import htcondor_status_updater
 from tardis.interfaces.batchsystemadapter import MachineStatus
@@ -8,35 +8,50 @@ from tardis.utilities.attributedict import AttributeDict
 
 from functools import partial
 from shlex import quote
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from unittest import TestCase
 
 import logging
 
+CPU_RATIO = 0.9
+MEMORY_RATIO = 0.8
+CONDOR_RETURN = "\n".join(
+    [
+        f"test\tslot1@test\tUnclaimed\tIdle\tundefined\t{CPU_RATIO}\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_drain\tslot1@test\tDrained\tRetiring\tundefined\t{CPU_RATIO}\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_drained\tslot1@test\tDrained\tIdle\tundefined\t{CPU_RATIO}\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_owner\tslot1@test\tOwner\tIdle\tundefined\t{CPU_RATIO}\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_uuid_plus\tslot1@test_uuid@test\tUnclaimed\tIdle\ttest_uuid\t{CPU_RATIO}\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_undefined\tslot1@test\tUnclaimed\tIdle\tundefined\tundefined\t{MEMORY_RATIO}",  # noqa: B950
+        f"test_error\tslot1@test\tUnclaimed\tIdle\tundefined\terror\t{MEMORY_RATIO}",  # noqa: B950
+        "exoscale-26d361290f\tslot1@exoscale-26d361290f\tUnclaimed\tIdle\tundefined\t0.125\t0.125",  # noqa: B950
+    ]
+)
+
 
 class TestHTCondorAdapter(TestCase):
     mock_config_patcher = None
-    mock_async_run_command_patcher = None
+    mock_executor_patcher = None
 
     @classmethod
     def setUpClass(cls):
         cls.mock_config_patcher = patch(
             "tardis.adapters.batchsystems.htcondor.Configuration"
         )
-        cls.mock_async_run_command_patcher = patch(
-            "tardis.adapters.batchsystems.htcondor.async_run_command", new=MagicMock()
+        cls.mock_executor_patcher = patch(
+            "tardis.adapters.batchsystems.slurm.ShellExecutor"
         )
+        cls.mock_executor = cls.mock_executor_patcher.start()
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_async_run_command = cls.mock_async_run_command_patcher.start()
 
     @classmethod
     def tearDownClass(cls):
         cls.mock_config_patcher.stop()
-        cls.mock_async_run_command_patcher.stop()
+        cls.mock_executor_patcher.stop()
 
     def setUp(self):
-        self.cpu_ratio = 0.9
-        self.memory_ratio = 0.8
+        self.cpu_ratio = CPU_RATIO
+        self.memory_ratio = MEMORY_RATIO
         self.command = (
             "condor_status -af:t Machine Name State Activity TardisDroneUuid "
             "'Real(TotalSlotCpus-Cpus)/TotalSlotCpus' "
@@ -50,31 +65,16 @@ class TestHTCondorAdapter(TestCase):
             "'Real(TotalSlotMemory-Memory)/TotalSlotMemory' -constraint PartitionableSlot=?=True"  # noqa: B950
         )
 
-        return_value = "\n".join(
-            [
-                f"test\tslot1@test\tUnclaimed\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
-                f"test_drain\tslot1@test\tDrained\tRetiring\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
-                f"test_drained\tslot1@test\tDrained\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
-                f"test_owner\tslot1@test\tOwner\tIdle\tundefined\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
-                f"test_uuid_plus\tslot1@test_uuid@test\tUnclaimed\tIdle\ttest_uuid\t{self.cpu_ratio}\t{self.memory_ratio}",  # noqa: B950
-                f"test_undefined\tslot1@test\tUnclaimed\tIdle\tundefined\tundefined\t{self.memory_ratio}",  # noqa: B950
-                f"test_error\tslot1@test\tUnclaimed\tIdle\tundefined\terror\t{self.memory_ratio}",  # noqa: B950
-                "exoscale-26d361290f\tslot1@exoscale-26d361290f\tUnclaimed\tIdle\tundefined\t0.125\t0.125",  # noqa: B950
-            ]
-        )
-        self.mock_async_run_command.return_value = async_return(
-            return_value=return_value
-        )
-
         self.setup_config_mock(options={"pool": "my-htcondor.local", "test": None})
 
         self.htcondor_adapter = HTCondorAdapter()
 
     def tearDown(self):
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
     def setup_config_mock(self, options=None):
         self.config = self.mock_config.return_value
+        self.config.BatchSystem.executor = self.mock_executor.return_value
         self.config.BatchSystem.ratios = {
             "cpu_ratio": "Real(TotalSlotCpus-Cpus)/TotalSlotCpus",
             "memory_ratio": "Real(TotalSlotMemory-Memory)/TotalSlotMemory",
@@ -90,53 +90,60 @@ class TestHTCondorAdapter(TestCase):
             run_async(self.htcondor_adapter.disintegrate_machine, drone_uuid="test")
         )
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_drain_machine(self):
         run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -pool my-htcondor.local -test -graceful slot1@test"
         )
 
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
         run_async(self.htcondor_adapter.drain_machine, drone_uuid="test_uuid")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -pool my-htcondor.local -test -graceful slot1@test_uuid@test"
         )
         self.assertIsNone(
             run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists")
         )
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(
-            message="Does not exists", exit_code=1, stderr="Does not exists"
+        self.mock_executor.return_value.run_command.side_effect = (
+            CommandExecutionFailure(
+                message="Does not exists", exit_code=1, stderr="Does not exists"
+            )
         )
         with self.assertLogs(level=logging.WARNING):
             self.assertIsNone(
                 run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
             )
 
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(
-            message="Unhandled error", exit_code=2, stderr="Unhandled error"
+        self.mock_executor.return_value.run_command.side_effect = (
+            CommandExecutionFailure(
+                message="Unhandled error", exit_code=2, stderr="Unhandled error"
+            )
         )
+
         with self.assertRaises(CommandExecutionFailure):
             with self.assertLogs(level=logging.CRITICAL):
                 self.assertIsNone(
                     run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
                 )
 
-        self.mock_async_run_command.side_effect = None
+        self.mock_executor.return_value.run_command.side_effect = None
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
         self.htcondor_adapter = HTCondorAdapter()
 
         run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -graceful slot1@test"
         )
 
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
         run_async(self.htcondor_adapter.drain_machine, drone_uuid="test_uuid")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -graceful slot1@test_uuid@test"
         )
 
@@ -145,6 +152,7 @@ class TestHTCondorAdapter(TestCase):
             run_async(self.htcondor_adapter.integrate_machine, drone_uuid="test")
         )
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_get_resource_ratios(self):
         self.assertCountEqual(
             list(
@@ -152,8 +160,8 @@ class TestHTCondorAdapter(TestCase):
             ),
             [self.cpu_ratio, self.memory_ratio],
         )
-        self.mock_async_run_command.assert_called_with(self.command)
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
+        self.mock_executor.reset_mock()
 
         self.assertEqual(
             run_async(
@@ -161,8 +169,8 @@ class TestHTCondorAdapter(TestCase):
             ),
             [],
         )
-        self.mock_async_run_command.assert_not_called()
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.return_value.run_command.assert_not_called()
+        self.mock_executor.reset_mock()
 
         self.assertEqual(
             run_async(
@@ -170,8 +178,8 @@ class TestHTCondorAdapter(TestCase):
             ),
             [],
         )
-        self.mock_async_run_command.assert_not_called()
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.return_value.run_command.assert_not_called()
+        self.mock_executor.reset_mock()
 
         self.assertEqual(
             run_async(
@@ -180,6 +188,7 @@ class TestHTCondorAdapter(TestCase):
             [],
         )
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_get_resource_ratios_without_options(self):
         self.setup_config_mock()
         del self.config.BatchSystem.options
@@ -192,59 +201,63 @@ class TestHTCondorAdapter(TestCase):
             [self.cpu_ratio, self.memory_ratio],
         )
 
-        self.mock_async_run_command.assert_called_with(self.command_wo_options)
+        self.mock_executor.return_value.run_command.assert_called_with(
+            self.command_wo_options
+        )
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_get_allocation(self):
         self.assertEqual(
             run_async(self.htcondor_adapter.get_allocation, drone_uuid="test"),
             max([self.cpu_ratio, self.memory_ratio]),
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_get_machine_status(self):
         self.assertEqual(
             run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test"),
             MachineStatus.Available,
         )
-        self.mock_async_run_command.assert_called_with(self.command)
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
+        self.mock_executor.reset_mock()
         self.assertEqual(
             run_async(
                 self.htcondor_adapter.get_machine_status, drone_uuid="not_exists"
             ),
             MachineStatus.NotAvailable,
         )
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
         self.assertEqual(
             run_async(
                 self.htcondor_adapter.get_machine_status, drone_uuid="test_drain"
             ),
             MachineStatus.Draining,
         )
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
         self.assertEqual(
             run_async(
                 self.htcondor_adapter.get_machine_status, drone_uuid="test_drained"
             ),
             MachineStatus.Drained,
         )
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
         self.assertEqual(
             run_async(
                 self.htcondor_adapter.get_machine_status, drone_uuid="test_owner"
             ),
             MachineStatus.NotAvailable,
         )
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
         self.assertEqual(
             run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test_uuid"),
             MachineStatus.Available,
         )
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(
-            message="Test", exit_code=123, stderr="Test"
+        self.mock_executor.return_value.run_command.side_effect = (
+            CommandExecutionFailure(message="Test", exit_code=123, stderr="Test")
         )
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
@@ -266,17 +279,21 @@ class TestHTCondorAdapter(TestCase):
                         htcondor_status_updater,
                         self.config.BatchSystem.options,
                         attributes,
+                        self.mock_executor.return_value,
                     )
                 )
-                self.mock_async_run_command.assert_called_with(self.command)
-        self.mock_async_run_command.side_effect = None
+                self.mock_executor.return_value.run_command.assert_called_with(
+                    self.command
+                )
+        self.mock_executor.return_value.run_command.side_effect = None
 
+    @mock_executor_run_command(stdout=CONDOR_RETURN)
     def test_get_utilisation(self):
         self.assertEqual(
             run_async(self.htcondor_adapter.get_utilisation, drone_uuid="test"),
             min([self.cpu_ratio, self.memory_ratio]),
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
     def test_machine_meta_data_translation_mapping(self):
         self.assertEqual(

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -12,7 +12,6 @@ from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from functools import partial
 
-#  from unittest.mock import MagicMock, patch
 from unittest.mock import patch
 from unittest import TestCase
 
@@ -197,6 +196,7 @@ class TestSlurmAdapter(TestCase):
                         slurm_status_updater,
                         self.config.BatchSystem.options,
                         attributes,
+                        self.mock_executor.return_value,
                     )
                 )
                 self.mock_executor.return_value.run_command.assert_called_with(

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -15,18 +15,16 @@ from functools import partial
 from unittest.mock import patch
 from unittest import TestCase
 
-SINFO_RETURN = "\n".join(
-    [
-        "mixed      2/2/0/4   6000    24000   VM-1   host-10-18-1-1",
-        "mixed      3/1/0/4   15853   22011   VM-2   host-10-18-1-2",
-        "mixed      1/3/0/4   18268   22011   VM-3   host-10-18-1-4",
-        "mixed      3/1/0/4   17803   22011   VM-4   host-10-18-1-7",
-        "draining   0/4/0/4   17803   22011   draining_m   draining_m",
-        "idle       0/4/0/4   17803   22011   idle_m   idle_m",
-        "drained    0/4/0/4   17803   22011   drained_m   drained_m",
-        "powerup    0/4/0/4   17803   22011   pwr_up_m   pwr_up_m",
-    ]
-)
+SINFO_RETURN = """\
+mixed      2/2/0/4   6000    24000   VM-1   host-10-18-1-1
+mixed      3/1/0/4   15853   22011   VM-2   host-10-18-1-2
+mixed      1/3/0/4   18268   22011   VM-3   host-10-18-1-4
+mixed      3/1/0/4   17803   22011   VM-4   host-10-18-1-7
+draining   0/4/0/4   17803   22011   draining_m   draining_m
+idle       0/4/0/4   17803   22011   idle_m   idle_m
+drained    0/4/0/4   17803   22011   drained_m   drained_m
+powerup    0/4/0/4   17803   22011   pwr_up_m   pwr_up_m\
+"""
 
 
 class TestSlurmAdapter(TestCase):

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -1,5 +1,7 @@
-from tests.utilities.utilities import async_return
+import logging
+
 from tests.utilities.utilities import run_async
+from tests.utilities.utilities import mock_executor_run_command
 from tardis.adapters.batchsystems.slurm import SlurmAdapter
 from tardis.utilities.attributedict import AttributeDict
 
@@ -9,29 +11,44 @@ from tardis.interfaces.batchsystemadapter import MachineStatus
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from functools import partial
-from unittest.mock import MagicMock, patch
+
+#  from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from unittest import TestCase
+
+SINFO_RETURN = "\n".join(
+    [
+        "mixed      2/2/0/4   6000    24000   VM-1   host-10-18-1-1",
+        "mixed      3/1/0/4   15853   22011   VM-2   host-10-18-1-2",
+        "mixed      1/3/0/4   18268   22011   VM-3   host-10-18-1-4",
+        "mixed      3/1/0/4   17803   22011   VM-4   host-10-18-1-7",
+        "draining   0/4/0/4   17803   22011   draining_m   draining_m",
+        "idle       0/4/0/4   17803   22011   idle_m   idle_m",
+        "drained    0/4/0/4   17803   22011   drained_m   drained_m",
+        "powerup    0/4/0/4   17803   22011   pwr_up_m   pwr_up_m",
+    ]
+)
 
 
 class TestSlurmAdapter(TestCase):
     mock_config_patcher = None
-    mock_async_run_command_patcher = None
+    mock_executor_patcher = None
 
     @classmethod
     def setUpClass(cls):
         cls.mock_config_patcher = patch(
             "tardis.adapters.batchsystems.slurm.Configuration"
         )
-        cls.mock_async_run_command_patcher = patch(
-            "tardis.adapters.batchsystems.slurm.async_run_command", new=MagicMock()
-        )
         cls.mock_config = cls.mock_config_patcher.start()
-        cls.mock_async_run_command = cls.mock_async_run_command_patcher.start()
+        cls.mock_executor_patcher = patch(
+            "tardis.adapters.batchsystems.slurm.ShellExecutor"
+        )
+        cls.mock_executor = cls.mock_executor_patcher.start()
 
     @classmethod
     def tearDownClass(cls):
         cls.mock_config_patcher.stop()
-        cls.mock_async_run_command_patcher.stop()
+        cls.mock_executor_patcher.stop()
 
     def setUp(self):
         self.cpu_ratio = 0.5
@@ -41,23 +58,6 @@ class TestSlurmAdapter(TestCase):
 
         self.command_wo_options = 'sinfo --Format="statelong,cpusstate,allocmem,memory,features,nodehost" -e --noheader -r'  # noqa B950
 
-        return_value = "\n".join(
-            [
-                "mixed      2/2/0/4   6000    24000   VM-1   host-10-18-1-1",
-                "mixed      3/1/0/4   15853   22011   VM-2   host-10-18-1-2",
-                "mixed      1/3/0/4   18268   22011   VM-3   host-10-18-1-4",
-                "mixed      3/1/0/4   17803   22011   VM-4   host-10-18-1-7",
-                "draining   0/4/0/4   17803   22011   draining_m   draining_m",
-                "idle       0/4/0/4   17803   22011   idle_m   idle_m",
-                "drained    0/4/0/4   17803   22011   drained_m   drained_m",
-                "powerup    0/4/0/4   17803   22011   pwr_up_m   pwr_up_m",
-            ]
-        )
-
-        self.mock_async_run_command.return_value = async_return(
-            return_value=return_value
-        )
-
         self.setup_config_mock(
             options=AttributeDict({"long": {"partition": "test_part"}})
         )
@@ -65,11 +65,12 @@ class TestSlurmAdapter(TestCase):
         self.slurm_adapter = SlurmAdapter()
 
     def tearDown(self):
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
     def setup_config_mock(self, options=None):
         self.config = self.mock_config.return_value
         self.config.BatchSystem.max_age = 10
+        self.config.BatchSystem.executor = self.mock_executor.return_value
         if options:
             self.config.BatchSystem.options = options
         else:
@@ -80,53 +81,59 @@ class TestSlurmAdapter(TestCase):
             run_async(self.slurm_adapter.disintegrate_machine, drone_uuid="test")
         )
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_drain_machine(self):
         run_async(self.slurm_adapter.drain_machine, drone_uuid="VM-1")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "scontrol update NodeName=host-10-18-1-1 State=DRAIN Reason='COBalD/TARDIS'"
         )
-
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
         self.assertIsNone(
             run_async(self.slurm_adapter.drain_machine, drone_uuid="not_exists")
         )
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(
-            message="Does not exists", exit_code=1, stderr="Does not exists"
-        )
-        with self.assertRaises(CommandExecutionFailure):
-            self.assertIsNone(
-                run_async(self.slurm_adapter.drain_machine, drone_uuid="idle_m")
-            )
 
-        self.mock_async_run_command.side_effect = None
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+        ),
+    )
+    def test_update_exception(self):
+        with self.assertLogs(level=logging.WARNING):
+            self.assertIsNone(run_async(self.slurm_adapter._slurm_status.update_status))
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
         self.slurm_adapter = SlurmAdapter()
 
         run_async(self.slurm_adapter.drain_machine, drone_uuid="VM-1")
-        self.mock_async_run_command.assert_called_with(
+        self.mock_executor.return_value.run_command.assert_called_with(
             "scontrol update NodeName=host-10-18-1-1 State=DRAIN Reason='COBalD/TARDIS'"
         )
+        self.mock_executor.reset_mock()
 
     def test_integrate_machine(self):
         self.assertIsNone(
             run_async(self.slurm_adapter.integrate_machine, drone_uuid="VM-1")
         )
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_resource_ratios(self):
         self.assertEqual(
             list(run_async(self.slurm_adapter.get_resource_ratios, drone_uuid="VM-1")),
             [self.cpu_ratio, self.memory_ratio],
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
+        self.mock_executor.reset_mock()
 
         self.assertEqual(
             run_async(self.slurm_adapter.get_resource_ratios, drone_uuid="not_exists"),
             {},
         )
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_resource_ratios_without_options(self):
         self.setup_config_mock()
         del self.config.BatchSystem.options
@@ -137,20 +144,24 @@ class TestSlurmAdapter(TestCase):
             [self.cpu_ratio, self.memory_ratio],
         )
 
-        self.mock_async_run_command.assert_called_with(self.command_wo_options)
+        self.mock_executor.return_value.run_command.assert_called_with(
+            self.command_wo_options
+        )
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_allocation(self):
         self.assertEqual(
             run_async(self.slurm_adapter.get_allocation, drone_uuid="VM-1"),
             max([self.cpu_ratio, self.memory_ratio]),
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
         self.assertEqual(
             run_async(self.slurm_adapter.get_allocation, drone_uuid="not_exists"),
             0.0,
         )
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_machine_status(self):
         state_mapping = {
             "VM-1": MachineStatus.Available,
@@ -167,11 +178,12 @@ class TestSlurmAdapter(TestCase):
                 state,
             )
 
-        self.mock_async_run_command.reset_mock()
+        self.mock_executor.reset_mock()
 
-        self.mock_async_run_command.side_effect = CommandExecutionFailure(
-            message="Test", exit_code=123, stderr="Test"
+        self.mock_executor.return_value.run_command.side_effect = (
+            CommandExecutionFailure(message="Test", exit_code=123, stderr="Test")
         )
+
         with self.assertLogs(level="WARN"):
             with self.assertRaises(CommandExecutionFailure):
                 attributes = {
@@ -187,16 +199,19 @@ class TestSlurmAdapter(TestCase):
                         attributes,
                     )
                 )
-                self.mock_async_run_command.assert_called_with(self.command)
+                self.mock_executor.return_value.run_command.assert_called_with(
+                    self.command
+                )
 
-        self.mock_async_run_command.side_effect = None
+        self.mock_executor.return_value.run_command.side_effect = None
 
+    @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_utilisation(self):
         self.assertEqual(
             run_async(self.slurm_adapter.get_utilisation, drone_uuid="VM-1"),
             min([self.cpu_ratio, self.memory_ratio]),
         )
-        self.mock_async_run_command.assert_called_with(self.command)
+        self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
         self.assertEqual(
             run_async(self.slurm_adapter.get_utilisation, drone_uuid="not_exists"),

--- a/tests/utilities_t/executors_t/test_shellexecutor.py
+++ b/tests/utilities_t/executors_t/test_shellexecutor.py
@@ -14,10 +14,13 @@ class TestAsyncRunCommand(TestCase):
     def test_run_command(self):
 
         self.assertEqual(run_async(self.executor.run_command, "exit 0").exit_code, 0)
+        self.assertEqual(
+            run_async(self.executor.run_command, "exit 255").exit_code, 255
+        )
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, "exit 255")
-        self.assertEqual(cf.exception.exit_code, 255)
+            run_async(self.executor.run_command, "exit 254")
+        self.assertEqual(cf.exception.exit_code, 254)
 
         self.assertEqual(
             run_async(self.executor.run_command, 'echo "Test"').stdout, "Test"
@@ -42,10 +45,11 @@ class TestAsyncRunCommand(TestCase):
         """
         )
         self.assertEqual(run_async(executor.run_command, "exit 0").exit_code, 0)
+        self.assertEqual(run_async(executor.run_command, "exit 255").exit_code, 255)
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, "exit 255")
-        self.assertEqual(cf.exception.exit_code, 255)
+            run_async(self.executor.run_command, "exit 254")
+        self.assertEqual(cf.exception.exit_code, 254)
 
         self.assertEqual(run_async(executor.run_command, 'echo "Test"').stdout, "Test")
 

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,24 +1,9 @@
 from tardis.utilities.attributedict import AttributeDict
-from tardis.utilities.utils import async_run_command
 from tardis.utilities.utils import htcondor_cmd_option_formatter
 from tardis.utilities.utils import csv_parser
 from tardis.utilities.utils import submit_cmd_option_formatter
-from tardis.exceptions.executorexceptions import CommandExecutionFailure
-
-from ..utilities.utilities import run_async
 
 from unittest import TestCase
-
-
-class TestAsyncRunCommand(TestCase):
-    def test_async_run_command(self):
-        run_async(async_run_command, "exit 0")
-        run_async(async_run_command, "exit 255")
-
-        with self.assertRaises(CommandExecutionFailure):
-            run_async(async_run_command, "exit 1")
-
-        self.assertEqual(run_async(async_run_command, 'echo "Test"'), "Test")
 
 
 class TestHTCondorCMDOptionFormatter(TestCase):


### PR DESCRIPTION
This PR allows users to specify and executor (ShellExecutor or SSHExecutor, default is the first) for the Slurm and HTCondor batch system adapters. Documentation and tests were also updated accordingly. Due to the needed `mock_executor_run_command` decorator in the tests, it was necessary move some data from the test class into global variables. 

We don't have an HTCondor setup, therefore I was only able to verify the Slurm part.