### PR TITLE
Add english language packs to ubuntu, centos8 and rockylinux images

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.centos8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.centos8
@@ -11,6 +11,7 @@ RUN yum -y update \
                       gcc \
                       python38-devel \
                       nodejs \
+                      glibc-langpack-en \
     && yum clean all
 
 SHELL [ "/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c" ]

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
@@ -11,6 +11,7 @@ RUN yum -y update \
                       gcc \
                       python38-devel \
                       nodejs \
+                      glibc-langpack-en \
     && yum clean all
 
 SHELL [ "/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c" ]

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip\
+    python3 python3-pip language-pack-en\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu20_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu20_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip\
+    python3 python3-pip language-pack-en\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
In #183 a token generation cli will be introduced using https://github.com/tiangolo/typer. Typer is using [click](https://click.palletsprojects.com) for the CLI. Click is relying on correct set `LANG` environment on the host. In order to set `LANG=en_US.ut8` for the deployment tests, it is necessary to install the corresponding language packs in the deployment images. For `centos:7` those are installed by default in the docker base image.