### PR TITLE
Adjust Prometheus plugin to the latest `aioprometheus` version 21.9.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-09-01, command
+.. Created by changelog.py at 2021-09-24, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "asyncssh",
         "aiotelegraf",
         "elasticsearch",
-        "aioprometheus",
+        "aioprometheus>=21.9.0",
         "kubernetes_asyncio",
         "pydantic",
     ],

--- a/tardis/plugins/prometheusmonitoring.py
+++ b/tardis/plugins/prometheusmonitoring.py
@@ -5,7 +5,8 @@ from ..interfaces.siteadapter import ResourceStatus
 from ..utilities.attributedict import AttributeDict
 
 import logging
-from aioprometheus import Service, Gauge
+from aioprometheus.service import Service
+from aioprometheus import Gauge
 
 logger = logging.getLogger("cobald.runtime.tardis.plugins.prometheusmonitoring")
 
@@ -36,7 +37,6 @@ class PrometheusMonitoring(Plugin):
         }
 
         for gauge in self._gauges.values():
-            self._svr.register(gauge)
             gauge.set({}, 0)
 
     async def start(self):


### PR DESCRIPTION
`aioprometheus` has changed its API so that metrics are automatically registered when they are created according to https://github.com/claws/aioprometheus/blob/master/CHANGELOG.md. With newer versions the unittest is failing, because the method to register new metrics does not exists anymore. This pull request changes the Prometheus plugin accordingly and enforces the installation of `aioprometheus>=21.9.0`.