### PR TITLE
Fix machine_type unique constraint to support a machine_type for multiple sites

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,9 +4,9 @@ Manuel Giffels <giffels@gmail.com>
 Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
+Max Fischer <maxfischer2781@gmail.com>
 ubdsv <ubdsv@student.kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
-Max Fischer <maxfischer2781@gmail.com>
 Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-11-29, command
+.. Created by changelog.py at 2021-11-30, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,13 +6,18 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-11-29
+[Unreleased] - 2021-11-30
 =========================
 
 Changed
 -------
 
 * SSHExecutor respects the remote MaxSessions via queueing
+
+Fixed
+-----
+
+* Unique constraints in database schema have been fixed to allow same machine_type and remote_resource_uuid on multiple sites
 
 [0.6.0] - 2021-08-09
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,18 @@
-.. Created by changelog.py at 2021-10-06, command
-   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.9/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2021-11-25, command
+   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
+
+[Unreleased] - 2021-11-25
+=========================
+
+Changed
+-------
+
+* SSHExecutor respects the remote MaxSessions via queueing
 
 [0.6.0] - 2021-08-09
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2021-11-25, command
+.. Created by changelog.py at 2021-11-29, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2021-11-25
+[Unreleased] - 2021-11-29
 =========================
 
 Changed

--- a/docs/source/changes/220.fix_unique_constraints_db_schema.yaml
+++ b/docs/source/changes/220.fix_unique_constraints_db_schema.yaml
@@ -1,0 +1,9 @@
+category: fixed
+summary: "Unique constraints in database schema have been fixed to allow same machine_type and remote_resource_uuid on multiple sites"
+description: |
+  The unique constraints in the datebase schema have been relaxed to allow the same machine_type and the same
+  remote_resource_uuid to be used on multiple sites. In addition, the unittest of the SqliteRegistry have been improved.
+pull_requests:
+  - 220
+issues:
+  - 219

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -5,7 +5,7 @@ from ..interfaces.state import State
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import List, Dict
+from typing import List, Dict, Generator
 import asyncio
 import logging
 import sqlite3
@@ -24,9 +24,11 @@ class SqliteRegistry(Plugin):
         configuration = Configuration()
         self._db_file = configuration.Plugins.SqliteRegistry.db_file
         self._deploy_db_schema()
-        self._dispatch_on_state = dict(
-            BootingState=self.insert_resource, DownState=self.delete_resource
-        )
+        self._dispatch_on_state = {
+            "BootingState": self.insert_resource,
+            "DownState": self.delete_resource,
+        }
+
         self.thread_pool_executor = ThreadPoolExecutor(max_workers=1)
 
         for site in configuration.Sites:
@@ -35,7 +37,7 @@ class SqliteRegistry(Plugin):
                 self.add_machine_types(site.name, machine_type)
 
     def add_machine_types(self, site_name: str, machine_type: str) -> None:
-        if self.get_machine_type(site_name, machine_type):
+        if self._get_machine_type(site_name, machine_type):
             logger.debug(
                 f"{machine_type} is already present for {site_name} in database! Skipping insertion!"  # noqa B950
             )
@@ -44,38 +46,38 @@ class SqliteRegistry(Plugin):
         INSERT OR ROLLBACK INTO MachineTypes(machine_type, site_id)
         SELECT :machine_type, Sites.site_id FROM Sites
         WHERE Sites.site_name = :site_name"""
-        self.execute(sql_query, dict(site_name=site_name, machine_type=machine_type))
+        self.execute(sql_query, {"site_name": site_name, "machine_type": machine_type})
 
-    def get_machine_type(self, site_name: str, machine_type: str) -> List[Dict]:
+    def _get_machine_type(self, site_name: str, machine_type: str) -> List[Dict]:
         sql_query = """
         SELECT * FROM MachineTypes MT
         JOIN Sites S ON MT.site_id = S.site_id
         WHERE MT.machine_type = :machine_type AND S.site_name = :site_name"""
         return self.execute(
-            sql_query, dict(site_name=site_name, machine_type=machine_type)
+            sql_query, {"site_name": site_name, "machine_type": machine_type}
         )
 
     def add_site(self, site_name: str) -> None:
-        if self.get_site(site_name):
+        if self._get_site(site_name):
             logger.debug(
                 f"{site_name} already present in database! Skipping insertion!"
             )
             return
         sql_query = "INSERT OR ROLLBACK INTO Sites(site_name) VALUES (:site_name)"
-        self.execute(sql_query, dict(site_name=site_name))
+        self.execute(sql_query, {"site_name": site_name})
 
-    def get_site(self, site_name: str) -> List[Dict]:
+    def _get_site(self, site_name: str) -> List[Dict]:
         sql_query = "SELECT * FROM Sites WHERE site_name = :site_name"
-        return self.execute(sql_query, dict(site_name=site_name))
+        return self.execute(sql_query, {"site_name": site_name})
 
-    async def async_execute(self, sql_query: str, bind_parameters: dict) -> List[Dict]:
+    async def async_execute(self, sql_query: str, bind_parameters: Dict) -> List[Dict]:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             self.thread_pool_executor, self.execute, sql_query, bind_parameters
         )
 
     @contextmanager
-    def connect(self) -> None:
+    def connect(self) -> Generator[sqlite3.Connection, None, None]:
         con = sqlite3.connect(
             self._db_file, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
         )
@@ -134,13 +136,13 @@ class SqliteRegistry(Plugin):
                     (state,),
                 )
 
-    async def delete_resource(self, bind_parameters: dict) -> None:
+    async def delete_resource(self, bind_parameters: Dict) -> None:
         sql_query = """DELETE FROM Resources
         WHERE drone_uuid = :drone_uuid
         AND site_id = (SELECT site_id from Sites WHERE site_name = :site_name)"""
         await self.async_execute(sql_query, bind_parameters)
 
-    def execute(self, sql_query: str, bind_parameters: dict) -> List[Dict]:
+    def execute(self, sql_query: str, bind_parameters: Dict) -> List[Dict]:
         with self.connect() as connection:
             connection.row_factory = lambda cur, row: {
                 col[0]: row[idx] for idx, col in enumerate(cur.description)
@@ -159,10 +161,10 @@ class SqliteRegistry(Plugin):
         JOIN MachineTypes MT ON R.machine_type_id = MT.machine_type_id
         WHERE S.site_name = :site_name AND MT.machine_type = :machine_type"""
         return self.execute(
-            sql_query, dict(site_name=site_name, machine_type=machine_type)
+            sql_query, {"site_name": site_name, "machine_type": machine_type}
         )
 
-    async def insert_resource(self, bind_parameters: dict) -> None:
+    async def insert_resource(self, bind_parameters: Dict) -> None:
         sql_query = """
         INSERT OR ROLLBACK INTO
         Resources(remote_resource_uuid, drone_uuid, state_id, site_id, machine_type_id,
@@ -179,11 +181,11 @@ class SqliteRegistry(Plugin):
     async def notify(self, state: State, resource_attributes: AttributeDict) -> None:
         state = str(state)
         logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
-        bind_parameters = dict(state=state)
+        bind_parameters = {"state": state}
         bind_parameters.update(resource_attributes)
         await self._dispatch_on_state.get(state, self.update_resource)(bind_parameters)
 
-    async def update_resource(self, bind_parameters: dict) -> None:
+    async def update_resource(self, bind_parameters: Dict) -> None:
         sql_query = """UPDATE Resources SET updated = :updated,
         state_id = (SELECT state_id FROM ResourceStates WHERE state = :state)
         WHERE drone_uuid = :drone_uuid

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -5,6 +5,7 @@ from ..interfaces.state import State
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from typing import List, Dict
 import asyncio
 import logging
 import sqlite3
@@ -33,25 +34,48 @@ class SqliteRegistry(Plugin):
             for machine_type in getattr(configuration, site.name).MachineTypes:
                 self.add_machine_types(site.name, machine_type)
 
-    def add_machine_types(self, site_name: str, machine_type: str):
+    def add_machine_types(self, site_name: str, machine_type: str) -> None:
+        if self.get_machine_type(site_name, machine_type):
+            logger.debug(
+                f"{machine_type} is already present for {site_name} in database! Skipping insertion!"  # noqa B950
+            )
+            return
         sql_query = """
-        INSERT OR IGNORE INTO MachineTypes(machine_type, site_id)
+        INSERT OR ROLLBACK INTO MachineTypes(machine_type, site_id)
         SELECT :machine_type, Sites.site_id FROM Sites
         WHERE Sites.site_name = :site_name"""
         self.execute(sql_query, dict(site_name=site_name, machine_type=machine_type))
 
-    def add_site(self, site_name: str):
-        sql_query = "INSERT OR IGNORE INTO Sites(site_name) VALUES (:site_name)"
+    def get_machine_type(self, site_name: str, machine_type: str) -> List[Dict]:
+        sql_query = """
+        SELECT * FROM MachineTypes MT
+        JOIN Sites S ON MT.site_id = S.site_id
+        WHERE MT.machine_type = :machine_type AND S.site_name = :site_name"""
+        return self.execute(
+            sql_query, dict(site_name=site_name, machine_type=machine_type)
+        )
+
+    def add_site(self, site_name: str) -> None:
+        if self.get_site(site_name):
+            logger.debug(
+                f"{site_name} already present in database! Skipping insertion!"
+            )
+            return
+        sql_query = "INSERT OR ROLLBACK INTO Sites(site_name) VALUES (:site_name)"
         self.execute(sql_query, dict(site_name=site_name))
 
-    async def async_execute(self, sql_query: str, bind_parameters: dict):
+    def get_site(self, site_name: str) -> List[Dict]:
+        sql_query = "SELECT * FROM Sites WHERE site_name = :site_name"
+        return self.execute(sql_query, dict(site_name=site_name))
+
+    async def async_execute(self, sql_query: str, bind_parameters: dict) -> List[Dict]:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             self.thread_pool_executor, self.execute, sql_query, bind_parameters
         )
 
     @contextmanager
-    def connect(self):
+    def connect(self) -> None:
         con = sqlite3.connect(
             self._db_file, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
         )
@@ -61,7 +85,7 @@ class SqliteRegistry(Plugin):
         finally:
             con.close()
 
-    def _deploy_db_schema(self):
+    def _deploy_db_schema(self) -> None:
         tables = {
             "MachineTypes": [
                 "machine_type_id INTEGER PRIMARY KEY AUTOINCREMENT",
@@ -72,7 +96,7 @@ class SqliteRegistry(Plugin):
             ],
             "Resources": [
                 "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                "remote_resource_uuid VARCHAR(255) UNIQUE",
+                "remote_resource_uuid VARCHAR(255)",
                 "drone_uuid VARCHAR(255) UNIQUE",
                 "state_id INTEGER",
                 "site_id INTEGER",
@@ -82,6 +106,7 @@ class SqliteRegistry(Plugin):
                 "FOREIGN KEY(state_id) REFERENCES ResourceState(state_id)",
                 "FOREIGN KEY(site_id) REFERENCES Sites(site_id)",
                 "FOREIGN KEY(machine_type_id) REFERENCES MachineTypes(machine_type_id)",
+                "CONSTRAINT unique_remote_resource_uuid_per_site UNIQUE (site_id, remote_resource_uuid)",  # noqa B950
             ],
             "ResourceStates": [
                 "state_id INTEGER PRIMARY KEY AUTOINCREMENT",
@@ -109,13 +134,13 @@ class SqliteRegistry(Plugin):
                     (state,),
                 )
 
-    async def delete_resource(self, bind_parameters: dict):
+    async def delete_resource(self, bind_parameters: dict) -> None:
         sql_query = """DELETE FROM Resources
         WHERE drone_uuid = :drone_uuid
         AND site_id = (SELECT site_id from Sites WHERE site_name = :site_name)"""
         await self.async_execute(sql_query, bind_parameters)
 
-    def execute(self, sql_query: str, bind_parameters: dict):
+    def execute(self, sql_query: str, bind_parameters: dict) -> List[Dict]:
         with self.connect() as connection:
             connection.row_factory = lambda cur, row: {
                 col[0]: row[idx] for idx, col in enumerate(cur.description)
@@ -125,7 +150,7 @@ class SqliteRegistry(Plugin):
             logger.debug(f"{sql_query},{bind_parameters} executed")
             return cursor.fetchall()
 
-    def get_resources(self, site_name: str, machine_type: str):
+    def get_resources(self, site_name: str, machine_type: str) -> List[Dict]:
         sql_query = """
         SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, R.created, R.updated
         FROM Resources R
@@ -137,9 +162,9 @@ class SqliteRegistry(Plugin):
             sql_query, dict(site_name=site_name, machine_type=machine_type)
         )
 
-    async def insert_resource(self, bind_parameters: dict):
+    async def insert_resource(self, bind_parameters: dict) -> None:
         sql_query = """
-        INSERT OR IGNORE INTO
+        INSERT OR ROLLBACK INTO
         Resources(remote_resource_uuid, drone_uuid, state_id, site_id, machine_type_id,
         created, updated)
         SELECT :remote_resource_uuid, :drone_uuid, RS.state_id, S.site_id,
@@ -158,7 +183,7 @@ class SqliteRegistry(Plugin):
         bind_parameters.update(resource_attributes)
         await self._dispatch_on_state.get(state, self.update_resource)(bind_parameters)
 
-    async def update_resource(self, bind_parameters: dict):
+    async def update_resource(self, bind_parameters: dict) -> None:
         sql_query = """UPDATE Resources SET updated = :updated,
         state_id = (SELECT state_id FROM ResourceStates WHERE state = :state)
         WHERE drone_uuid = :drone_uuid

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -65,9 +65,10 @@ class SqliteRegistry(Plugin):
         tables = {
             "MachineTypes": [
                 "machine_type_id INTEGER PRIMARY KEY AUTOINCREMENT",
-                "machine_type VARCHAR(255) UNIQUE",
+                "machine_type VARCHAR(255)",
                 "site_id INTEGER",
                 "FOREIGN KEY(site_id) REFERENCES Sites(site_id)",
+                "CONSTRAINT unique_machine_type_per_site UNIQUE (machine_type, site_id)",  # noqa B950
             ],
             "Resources": [
                 "id INTEGER PRIMARY KEY AUTOINCREMENT,"

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -210,7 +210,7 @@ class TestSqliteRegistry(TestCase):
             run_async(
                 self.registry.notify, BootingState(), self.test_resource_attributes
             )
-        self.assertTrue("UNIQUE constraint failed" in str(ie.exception))
+        self.assertTrue("unique" in str(ie.exception).lower())
 
         run_async(
             self.registry.notify,
@@ -250,7 +250,7 @@ class TestSqliteRegistry(TestCase):
 
         with self.assertRaises(sqlite3.IntegrityError) as ie:
             run_async(self.registry.insert_resource, bind_parameters)
-        self.assertTrue("UNIQUE constraint failed" in str(ie.exception))
+        self.assertTrue("unique" in str(ie.exception).lower())
 
         self.assertListEqual([self.test_notify_result], fetch_all())
 

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -109,6 +109,8 @@ class TestSqliteRegistry(TestCase):
             self.registry.add_site(site_name)
             self.registry.add_machine_types(site_name, self.test_machine_type)
 
+        # Database content has to be checked several times
+        # Define inline function to re-use code
         def check_db_content():
             machine_types = self.execute_db_query(
                 sql_query="""SELECT MachineTypes.machine_type, Sites.site_name
@@ -141,6 +143,8 @@ class TestSqliteRegistry(TestCase):
         test_site_names = (self.test_site_name, self.other_test_site_name)
         self.registry.add_site(test_site_names[0])
 
+        # Database content has to be checked several times
+        # Define inline function to re-use code
         def check_db_content():
             for row, site_name in zip(
                 self.execute_db_query("SELECT site_name FROM Sites"), test_site_names
@@ -189,6 +193,8 @@ class TestSqliteRegistry(TestCase):
 
     @patch("tardis.plugins.sqliteregistry.logging", Mock())
     def test_notify(self):
+        # Database has to be queried multiple times
+        # Define inline function to re-use code
         def fetch_all():
             return self.execute_db_query(
                 sql_query="""SELECT R.remote_resource_uuid, R.drone_uuid, RS.state,
@@ -227,6 +233,8 @@ class TestSqliteRegistry(TestCase):
         self.assertListEqual([], fetch_all())
 
     def test_insert_resources(self):
+        # Database has to be queried multiple times
+        # Define inline function to re-use code
         def fetch_all():
             return self.execute_db_query(
                 sql_query="""SELECT R.remote_resource_uuid, R.drone_uuid, RS.state,
@@ -242,7 +250,8 @@ class TestSqliteRegistry(TestCase):
             self.registry.add_site(site_name)
             self.registry.add_machine_types(site_name, self.test_machine_type)
 
-        bind_parameters = dict(state="BootingState", **self.test_resource_attributes)
+        bind_parameters = {"state": "BootingState"}
+        bind_parameters.update(self.test_resource_attributes)
 
         run_async(self.registry.insert_resource, bind_parameters)
 
@@ -255,7 +264,8 @@ class TestSqliteRegistry(TestCase):
         self.assertListEqual([self.test_notify_result], fetch_all())
 
         # Test same remote_resource_uuids on different sites
-        bind_parameters = dict(state="BootingState", **self.test_resource_attributes)
+        bind_parameters = {"state": "BootingState"}
+        bind_parameters.update(self.test_resource_attributes)
         bind_parameters["drone_uuid"] = f"{self.other_test_site_name}-045285abef1"
         bind_parameters["site_name"] = self.other_test_site_name
 


### PR DESCRIPTION
This pull request fixes a bug in the database schema of the `SqliteRegistry` plugin. In the current schema it was not possible to have the very same `MachineTypes` on different `Sites`, since the unique constraints put on the database table were too strict. This pull request introduces a more relaxed unique constraint, that requires only the combination (`MachineType`, `Site`) to be unique.

In addition, this pull request introduces a more relaxed unique constraint on the `Resources` table, too. Now it is possible that the same `remote_resource_uuid` can be used at different sites within the same table. This was not mentioned in #219, but could lead to further trouble in the future. For example, two HTCondor batch systems at different sites can have the same job number used as `remote_resource_uuid`.

In addition, the unittest of the `SqliteRegistry` have been improved by adding both scenarios mentioned above and de-duplicate some of the test code.

Fixes #219 