### PR TITLE
Set elasticsearch client version to >=7.17,<8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "cobald>=0.12.3",
         "asyncssh",
         "aiotelegraf",
-        "elasticsearch",
+        "elasticsearch>=7.17,<8.0.0",
         "aioprometheus>=21.9.0",
         "kubernetes_asyncio",
         "pydantic",

--- a/tardis/plugins/elasticsearchmonitoring.py
+++ b/tardis/plugins/elasticsearchmonitoring.py
@@ -25,7 +25,9 @@ class ElasticsearchMonitoring(Plugin):
         self._index = config.index
         self._meta = getattr(config, "meta", "")
 
-        self._es = Elasticsearch([{"host": config.host, "port": config.port}])
+        self._es = Elasticsearch(
+            [{"scheme": "http", "host": config.host, "port": config.port}]
+        )
 
     async def notify(self, state: State, resource_attributes: AttributeDict) -> None:
         """
@@ -47,7 +49,7 @@ class ElasticsearchMonitoring(Plugin):
             "state": str(state),
             "meta": self._meta,
             "timestamp": int(time() * 1000),
-            "resource_status": str(resource_attributes["resource_status"]),
+            "resource_status": str(resource_attributes.get("resource_status", "")),
         }
 
         await self.async_execute(document)

--- a/tests/plugins_t/test_elasticsearchmonitoring.py
+++ b/tests/plugins_t/test_elasticsearchmonitoring.py
@@ -80,3 +80,39 @@ class TestElasticsearchMonitoring(TestCase):
             id=f"{test_param.drone_uuid}-2",
             index=f"{self.plugin._index}-{self.mock_datetime.now.return_value.strftime.return_value}",  # noqa: B950
         )
+
+    def test_notify_resource_status_missing(self):
+        test_param = AttributeDict(
+            site_name="test-site",
+            machine_type="test_machine_type",
+            created=datetime.now(),
+            updated=datetime.now(),
+            drone_uuid="test-drone",
+        )
+
+        test_param_ext = {
+            **test_param,
+            "state": str(CleanupState()),
+            "meta": self.plugin._meta,
+            "timestamp": int(self.mock_time.return_value * 1000),
+            "resource_status": "",
+            "revision": 2,
+        }
+
+        self.mock_elasticsearch.return_value.search.return_value = {
+            "hits": {"total": {"value": 2}}
+        }
+
+        run_async(
+            self.plugin.notify, state=CleanupState(), resource_attributes=test_param
+        )
+
+        self.mock_elasticsearch.return_value.search.assert_called_with(
+            index=f"{self.plugin._index}*",
+            body={"query": {"term": {"drone_uuid.keyword": test_param.drone_uuid}}},
+        )
+        self.mock_elasticsearch.return_value.create.assert_called_with(
+            body=test_param_ext,
+            id=f"{test_param.drone_uuid}-2",
+            index=f"{self.plugin._index}-{self.mock_datetime.now.return_value.strftime.return_value}",  # noqa: B950
+        )


### PR DESCRIPTION
The latest versions of the Elasticsearch client have a compatibility mode which can also be used for newer server versions; however, the other way around does not work. Fixing the version to >=7.17,<8.0.0 is therefore a save option for the near future.
This commit also includes a fix for the case where "resource_status" is not part of `resource_attributes`, which occasionally caused crashes. If this key is not present, `resource_status` will be set to an empty string.
Also, newer versions of the Elasticsearch client require the "scheme" parameter to be set. By setting this already, it will be easier to eventually transition to client version 8.