### PR TITLE
Kubernetes Client Enhancements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,13 +4,14 @@ Manuel Giffels <giffels@gmail.com>
 Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
+ubdsv <ubdsv@student.kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Max Fischer <maxfischer2781@gmail.com>
-ubdsv <ubdsv@student.kit.edu>
+Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
 PSchuhmacher <leon_schuhmacher@yahoo.de>
-Peter Wienemann <peter.wienemann@uni-bonn.de>
 rfvc <florian.voncube@gmail.com>
+Peter Wienemann <peter.wienemann@uni-bonn.de>

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -573,7 +573,7 @@ Available machine type configuration options
           MachineMetaData:
             example:
               Cores: 2
-              Memory: 400Mi
+              Memory: 4
 
 .. content-tabs:: left-col
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-08-03, command
+.. Created by changelog.py at 2021-08-04, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-08-03
+[Unreleased] - 2021-08-04
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-15, command
+.. Created by changelog.py at 2021-07-28, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-15
+[Unreleased] - 2021-07-28
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-07-28, command
+.. Created by changelog.py at 2021-08-03, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-07-28
+[Unreleased] - 2021-08-03
 =========================
 
 Added

--- a/tardis/adapters/sites/kubernetes.py
+++ b/tardis/adapters/sites/kubernetes.py
@@ -5,6 +5,7 @@ from ...interfaces.siteadapter import SiteAdapter
 from ...interfaces.siteadapter import ResourceStatus
 from ...utilities.attributedict import AttributeDict
 from ...utilities.staticmapping import StaticMapping
+from ...utilities.utils import convert_to
 
 from functools import partial
 from datetime import datetime
@@ -89,7 +90,7 @@ class KubernetesAdapter(SiteAdapter):
             resources=k8s_client.V1ResourceRequirements(
                 requests={
                     "cpu": self.machine_meta_data.Cores,
-                    "memory": self.machine_meta_data.Memory,
+                    "memory": convert_to(self.machine_meta_data.Memory * 1e09, int),
                 }
             ),
         )

--- a/tardis/adapters/sites/kubernetes.py
+++ b/tardis/adapters/sites/kubernetes.py
@@ -146,6 +146,7 @@ class KubernetesAdapter(SiteAdapter):
                     response_type = response_temp.status.conditions[0].type
         except K8SApiException as ex:
             if ex.status != 404:
+                logger.warning(f"Retrieving deployment status failed: {ex}")
                 raise
             response_uid = resource_attributes.remote_resource_uuid
             response_name = resource_attributes.drone_uuid

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -72,6 +72,11 @@ class TestKubernetesStackAdapter(TestCase):
             resources=client.V1ResourceRequirements(
                 requests={"cpu": 2, "memory": 4000000000}
             ),
+            env=[
+                client.V1EnvVar(name="TardisDroneCores", value="2"),
+                client.V1EnvVar(name="TardisDroneMemory", value="4096"),
+                client.V1EnvVar(name="TardisDroneUuid", value="testsite-089123"),
+            ],
         )
         spec.template.metadata = client.V1ObjectMeta(
             name="testsite-089123",
@@ -150,7 +155,11 @@ class TestKubernetesStackAdapter(TestCase):
             run_async(
                 self.kubernetes_adapter.deploy_resource,
                 resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    drone_uuid="testsite-089123",
+                    remote_resource_uuid="123456",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1, Memory=1024, Disk=1024 * 1024
+                    ),
                 ),
             ),
             AttributeDict(

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -237,14 +237,15 @@ class TestKubernetesStackAdapter(TestCase):
             ),
         )
         self.update_read_side_effect(exception=K8SApiException(status=500))
-        with self.assertRaises(K8SApiException):
-            run_async(
-                self.kubernetes_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                ),
-            )
-        self.update_read_side_effect(exception=None)
+        with self.assertLogs(level=logging.WARNING):
+            with self.assertRaises(K8SApiException):
+                run_async(
+                    self.kubernetes_adapter.resource_status,
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    ),
+                )
+            self.update_read_side_effect(exception=None)
 
     @patch("kubernetes_asyncio.client.rest.aiohttp")
     def test_stop_resource(self, mocked_aiohttp):
@@ -282,18 +283,20 @@ class TestKubernetesStackAdapter(TestCase):
             ),
         )
         self.update_delete_side_effect(exception=K8SApiException(status=500))
-        with self.assertRaises(K8SApiException):
-            run_async(
-                self.kubernetes_adapter.terminate_resource,
-                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
-            )
+        with self.assertLogs(level=logging.WARNING):
+            with self.assertRaises(K8SApiException):
+                run_async(
+                    self.kubernetes_adapter.terminate_resource,
+                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                )
         self.update_delete_side_effect(exception=None)
         self.update_delete_hpa_side_effect(exception=K8SApiException(status=500))
-        with self.assertRaises(K8SApiException):
-            run_async(
-                self.kubernetes_adapter.terminate_resource,
-                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
-            )
+        with self.assertLogs(level=logging.WARNING):
+            with self.assertRaises(K8SApiException):
+                run_async(
+                    self.kubernetes_adapter.terminate_resource,
+                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                )
         self.update_delete_hpa_side_effect(exception=None)
 
     def test_exception_handling(self):

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -56,7 +56,7 @@ class TestKubernetesStackAdapter(TestCase):
             )
         )
         test_site_config.MachineMetaData = AttributeDict(
-            test2large=AttributeDict(Cores="2", Memory="400Mi")
+            test2large=AttributeDict(Cores=2, Memory=4)
         )
         kubernetes_api = self.mock_kubernetes_api.return_value
         kubernetes_hpa = self.mock_kubernetes_hpa.return_value
@@ -70,7 +70,7 @@ class TestKubernetesStackAdapter(TestCase):
             args=["sleep", "3600"],
             name="testsite-089123",
             resources=client.V1ResourceRequirements(
-                requests={"cpu": "2", "memory": "400Mi"}
+                requests={"cpu": 2, "memory": 4000000000}
             ),
         )
         spec.template.metadata = client.V1ObjectMeta(
@@ -166,7 +166,7 @@ class TestKubernetesStackAdapter(TestCase):
     def test_machine_meta_data(self):
         self.assertEqual(
             self.kubernetes_adapter.machine_meta_data,
-            AttributeDict(Cores="2", Memory="400Mi"),
+            AttributeDict(Cores=2, Memory=4),
         )
 
     def test_machine_type(self):

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -70,7 +70,10 @@ class TestKubernetesStackAdapter(TestCase):
             args=["sleep", "3600"],
             name="testsite-089123",
             resources=client.V1ResourceRequirements(
-                requests={"cpu": 2, "memory": 4000000000}
+                requests={
+                    "cpu": test_site_config.MachineMetaData.test2large.Cores,
+                    "memory": test_site_config.MachineMetaData.test2large.Memory * 1e9,
+                }
             ),
             env=[
                 client.V1EnvVar(name="TardisDroneCores", value="2"),


### PR DESCRIPTION
This pull requests 

- changes the internal unit for memory requests to bytes, while the user requests memory in giga bytes. So that all site adapter behave the same. This includes changes in the documentation as well.
- adds a bit more verbose logging in case errors are returned by the Kubernetes API.
- adds the `TardisDrone...` environment variables to the pods deployed on the Kubernetes cluster.