### PR TITLE
Bump CloudStackAIO version and remove event loop usage in adapter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "aiohttp<4.0; python_version<'3.7'",  # to support python3.6 (Centos 7)
         "aiohttp; python_version>='3.7'",
         get_cryptography_version(),
-        "CloudStackAIO",
+        "CloudStackAIO>=0.0.8",
         "PyYAML",
         "AsyncOpenStackClient",
         "cobald>=0.12.3",

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -8,7 +8,6 @@ from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.staticmapping import StaticMapping
 
 from aiohttp import ClientConnectionError
-from cobald.daemon import runtime
 from CloudStackAIO.CloudStack import CloudStack
 from CloudStackAIO.CloudStack import CloudStackClientException
 
@@ -31,7 +30,6 @@ class CloudStackAdapter(SiteAdapter):
             end_point=self.configuration.end_point,
             api_key=self.configuration.api_key,
             api_secret=self.configuration.api_secret,
-            event_loop=runtime._meta_runner.runners[asyncio].event_loop,
         )
 
         key_translator = StaticMapping(


### PR DESCRIPTION
This pull request bumps the version of the CloudStackAIO client to 0.0.8 and removes the `event_loop` argument in the `CloudStackAdapter` in order to be compatible to the newest yet unreleased COBalD version. 