### PR TITLE
SSHExecutor respects MaxSessions

### DIFF
--- a/docs/source/changes/218.respect_ssh_maxsessions.yaml
+++ b/docs/source/changes/218.respect_ssh_maxsessions.yaml
@@ -1,0 +1,10 @@
+category: changed
+summary: "SSHExecutor respects the remote MaxSessions via queueing"
+description: |
+  The SSHExecutor now is aware of sshd MaxSessions, which is a limit on the concurrent
+  operations per connection. If more operations are to be run at once, operations are
+  queued until a session becomes available.
+pull requests:
+- 218
+issues:
+- 217

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "aioprometheus>=21.9.0",
         "kubernetes_asyncio",
         "pydantic",
+        "asyncstdlib",
     ],
     extras_require={
         "docs": [

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -6,7 +6,10 @@ from ..attributedict import AttributeDict
 
 import asyncio
 import asyncssh
-import asyncstdlib as a
+from asyncstdlib import (
+    ExitStack as AsyncExitStack,
+    contextmanager as asynccontextmanager,
+)
 
 
 async def probe_max_session(connection: asyncssh.SSHClientConnection):
@@ -18,7 +21,7 @@ async def probe_max_session(connection: asyncssh.SSHClientConnection):
     # - it should stay open without a separate task to manage it
     # - it should reliably and promptly clean up when done probing
     # `create_process` is a bit heavy but does all that.
-    async with a.ExitStack() as aes:
+    async with AsyncExitStack() as aes:
         try:
             while True:
                 await aes.enter_context(await connection.create_process())
@@ -52,7 +55,7 @@ class SSHExecutor(Executor):
         return await asyncssh.connect(**self._parameters)
 
     @property
-    @a.contextmanager
+    @asynccontextmanager
     async def bounded_connection(self):
         """
         Get the current connection with a single reserved session slot

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -66,8 +66,9 @@ class SSHExecutor(Executor):
                     self._session_bound = asyncio.Semaphore(value=max_session)
         assert self._ssh_connection is not None
         assert self._session_bound is not None
-        async with self._session_bound:
-            yield self._ssh_connection
+        bound, session = self._session_bound, self._ssh_connection
+        async with bound:
+            yield session
 
     @property
     def lock(self):

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -5,6 +5,22 @@ from ..attributedict import AttributeDict
 
 import asyncio
 import asyncssh
+import asyncstdlib as a
+
+
+async def probe_max_session(connection: asyncssh.SSHClientConnection):
+    """
+    Probe the sshd `MaxSessions`, i.e. the multiplexing limit per connection
+    """
+    sessions = 0
+    async with a.ExitStack() as aes:
+        try:
+            while True:
+                await aes.enter_context(await connection.create_process())
+                sessions += 1
+        except asyncssh.ChannelOpenError:
+            pass
+    return sessions
 
 
 @enable_yaml_load("!SSHExecutor")

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -14,6 +14,10 @@ async def probe_max_session(connection: asyncssh.SSHClientConnection):
     Probe the sshd `MaxSessions`, i.e. the multiplexing limit per connection
     """
     sessions = 0
+    # It does not actually matter what kind of session we open here, but:
+    # - it should stay open without a separate task to manage it
+    # - it should reliably and promptly clean up when done probing
+    # `create_process` is a bit heavy but does all that.
     async with a.ExitStack() as aes:
         try:
             while True:

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -98,7 +98,9 @@ class SSHExecutor(Executor):
                 if ssh_connection is self._ssh_connection:
                     self._ssh_connection = None
                 raise CommandExecutionFailure(
-                    message=f"Could not run command {command} due to SSH failure: {coe}",
+                    message=(
+                        f"Could not run command {command} due to SSH failure: {coe}"
+                    ),
                     exit_code=255,
                     stdout="",
                     stderr="SSH Broken Connection",

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -14,8 +14,11 @@ import contextlib
 from asyncstdlib import contextmanager as asynccontextmanager
 
 
+DEFAULT_MAX_SESSIONS = 10
+
+
 class MockConnection(object):
-    def __init__(self, exception=None, __max_sessions=10, **kwargs):
+    def __init__(self, exception=None, __max_sessions=DEFAULT_MAX_SESSIONS, **kwargs):
         self.exception = exception and exception(**kwargs)
         self.max_sessions = __max_sessions
         self.current_sessions = 0
@@ -55,7 +58,9 @@ class MockConnection(object):
 class TestSSHExecutorUtilities(TestCase):
     def test_max_sessions(self):
         with self.subTest(sessions="default"):
-            self.assertEqual(10, run_async(probe_max_session, MockConnection()))
+            self.assertEqual(
+                DEFAULT_MAX_SESSIONS, run_async(probe_max_session, MockConnection())
+            )
         for expected in (1, 9, 11, 20, 100):
             with self.subTest(sessions=expected):
                 self.assertEqual(

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -1,6 +1,6 @@
 from tests.utilities.utilities import async_return, run_async
 from tardis.utilities.attributedict import AttributeDict
-from tardis.utilities.executors.sshexecutor import SSHExecutor
+from tardis.utilities.executors.sshexecutor import SSHExecutor, probe_max_session
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 
 from asyncssh import ChannelOpenError, ConnectionLost, DisconnectError, ProcessError
@@ -45,6 +45,18 @@ class MockConnection(object):
                 yield
 
         return fake_process()
+
+
+class TestSSHExecutorUtilities(TestCase):
+    def test_max_sessions(self):
+        with self.subTest(sessions="default"):
+            self.assertEqual(10, run_async(probe_max_session, MockConnection()))
+        for expected in (1, 9, 11, 20, 100):
+            with self.subTest(sessions=expected):
+                self.assertEqual(
+                    expected,
+                    run_async(probe_max_session, MockConnection(None, expected)),
+                )
 
 
 class TestSSHExecutor(TestCase):

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -103,18 +103,16 @@ class TestSSHExecutor(TestCase):
         self.mock_asyncssh.connect.side_effect = None
 
     def test_connection_property(self):
-        async def helper_coroutine():
-            return await self.executor.ssh_connection
+        async def force_connection():
+            async with self.executor.bounded_connection as connection:
+                return connection
 
         self.assertIsNone(self.executor._ssh_connection)
-        run_async(helper_coroutine)
-
+        run_async(force_connection)
         self.assertIsInstance(self.executor._ssh_connection, MockConnection)
-
         current_ssh_connection = self.executor._ssh_connection
-
-        run_async(helper_coroutine)
-
+        run_async(force_connection)
+        # make sure the connection is not needlessly replaced
         self.assertEqual(self.executor._ssh_connection, current_ssh_connection)
 
     def test_lock(self):

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -144,11 +144,11 @@ class TestSSHExecutor(TestCase):
         async def is_queued(n: int):
             """Check whether the n'th command runs is queued or immediately"""
             background = [
-                asyncio.create_task(self.executor.run_command("sleep 5"))
+                asyncio.ensure_future(self.executor.run_command("sleep 5"))
                 for _ in range(n - 1)
             ]
             # probe can only finish in time if it is not queued
-            probe = asyncio.create_task(self.executor.run_command("sleep 0.01"))
+            probe = asyncio.ensure_future(self.executor.run_command("sleep 0.01"))
             await asyncio.sleep(0.05)
             queued = not probe.done()
             for task in background + [probe]:

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import asyncio
 import yaml
 import contextlib
-import asyncstdlib as a
+from asyncstdlib import contextmanager as asynccontextmanager
 
 
 class MockConnection(object):
@@ -44,7 +44,7 @@ class MockConnection(object):
             )
 
     async def create_process(self):
-        @a.contextmanager
+        @asynccontextmanager
         async def fake_process():
             with self._multiplex_session():
                 yield

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -142,11 +142,12 @@ class TestSSHExecutor(TestCase):
         # There is no way to directly count how many "commands" are running at once:
         # if we do something "while" `run_command` is active, we don't know whether
         # it actually runs or is queued.
+        #
         # This approach exploits that MaxSessions queueing will start n=MaxSessions
         # commands immediately, but the n+1'th command will run `delay` seconds later.
         # As each command adds itself and then waits for `delay / 2` before removing
         # itself, there is a window of roughly [delay, delay * 1.5] during which all
-        # n sessions are counted.
+        # first n sessions are counted.
         # Note that for this to work, `delay` must be larger than `asyncio`'s task
         # switching speed.
         async def count_sessions():

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -34,6 +34,11 @@ class MockConnection(object):
         with self._multiplex_session():
             if self.exception:
                 raise self.exception
+            if command.startswith("sleep"):
+                _, duration = command.split()
+                await asyncio.sleep(float(duration))
+            elif command != "Test":
+                raise ValueError(f"Unsupported mock command: {command}")
             return AttributeDict(
                 stdout=input and input.decode(), stderr="TestError", exit_status=0
             )


### PR DESCRIPTION
This PR changes ``SSHExecutor`` to use at most ``MaxSessions`` at once.

* [x] Detect remote sshd ``MaxSessions`` via probing
* [x] Limit concurrent sessions

This is a rather straightforward implementation of step 1 in #217. After opening a new connection, it is probed until ``ChannelOpenError`` to deduce the remote ``MaxSessions``. This limit is then enforced using a Semaphore on accessing the connection, queueing additional requests.  
The large diff of ``run_command`` is because the Semaphore logic works best with a context manager.