### PR TITLE
Update CI/CD configuration

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'centosstream8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04']
+        os_container: ['centos7', 'centosstream8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04', 'ubuntu22_04']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'centosstream8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04']
+        os_container: ['centos7', 'centosstream8', 'rockylinux8', 'ubuntu20_04', 'ubuntu18_04', 'ubuntu22_04']
     container: matterminers/cobald-tardis-deployment-test-env:${{ matrix.os_container }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,6 +21,7 @@ jobs:
         pip install .[contrib]
         pip install coverage codecov
     - name: Test with unittest
+      continue-on-error: ${{ matrix.python-version == 'pypy3' }}
       run: |
         coverage run -m unittest -v
     - name: Upload coverage to Codecov

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,8 +21,8 @@ jobs:
         pip install .[contrib]
         pip install coverage codecov
     - name: Test with unittest
-      continue-on-error: ${{ matrix.python-version == 'pypy3' }}
       run: |
         coverage run -m unittest -v
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
+    continue-on-error: ${{ matrix.python-version == 'pypy3' }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -25,4 +25,3 @@ jobs:
         coverage run -m unittest -v
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-    continue-on-error: ${{ matrix.python-version == 'pypy3' }}

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.centos7
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.centos7
@@ -3,7 +3,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 RUN yum -y install epel-release curl && yum clean all
 
-RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 
 RUN yum -y update \
     && yum -y install git \

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.centosstream8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.centosstream8
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream8
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN dnf -y module enable nodejs:12
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 
 RUN dnf -y update \
     && dnf -y install git \

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
@@ -3,7 +3,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 RUN yum -y install epel-release curl && yum clean all
 
-RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 
 RUN yum -y update \
     && yum -y install git \

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get install -y nodejs \
     && apt-get clean \

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu22_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu22_04
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 RUN apt-get update && apt-get upgrade -y \

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-06-24, command
+.. Created by changelog.py at 2022-07-07, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-06-24
+[Unreleased] - 2022-07-07
 =========================
 
 Added

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -125,7 +125,7 @@ class AsyncBulkCall(Generic[T, R]):
             # track tasks via strong references to avoid them being garbage collected.
             # see bpo#44665
             self._bulk_tasks.add(task)
-            task.add_done_callback(lambda _: self._bulk_tasks.discard(task))
+            task.add_done_callback(lambda _, task=task: self._bulk_tasks.discard(task))
             # yield to the event loop so that the `while True` loop does not arbitrarily
             # delay other tasks on the fast paths for `_get_bulk` and `acquire`.
             await asyncio.sleep(0)


### PR DESCRIPTION
This pull request:

- [x] enables deployment test on Ubuntu 22.04 LTS
- [x] enables docker builds of Ubuntu 22.04 LTS deployment test image
- [x] ~~makes unittests on pypy optional~~ removes pypy unittest due to broken dependencies
- [x] Fix Flake B023 in asyncbulkcall as suggested by @maxfischer2781 
- [x] Update NodeJs to a maintained version 18