### PR TITLE
Add git to ubuntu deployment docker images

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip language-pack-en\
+    python3 python3-pip language-pack-en git\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu20_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu20_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip language-pack-en\
+    python3 python3-pip language-pack-en git\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-02-23, command
+.. Created by changelog.py at 2022-03-07, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-02-23
+[Unreleased] - 2022-03-07
 =========================
 
 Added


### PR DESCRIPTION
This pull requests adds `git` to the Ubuntu 18.04 and  Ubunut 20.04 deployment docker images.