### PR TITLE
Enable GitHub Actions for automated docker builds

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -17,7 +17,18 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get containers to build
         id: get_containers
-        run: python3 -c 'import json; import os; os.chdir("containers"); print("::set-output name=containers::%s" % json.dumps([os.path.normpath(dirpath) for dirpath, dirnames, filenames in os.walk(".") if "Dockerfile" in filenames]))'
+        run: |
+           python3 -c '
+           import json
+           import pathlib
+           print(
+               "::set-output name=containers::%s"
+               % json.dumps([
+                       str(path.parent.relative_to("containers"))
+                       for path in pathlib.Path("containers").glob("**/Dockerfile")
+                   ]
+           ))
+           '
     outputs:
       containers: ${{ steps.get_containers.outputs.containers }}
 

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -2,7 +2,13 @@ name: Docker Builds
 
 on:
   push:
+    branches:
+      - '**'
+    tags:
+      - '*.*.*'
   pull_request:
+    branches:
+      - 'master'
 
 jobs:
   setup-docker-builds:
@@ -31,7 +37,8 @@ jobs:
           uses: docker/metadata-action@v3
           with:
             tags: |
-              type=match,pattern=\d.\d.\d
+              type=pep440,pattern={{version}}
+              type=raw,value=latest
             images: matterminers/${{ matrix.containers }}
         - name: Login to DockerHub
           if: github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master'

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -1,0 +1,52 @@
+name: Docker Builds
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  setup-docker-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get containers to build
+        id: get_containers
+        run: python3 -c 'import json; import os; os.chdir("containers"); print("::set-output name=containers::%s" % json.dumps([os.path.normpath(dirpath) for dirpath, dirnames, filenames in os.walk(".") if "Dockerfile" in filenames]))'
+    outputs:
+      containers: ${{ steps.get_containers.outputs.containers }}
+
+  docker-builds:
+      needs: setup-docker-builds
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          containers: ${{ fromJSON(needs.setup-docker-builds.outputs.containers) }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v3
+          with:
+            tags: |
+              type=match,pattern=\d.\d.\d
+            images: matterminers/${{ matrix.containers }}
+        - name: Login to DockerHub
+          if: github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master'
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        - name: Build
+          id: docker_build
+          uses: docker/build-push-action@v2
+          with:
+            context: containers/${{ matrix.containers }}
+            push: ${{ github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master' }}
+            file: containers/${{ matrix.containers }}/Dockerfile
+            tags: ${{ steps.meta.outputs.tags }}
+            build-args: |
+              SOURCE_BRANCH=${{ github.ref }}
+              SOURCE_REPO_URL=https://github.com/${{ github.repository }}

--- a/containers/cobald-tardis-htcondor/Dockerfile
+++ b/containers/cobald-tardis-htcondor/Dockerfile
@@ -17,7 +17,8 @@ RUN yum -y update \
                       python3-devel \
     && yum clean all
 
-RUN python3 -m pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH
 
 WORKDIR /srv
 

--- a/containers/cobald-tardis-htcondor/hooks/build
+++ b/containers/cobald-tardis-htcondor/hooks/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-SOURCE_REPO_URL=$(git remote get-url origin)
-SOURCE_REPO_HTTPS_URL=${SOURCE_REPO_URL/git@github.com:/https:\/\/github.com\/}
-docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg SOURCE_REPO_URL=${SOURCE_REPO_HTTPS_URL} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/containers/cobald-tardis/hooks/build
+++ b/containers/cobald-tardis/hooks/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-SOURCE_REPO_URL=$(git remote get-url origin)
-SOURCE_REPO_HTTPS_URL=${SOURCE_REPO_URL/git@github.com:/https:\/\/github.com\/}
-docker build --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg SOURCE_REPO_URL=${SOURCE_REPO_HTTPS_URL} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-08-10, command
+.. Created by changelog.py at 2021-08-18, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-08-18, command
+.. Created by changelog.py at 2021-09-01, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 


### PR DESCRIPTION
Docker Hub's Autobuild service has been discontinued for free plans. This pull request enables automated docker builds using GitHub Actions as replacement and fixes #191. 

- Docker builds of `tardis` tags/releases are tagged as `latest` and with the corresponding version (e.g. `0.7.0`).
- Docker builds of the `master` branch are tagged as `latest`.
- On all other `pull_request` and `push` events images are build, but not pushed into the docker hub registry. 