### PR TITLE
Fixing recurrent cancelation of jobs TIMEOUTED in Slurm

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-03-09, command
+.. Created by changelog.py at 2022-04-13, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-03-09
+[Unreleased] - 2022-04-13
 =========================
 
 Added

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -92,6 +92,7 @@ class SlurmAdapter(SiteAdapter):
                 STAGE_OUT=ResourceStatus.Running,
                 STOPPED=ResourceStatus.Stopped,
                 SUSPENDED=ResourceStatus.Stopped,
+                TIMEOUT=ResourceStatus.Deleted,
             ): translator.get(x, default=ResourceStatus.Error),
             JobId=lambda x: int(x),
         )

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -323,7 +323,7 @@ class TestSlurmAdapter(TestCase):
             "STAGE_OUT": ResourceStatus.Running,
             "STOPPED": ResourceStatus.Stopped,
             "SUSPENDED": ResourceStatus.Stopped,
-            "TIMEOUT": ResourceStatus.Error,
+            "TIMEOUT": ResourceStatus.Deleted,
         }
 
         for id, value in enumerate(state_translations.values()):


### PR DESCRIPTION
As reported by @tmadlener in #240. TARDIS is currently not handling Slurm jobs in status `TIMEOUT` correctly. Currently the Slurm `TIMEOUT` state is handled as `ResourceStatus.Error`. In that state `TARDIS` is trying to cleanup the job from the batch system using `scancel`. However, this is not reasonable since the job is already cleaned up by Slurm. Since Slurm shows timeouted jobs for ~15 minutes in `squeue`, `TARDIS` is trying to repeatedly to clean it up.

This pull request changes handles timeouted drones in Slurm as `ResourceStatus.Deleted` instead, which seems more reasonable to me. 

Fixed #240