### PR TITLE
Fix missing libgcc for cryptography

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,9 +2,9 @@ Contributors ordered by number of commits:
 ==========================================
 Manuel Giffels <giffels@gmail.com>
 Stefan Kroboth <stefan.kroboth@gmail.com>
+Max Fischer <maxfischer2781@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
-Max Fischer <maxfischer2781@gmail.com>
 ubdsv <ubdsv@student.kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Leon Schuhmacher <ji7635@partner.kit.edu>

--- a/containers/cobald-tardis/Dockerfile
+++ b/containers/cobald-tardis/Dockerfile
@@ -13,6 +13,8 @@ RUN apk add --no-cache --virtual .build_deps \
     && pip install --no-cache-dir git+$SOURCE_REPO_URL@$SOURCE_BRANCH \
     && apk del --no-network .build_deps
 
+RUN apk add --no-cache --update libgcc
+
 WORKDIR /srv
 
 COPY cobald.yml /srv/cobald.yml

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-01-28, command
+.. Created by changelog.py at 2022-02-23, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-01-28
+[Unreleased] - 2022-02-23
 =========================
 
 Added


### PR DESCRIPTION
As reported by @stefan-k on Mattermost, `libgcc` is missing in the `cobald-tardis` container, which is necessary for the `cryptography` python package. 

This pull request adds `libgcc` to the image. 