### PR TITLE
Update state transition for stopped workers

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-03-07, command
+.. Created by changelog.py at 2022-03-09, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-03-07
+[Unreleased] - 2022-03-09
 =========================
 
 Added

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -143,7 +143,7 @@ class AvailableState(State):
     transition = {
         ResourceStatus.Running: lambda: {
             MachineStatus.Available: lambda: AvailableState(),
-            MachineStatus.NotAvailable: lambda: IntegratingState(),
+            MachineStatus.NotAvailable: lambda: ShutDownState(),
             MachineStatus.Draining: lambda: DrainingState(),
             MachineStatus.Drained: lambda: DisintegrateState(),
         },

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -197,7 +197,7 @@ class TestDroneStates(TestCase):
     def test_available_state(self):
         matrix = [
             (ResourceStatus.Running, MachineStatus.Available, AvailableState),
-            (ResourceStatus.Running, MachineStatus.NotAvailable, IntegratingState),
+            (ResourceStatus.Running, MachineStatus.NotAvailable, ShutDownState),
             (ResourceStatus.Running, MachineStatus.Draining, DrainingState),
             (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
             (ResourceStatus.Booting, MachineStatus.NotAvailable, BootingState),


### PR DESCRIPTION
During the integration of OpenStack cloud resources for PUNCH4NFDI, I noticed an unexpected behaviour for Drones in `AvailableState`. In this state the status of the resource (OpenStack VM) and the machine status (availability in HTCondor) is checked. Both status are used to decided on a possible state transition.

Due to missing payloads, the HTCondor daemon on this node shutdown automatically causing the machine status to be `NotAvailable`. While the resource status continues to be `Running`. In that case the drone state is reset to `IntegratingState`. Since HTCondor is not restarted, the Drone remains in this state forever. 

I would like to discuss the following change in this pull request. In case of the behaviour descriibed above, I would like to move the Drone into `ShutDown` state causing the VM to be stopped in OpenStack. What do you think?
