### PR TITLE
telegraf exception handling

### DIFF
--- a/tardis/plugins/telegrafmonitoring.py
+++ b/tardis/plugins/telegrafmonitoring.py
@@ -41,7 +41,6 @@ class TelegrafMonitoring(Plugin):
         :return: None
         """
         logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
-        await self.client.connect()
         data = dict(
             state=str(state),
             created=datetime.timestamp(resource_attributes.created),
@@ -51,5 +50,9 @@ class TelegrafMonitoring(Plugin):
             site_name=resource_attributes.site_name,
             machine_type=resource_attributes.machine_type,
         )
-        self.client.metric(self.metric, data, tags=tags)
-        await self.client.close()
+        try:
+            await self.client.connect()
+            self.client.metric(self.metric, data, tags=tags)
+            await self.client.close()
+        except OSError as e:
+            logger.warn(f"sending data to telegraf failed: {str(e)}")


### PR DESCRIPTION
This patch prevents the plugin `telegrafmonitoring` from throwing an exception (`socket.gaierror`) and stopping TARDIS when telegraf service is unreachable. Instead it logs a warning. This fixes the non-bug in already closed issue #189.

Optionally I could add a configuration variable making TARDIS crash if sending metrics to telegraf fails.