### PR TITLE
Add unit documentation

### DIFF
--- a/docs/source/adapters/batchsystem.rst
+++ b/docs/source/adapters/batchsystem.rst
@@ -97,6 +97,8 @@ Available configuration options
 
 .. content-tabs:: left-col
 
+    .. |executor| replace:: :ref:`executor<ref_executors>`
+
     +----------------+-------------------------------------------------------------------------+-----------------+
     | Option         | Short Description                                                       | Requirement     |
     +================+=========================================================================+=================+

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -59,6 +59,10 @@ Available configuration options
     * `MachineTypeMetaData` containing a MappingNode for each machine type specifying the amount of Cores, Memory and Disk
       available
 
+    .. note::
+        The amount of memory and disk space is always specified in units of Gigabytes (GB) in `TARDIS`. The amount of
+        cores is equivalent to the number of single core job slots provided by a machine.
+
 .. container:: content-tabs right-col
 
     .. rubric:: Example configuration

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-08-04, command
+.. Created by changelog.py at 2021-08-05, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-08-04
+[Unreleased] - 2021-08-05
 =========================
 
 Added


### PR DESCRIPTION
This pull requests fixes a missing reference to `executor` in the batchsystem adapter documentation. In addition, it adds a note about the units used for memory as well as disk space in `TARDIS` and defines what is meant by a core in `TARDIS`. Therefore, this pull request fixes #174.