### PR TITLE
Maintenance for AsyncBulkCall

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 statistics = True
 max-line-length = 80
-ignore = E501, B008, B011, W503
+ignore = E501, B008, B011, B019, W503
 select = C,E,F,W,B,B9
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -73,7 +73,7 @@ class AsyncBulkCall(Generic[T, R]):
         self._delay = delay
         self._concurrency = sys.maxsize if concurrent is None else concurrent
         # task handling dispatch from queue to command execution
-        self._master_worker: Optional[asyncio.Task] = None
+        self._dispatch_task: Optional[asyncio.Task] = None
         # tasks handling individual command executions
         self._bulk_tasks: Set[asyncio.Task] = set()
         self._verify_settings()
@@ -108,8 +108,8 @@ class AsyncBulkCall(Generic[T, R]):
 
     def _ensure_worker(self):
         """Ensure there is a worker to dispatch tasks for command execution"""
-        if self._master_worker is None:
-            self._master_worker = asyncio.ensure_future(self._bulk_dispatch())
+        if self._dispatch_task is None:
+            self._dispatch_task = asyncio.ensure_future(self._bulk_dispatch())
 
     async def _bulk_dispatch(self):
         """Collect tasks into bulks and dispatch them for command execution"""

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -113,7 +113,7 @@ class AsyncBulkCall(Generic[T, R]):
 
     async def _bulk_dispatch(self):
         """Collect tasks into bulks and dispatch them for command execution"""
-        while True:
+        while not self._queue.empty():
             bulk = list(zip(*(await self._get_bulk())))
             if not bulk:
                 continue
@@ -131,6 +131,7 @@ class AsyncBulkCall(Generic[T, R]):
             # yield to the event loop so that the `while True` loop does not arbitrarily
             # delay other tasks on the fast paths for `_get_bulk` and `acquire`.
             await asyncio.sleep(0)
+        self._dispatch_task = None
 
     async def _get_bulk(self) -> "List[Tuple[T, asyncio.Future[R]]]":
         """Fetch the next bulk from the internal queue"""

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -138,6 +138,7 @@ class AsyncBulkCall(Generic[T, R]):
         # always pull in at least one item asynchronously
         # this avoids stalling for very low delays and efficiently waits for items
         results = [await queue.get()]
+        queue.task_done()
         deadline = time.monotonic() + self._delay
         while len(results) < max_items and time.monotonic() < deadline:
             try:

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -102,7 +102,7 @@ class AsyncBulkCall(Generic[T, R]):
     async def __call__(self, __task: T) -> R:
         """Queue a ``task`` for bulk execution and return the result when available"""
         result: "asyncio.Future[R]" = asyncio.get_event_loop().create_future()
-        await self._queue.put((__task, result))
+        self._queue.put_nowait((__task, result))
         self._ensure_worker()
         return await result
 

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -69,7 +69,7 @@ class TestAsyncBulkCall(TestCase):
         bunch_size = 4
         # use large delay to only trigger on size
         execution = AsyncBulkCall(CallCounter(), size=bunch_size // 2, delay=256)
-        for repeat in range(4):
+        for repeat in range(6):
             result = await self.execute(execution, bunch_size)
             self.assertEqual(
                 result, [(i, i // 2 + repeat * 2) for i in range(bunch_size)]

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -72,7 +72,7 @@ class TestAsyncBulkCall(TestCase):
         for repeat in range(4):
             result = await self.execute(execution, bunch_size)
             self.assertEqual(
-                result, [(i, i//2 + repeat * 2) for i in range(bunch_size)]
+                result, [(i, i // 2 + repeat * 2) for i in range(bunch_size)]
             )
             await asyncio.sleep(0.01)  # pause to allow for cleanup
             assert execution._dispatch_task is None

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -61,6 +61,22 @@ class TestAsyncBulkCall(TestCase):
         result = run_async(self.execute, execution, count=2048)
         self.assertEqual(result, [(i, i) for i in range(2048)])
 
+    def test_restart(self):
+        """Test that calls work after pausing"""
+        run_async(self.check_restart)
+
+    async def check_restart(self):
+        bunch_size = 4
+        # use large delay to only trigger on size
+        execution = AsyncBulkCall(CallCounter(), size=bunch_size // 2, delay=256)
+        for repeat in range(4):
+            result = await self.execute(execution, bunch_size)
+            self.assertEqual(
+                result, [(i, i//2 + repeat * 2) for i in range(bunch_size)]
+            )
+            await asyncio.sleep(0.01)  # pause to allow for cleanup
+            assert execution._dispatch_task is None
+
     def test_sanity_checks(self):
         """Test against illegal settings"""
         for wrong_size in (0, -1, 0.5, 2j, "15"):


### PR DESCRIPTION
This PR fixes some internal issues of `AsyncBulkCall`. Major changes include:

* [x] correctly call `task_done` for each item read from the queue
* [x] maintain strong references for bulk tasks to avoid aborting them (see [bpo#44665](https://bugs.python.org/issue44665))
* [x] clean up the dispatch task when there is no work to do

Closes #232.

-----------

Note: I considered cleaning up the dispatch task via a callback, the way bulk tasks are cleaned up. However, I could not find guarantees on promptness so had to assume using a callback may introduce a race between shutting down `_bulk_dispatch` and `__call__` detecting that it needs to restart dispatch.