### PR TITLE
Fix docker build on vintage Centos 7

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.centos7
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.centos7
@@ -3,7 +3,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 RUN yum -y install epel-release curl && yum clean all
 
-RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 
 RUN yum -y update \
     && yum -y install git \

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-07-07, command
+.. Created by changelog.py at 2022-07-14, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-07-07
+[Unreleased] - 2022-07-14
 =========================
 
 Added


### PR DESCRIPTION
There is one thing I had not reckoned with. Seems that Centos 7 is too old for NodeJs18. So, this pull request is downgrading it to NodeJS16.