### PR TITLE
Ensure python3.10 compatibility

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,8 @@ R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
-PSchuhmacher <leon_schuhmacher@yahoo.de>
-rfvc <florian.voncube@gmail.com>
+Matthias J. Schnepf <maschnepf@schnepf-net.de>
+Matthias Schnepf <maschnepf@schnepf-net.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
+rfvc <florian.voncube@gmail.com>
+PSchuhmacher <leon_schuhmacher@yahoo.de>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-09-24, command
+.. Created by changelog.py at 2021-10-06, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
         "cobald.config.yaml_constructors": [

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -4,7 +4,8 @@ import socket
 
 
 def async_return(*args, return_value=None, **kwargs):
-    f = asyncio.Future()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    f = loop.create_future()
     f.set_result(return_value)
     return f
 
@@ -36,5 +37,5 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
 
 
 def run_async(coroutine, *args, **kwargs):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     return loop.run_until_complete(coroutine(*args, **kwargs))


### PR DESCRIPTION
This pull request enables Python 3.10 unittests, adds 3.10 as supported release into `setup.py` and fixes a few deprecation warnings occuring when executing unittests under 3.10.