### PR TITLE
Fix sqlite3 remote_resource_uuid update

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-05-11, command
+.. Created by changelog.py at 2022-05-25, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-05-11
+[Unreleased] - 2022-05-25
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,7 @@ Fixed
 -----
 
 * Unique constraints in database schema have been fixed to allow same machine_type and remote_resource_uuid on multiple sites
+* Update the remote_resource_uuid in sqlite registry on a each update
 
 [0.6.0] - 2021-08-09
 ====================

--- a/docs/source/changes/249_fix_sqlite_registry_remote_uuid_update.yaml
+++ b/docs/source/changes/249_fix_sqlite_registry_remote_uuid_update.yaml
@@ -1,0 +1,10 @@
+category: fixed
+summary: "Update the remote_resource_uuid in sqlite registry on a each update"
+description: |
+  The change drone state initialisation update revealed a bug in TARDIS. The ``remote_resource_uuid`` in the 
+  ``SqliteRegistry`` plugin in not updated at all. As a result, TARDIS keeps crashing on restarts due to the missing 
+  ``remote_resource_uuid`` until the DB has been removed.
+pull_requests:
+  - 249
+issues:
+  - 248

--- a/docs/source/changes/249_fix_sqlite_registry_remote_uuid_update.yaml
+++ b/docs/source/changes/249_fix_sqlite_registry_remote_uuid_update.yaml
@@ -2,7 +2,7 @@ category: fixed
 summary: "Update the remote_resource_uuid in sqlite registry on a each update"
 description: |
   The change drone state initialisation update revealed a bug in TARDIS. The ``remote_resource_uuid`` in the 
-  ``SqliteRegistry`` plugin in not updated at all. As a result, TARDIS keeps crashing on restarts due to the missing 
+  ``SqliteRegistry`` plugin is not updated at all. As a result, TARDIS keeps crashing on restarts due to the missing 
   ``remote_resource_uuid`` until the DB has been removed.
 pull_requests:
   - 249

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -190,6 +190,7 @@ class SqliteRegistry(Plugin):
 
     async def update_resource(self, bind_parameters: Dict) -> None:
         sql_query = """UPDATE Resources SET updated = :updated,
+        remote_resource_uuid = :remote_resource_uuid,
         state_id = (SELECT state_id FROM ResourceStates WHERE state = :state)
         WHERE drone_uuid = :drone_uuid
         AND site_id = (SELECT site_id FROM Sites WHERE site_name = :site_name)"""

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -1,7 +1,6 @@
 import logging
 
 from tardis.resources.dronestates import BootingState
-from tardis.resources.dronestates import IntegrateState
 from tardis.resources.dronestates import RequestState, DownState
 from tardis.interfaces.state import State
 from tardis.plugins.sqliteregistry import SqliteRegistry
@@ -27,7 +26,7 @@ class TestSqliteRegistry(TestCase):
         cls.test_machine_type = "MyGreatTestMachineType"
         cls.tables_in_db = {"MachineTypes", "Resources", "ResourceStates", "Sites"}
         cls.test_resource_attributes = {
-            "remote_resource_uuid": "bf85022b-fdd6-42b1-932d-086c288d4755",
+            "remote_resource_uuid": None,
             "drone_uuid": f"{cls.test_site_name}-07af52405e",
             "site_name": cls.test_site_name,
             "machine_type": cls.test_machine_type,
@@ -66,7 +65,7 @@ class TestSqliteRegistry(TestCase):
         cls.test_updated_notify_result = (
             cls.test_updated_resource_attributes["remote_resource_uuid"],
             cls.test_updated_resource_attributes["drone_uuid"],
-            str(IntegrateState()),
+            str(BootingState()),
             cls.test_updated_resource_attributes["site_name"],
             cls.test_updated_resource_attributes["machine_type"],
             str(cls.test_updated_resource_attributes["created"]),
@@ -220,7 +219,7 @@ class TestSqliteRegistry(TestCase):
 
         run_async(
             self.registry.notify,
-            IntegrateState(),
+            BootingState(),
             self.test_updated_resource_attributes,
         )
 
@@ -250,7 +249,7 @@ class TestSqliteRegistry(TestCase):
             self.registry.add_site(site_name)
             self.registry.add_machine_types(site_name, self.test_machine_type)
 
-        bind_parameters = {"state": "RequestState"}
+        bind_parameters = {"state": str(RequestState())}
         bind_parameters.update(self.test_resource_attributes)
 
         run_async(self.registry.insert_resource, bind_parameters)

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -249,7 +249,7 @@ class TestSqliteRegistry(TestCase):
             self.registry.add_site(site_name)
             self.registry.add_machine_types(site_name, self.test_machine_type)
 
-        bind_parameters = {"state": str(RequestState())}
+        bind_parameters = {"state": "RequestState"}
         bind_parameters.update(self.test_resource_attributes)
 
         run_async(self.registry.insert_resource, bind_parameters)


### PR DESCRIPTION
Introducing #247 revealed a bug in TARDIS. The `remote_resource_uuid` in the `SqliteRegistry` plugin in not updated at all. As a result, TARDIS keeps crashing on restarts due to the missing `remote_resource_uuid` until the DB has been removed. 

This pull request add the missing `remote_resource_uuid` attribute to the update database calls  and fixes #248.