### PR TITLE
Remove minimum core limited from pool factory

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-06-23, command
+.. Created by changelog.py at 2022-06-24, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-06-23
+[Unreleased] - 2022-06-24
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,7 @@ Changed
 -------
 
 * SSHExecutor respects the remote MaxSessions via queueing
+* Remove minimum core limit (Standardiser) from pool factory
 * Change drone state initialisation and notification of plugins
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-05-25, command
+.. Created by changelog.py at 2022-06-23, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-05-25
+[Unreleased] - 2022-06-23
 =========================
 
 Added

--- a/docs/source/changes/252.change_min_core_limit_from_pool_factory.yaml
+++ b/docs/source/changes/252.change_min_core_limit_from_pool_factory.yaml
@@ -3,7 +3,7 @@ summary: "Remove minimum core limit (Standardiser) from pool factory"
 description: |
   Currently the ``create_composite_pool`` function applies a COBalD ``Standardiser`` to ensure the at least one drone is
   requested. This overwrites all Standardisers using the minimum parameter in the COBalD pipeline. It turns out that
-  that ``Standardiser`` is not needed anymore, since the ``utilisation`` and ``allocation`` is always 1.0 when no drone
+  the ``Standardiser`` is not needed anymore, since the ``utilisation`` and ``allocation`` is always 1.0 when no drone
   is running, so that automatically one is requested.
 pull_requests:
   - 252

--- a/docs/source/changes/252.change_min_core_limit_from_pool_factory.yaml
+++ b/docs/source/changes/252.change_min_core_limit_from_pool_factory.yaml
@@ -1,0 +1,9 @@
+category: changed
+summary: "Remove minimum core limit (Standardiser) from pool factory"
+description: |
+  Currently the ``create_composite_pool`` function applies a COBalD ``Standardiser`` to ensure the at least one drone is
+  requested. This overwrites all Standardisers using the minimum parameter in the COBalD pipeline. It turns out that
+  that ``Standardiser`` is not needed anymore, since the ``utilisation`` and ``allocation`` is always 1.0 when no drone
+  is running, so that automatically one is requested.
+pull_requests:
+  - 252

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -71,15 +71,10 @@ def create_composite_pool(configuration: str = None) -> WeightedComposite:
                 batch_system_agent=batch_system_agent,
                 plugins=plugins.values(),
             )
-            cpu_cores = getattr(configuration, site.name).MachineMetaData[machine_type][
-                "Cores"
-            ]
+
             site_composites.append(
                 Logger(
-                    Standardiser(
-                        FactoryPool(*check_pointed_drones, factory=drone_factory),
-                        minimum=cpu_cores,
-                    ),
+                    FactoryPool(*check_pointed_drones, factory=drone_factory),
                     name=f"{site.name.lower()}_{machine_type.lower()}",
                 )
             )

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -93,14 +93,9 @@ class TestPoolFactory(TestCase):
 
         self.assertEqual(mock_factory_pool.mock_calls, [call(factory=ANY)])
 
-        cpu_cores = getattr(
-            self.config, site_name
-        ).MachineMetaData.TestMachineType.Cores
-
         self.assertEqual(
             mock_standardiser.mock_calls,
             [
-                call(mock_factory_pool(), minimum=cpu_cores),
                 call(mock_weighted_composite(), maximum=self.config.Sites[0].quota),
             ],
         )
@@ -109,7 +104,7 @@ class TestPoolFactory(TestCase):
             mock_logger.mock_calls,
             [
                 call(
-                    mock_standardiser(),
+                    mock_factory_pool(),
                     name=f"{site_name.lower()}_{machine_type.lower()}",
                 )
             ],


### PR DESCRIPTION
In the current version the `create_composite_pool` function applies a COBalD `Standardiser` to ensure the at least one drone is requested in https://github.com/MatterMiners/tardis/blob/d45425afa984bf35b5c4a7a01617ded55b14a787/tardis/resources/poolfactory.py#L79-L82.
This conflicts now with the newly developed [`Stopper` plugin](https://github.com/MatterMiners/cobald-hep-plugins/blob/master/cobald_hep_plugins/stopper.py). The `Stopper` checks on less utilized  OBSes for any waiting jobs and reduces the `demand` to zero in case no jobs are available in order to avoid wasting resources.
Currently, the `demand=0` is always overwriiten by the `Standardiser`in the `create_composite_pool` function. 
After discussing on Mattermost, the utilization of this `Standardiser` is actual not needed anymore, since the `utilisation` and `allocation` is always `1.0` when no drone is running, so that automatically one is requested. In addition, the same could be archived, by applying the `Standardiser` in the COBalD configuration by using.

```yaml
pipeline:
  ...
  - !Standardiser
     minimum = 1
  ...
```

This pull request removes the additional `Standardiser` in the `create_composite_pool` function.