### PR TITLE
Change MacOS Version for deployment tests

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -52,7 +52,7 @@ jobs:
   deployment-macos:
     strategy:
       matrix:
-        platform: ['macos-10.15']
+        platform: ['macos-latest']
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-07-15, command
+.. Created by changelog.py at 2022-07-27, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-07-15
+[Unreleased] - 2022-07-27
 =========================
 
 Added


### PR DESCRIPTION
This pull request changes the MacOS Version for the deployment tests to use `macos-latest` (=`macos-11`), since `macos-10.15` is deprecated according to https://github.com/actions/virtual-environments. 