### PR TITLE
Enable remote draining capability of Drones via REST interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv
-venv/
+venv*/
 ENV/
 
 # Spyder project settings

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,9 +11,10 @@ Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 mschnepf <maschnepf@schnepf-net.de>
-Matthias Schnepf <matthias.schnepf@kit.edu>
 Matthias J. Schnepf <maschnepf@schnepf-net.de>
+Matthias Schnepf <matthias.schnepf@kit.edu>
 Matthias Schnepf <maschnepf@schnepf-net.de>
+PSchuhmacher <leon_schuhmacher@yahoo.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
 rfvc <florian.voncube@gmail.com>
 PSchuhmacher <leon_schuhmacher@yahoo.de>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ Contributors ordered by number of commits:
 ==========================================
 Manuel Giffels <giffels@gmail.com>
 Max Fischer <maxfischer2781@gmail.com>
+Alexander Haas <mail@haas-alexander.com>
 Stefan Kroboth <stefan.kroboth@gmail.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
@@ -10,6 +11,7 @@ Rene Caspart <rene.caspart@cern.ch>
 Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
+Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias J. Schnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
@@ -17,5 +19,3 @@ Matthias Schnepf <maschnepf@schnepf-net.de>
 PSchuhmacher <leon_schuhmacher@yahoo.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>
 rfvc <florian.voncube@gmail.com>
-PSchuhmacher <leon_schuhmacher@yahoo.de>
-Alexander Haas <mail@haas-alexander.com>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Added
 -----
 
 * Introduce a TARDIS REST API to query the state of resources from SqlRegistry
+* Added support for remote draining of drones i.e. using REST API
 * Add support for passing environment variables as executable arguments to support HTCondor grid universe
 
 Changed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,12 +1,12 @@
-.. Created by changelog.py at 2022-07-27, command
-   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-default/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2022-08-17, command
+   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
 
-[Unreleased] - 2022-07-27
+[Unreleased] - 2022-08-17
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-08-18, command
+.. Created by changelog.py at 2022-08-29, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,14 +6,14 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-08-18
+[Unreleased] - 2022-08-29
 =========================
 
 Added
 -----
 
 * Introduce a TARDIS REST API to query the state of resources from SqlRegistry
-* Added support for remote draining of drones i.e. using REST API
+* Added support for manual draining of drones using the REST API
 * Add support for passing environment variables as executable arguments to support HTCondor grid universe
 
 Changed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-08-17, command
+.. Created by changelog.py at 2022-08-18, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-08-17
+[Unreleased] - 2022-08-18
 =========================
 
 Added

--- a/docs/source/changes/260.add_remote_drone_draining.yaml
+++ b/docs/source/changes/260.add_remote_drone_draining.yaml
@@ -1,8 +1,8 @@
 category: added
 summary: "Added support for manual draining of drones using the REST API"
 description: |
-  Added limited support to synchronise the state stored in the ``SqliteRegistry`` with the current state of the drone. 
+  Added limited support to synchronize the state stored in the ``SqliteRegistry`` with the current state of the drone. 
   Only implemented for drones in ``AvailableState`` which can transition to ``DrainState`` via a remote update of the 
-  ``SqliteRegistry`` i.e. using the REST API.
+  ``SqliteRegistry``, i.e. using the REST API.
 pull requests:
 - 260

--- a/docs/source/changes/260.add_remote_drone_draining.yaml
+++ b/docs/source/changes/260.add_remote_drone_draining.yaml
@@ -1,0 +1,8 @@
+category: added
+summary: "Added support for remote draining of drones i.e. using REST API"
+description: |
+  Added limited support to synchronise the state stored in the ``SqliteRegistry`` with the current state of the drone. 
+  Only implemented for drones in ``AvailableState`` which can transition to ``DrainState`` via a remote update of the 
+  ``SqliteRegistry`` i.e. using the REST API.
+pull requests:
+- 260

--- a/docs/source/changes/260.add_remote_drone_draining.yaml
+++ b/docs/source/changes/260.add_remote_drone_draining.yaml
@@ -1,5 +1,5 @@
 category: added
-summary: "Added support for remote draining of drones i.e. using REST API"
+summary: "Added support for manual draining of drones using the REST API"
 description: |
   Added limited support to synchronise the state stored in the ``SqliteRegistry`` with the current state of the drone. 
   Only implemented for drones in ``AvailableState`` which can transition to ``DrainState`` via a remote update of the 

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -155,6 +155,15 @@ class SqliteRegistry(Plugin):
             logger.debug(f"{sql_query},{bind_parameters} executed")
             return cursor.fetchall()
 
+    async def get_resource_state(self, drone_uuid: str):
+        sql_query = """
+        SELECT RS.state
+        FROM Resources R
+        JOIN ResourceStates RS ON R.state_id = RS.state_id
+        WHERE R.drone_uuid = :drone_uuid
+        """
+        return await self.async_execute(sql_query, {"drone_uuid": drone_uuid})
+
     def get_resources(self, site_name: str, machine_type: str) -> List[Dict]:
         sql_query = """
         SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, R.created, R.updated

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -8,7 +8,7 @@ from .dronestates import RequestState
 from .dronestates import DownState
 from ..plugins.sqliteregistry import SqliteRegistry
 from ..utilities.attributedict import AttributeDict
-from ..utilities.utils import str_to_state
+from ..utilities.utils import load_states
 from cobald.daemon import service
 from cobald.interfaces import Pool
 
@@ -71,7 +71,7 @@ class Drone(Pool):
 
     async def database_state(self) -> Optional[Type[State]]:
         try:
-            return str_to_state(
+            return load_states(
                 await self._database.get_resource_state(
                     self.resource_attributes.drone_uuid
                 )

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Type
 
 from tardis.agents.batchsystemagent import BatchSystemAgent
 from tardis.agents.siteagent import SiteAgent
@@ -69,7 +69,7 @@ class Drone(Pool):
             if isinstance(plugin, SqliteRegistry):
                 return plugin
 
-    async def database_state(self) -> Optional[State]:
+    async def database_state(self) -> Optional[Type[State]]:
         try:
             return str_to_state(
                 await self._database.get_resource_state(

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -36,10 +36,8 @@ async def check_remote_draining(
 ):
     database_state = await drone.database_state()
 
-    if isinstance(database_state, DrainState) and not isinstance(
-        database_state, current_state.__class__
-    ):
-        raise StopProcessing(last_result=database_state)
+    if database_state is DrainState and database_state is not current_state:
+        raise StopProcessing(last_result=database_state())
     return state_transition
 
 

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -31,6 +31,18 @@ async def batchsystem_machine_status(
     return state_transition[machine_status]()
 
 
+async def check_remote_draining(
+    state_transition, drone: "Drone", current_state: Type[State]
+):
+    database_state = await drone.database_state()
+
+    if isinstance(database_state, DrainState) and not isinstance(
+        database_state, current_state.__class__
+    ):
+        raise StopProcessing(last_result=database_state)
+    return state_transition
+
+
 async def check_demand(state_transition, drone: "Drone", current_state: Type[State]):
     if not drone.demand:
         drone._supply = 0.0
@@ -154,6 +166,7 @@ class AvailableState(State):
     }
 
     processing_pipeline = [
+        check_remote_draining,
         check_demand,
         check_minimum_lifetime,
         resource_status,

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -6,7 +6,7 @@ from ..agents.batchsystemagent import BatchSystemAgent
 from ..agents.siteagent import SiteAgent
 from ..configuration.configuration import Configuration
 from ..resources.drone import Drone
-from ..utilities.utils import str_to_state
+from ..utilities.utils import load_states
 
 from cobald.composite.weighted import WeightedComposite
 from cobald.composite.factory import FactoryPool
@@ -109,7 +109,7 @@ def get_drones_to_restore(plugins: dict, site, machine_type: str):
     except KeyError:
         return []
     else:
-        return str_to_state(
+        return load_states(
             sql_registry.get_resources(site_name=site.name, machine_type=machine_type)
         )
 

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -6,6 +6,7 @@ from ..agents.batchsystemagent import BatchSystemAgent
 from ..agents.siteagent import SiteAgent
 from ..configuration.configuration import Configuration
 from ..resources.drone import Drone
+from ..utilities.utils import str_to_state
 
 from cobald.composite.weighted import WeightedComposite
 from cobald.composite.factory import FactoryPool
@@ -15,15 +16,6 @@ from cobald.utility.primitives import infinity as inf
 
 from functools import partial
 from importlib import import_module
-
-
-def str_to_state(resources):
-    for entry in resources:
-        state_class = getattr(
-            import_module(name="tardis.resources.dronestates"), f"{entry['state']}"
-        )
-        entry["state"] = state_class()
-    return resources
 
 
 def create_composite_pool(configuration: str = None) -> WeightedComposite:

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -1,7 +1,6 @@
 from .attributedict import AttributeDict
 
 from contextlib import contextmanager
-from importlib import import_module
 from io import StringIO
 from typing import Any, Callable, List, TypeVar, Tuple
 
@@ -100,10 +99,10 @@ def machine_meta_data_translation(
 
 
 def str_to_state(resources):
+    import tardis.resources.dronestates
+
     for entry in resources:
-        state_class = getattr(
-            tardis.resources.dronestates, str(entry['state'])
-        )
+        state_class = getattr(tardis.resources.dronestates, str(entry["state"]))
         entry["state"] = state_class()
     return resources
 

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -1,6 +1,7 @@
 from .attributedict import AttributeDict
 
 from contextlib import contextmanager
+from importlib import import_module
 from io import StringIO
 from typing import Any, Callable, List, TypeVar, Tuple
 
@@ -96,6 +97,15 @@ def machine_meta_data_translation(
             f"machine_meta_data_translation failed: no translation known for {ke}"
         )
         raise
+
+
+def str_to_state(resources):
+    for entry in resources:
+        state_class = getattr(
+            import_module(name="tardis.resources.dronestates"), f"{entry['state']}"
+        )
+        entry["state"] = state_class()
+    return resources
 
 
 def submit_cmd_option_formatter(options: AttributeDict) -> str:

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -102,7 +102,7 @@ def machine_meta_data_translation(
 def str_to_state(resources):
     for entry in resources:
         state_class = getattr(
-            import_module(name="tardis.resources.dronestates"), f"{entry['state']}"
+            tardis.resources.dronestates, str(entry['state'])
         )
         entry["state"] = state_class()
     return resources

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -98,7 +98,7 @@ def machine_meta_data_translation(
         raise
 
 
-def str_to_state(resources):
+def load_states(resources):
     import tardis.resources.dronestates
 
     for entry in resources:

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -178,6 +178,28 @@ class TestSqliteRegistry(TestCase):
         SqliteRegistry()
 
     @patch("tardis.plugins.sqliteregistry.logging", Mock())
+    def test_get_resource_state(self):
+        self.registry.add_site(self.test_site_name)
+        self.registry.add_machine_types(self.test_site_name, self.test_machine_type)
+        run_async(self.registry.notify, RequestState(), self.test_resource_attributes)
+
+        self.assertEqual(
+            run_async(
+                self.registry.get_resource_state,
+                drone_uuid=self.test_resource_attributes["drone_uuid"],
+            ),
+            [{"state": "RequestState"}],
+        )
+
+        self.assertEqual(
+            run_async(
+                self.registry.get_resource_state,
+                drone_uuid="does_not_exists",
+            ),
+            [],
+        )
+
+    @patch("tardis.plugins.sqliteregistry.logging", Mock())
     def test_get_resources(self):
         self.registry.add_site(self.test_site_name)
         self.registry.add_machine_types(self.test_site_name, self.test_machine_type)

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -3,7 +3,8 @@ from ..utilities.utilities import async_return, run_async
 from tardis.interfaces.plugin import Plugin
 from tardis.interfaces.state import State
 from tardis.resources.drone import Drone
-from tardis.resources.dronestates import DownState
+from tardis.resources.dronestates import DrainState, DownState
+from tardis.plugins.sqliteregistry import SqliteRegistry
 from tardis.utilities.attributedict import AttributeDict
 
 from logging import DEBUG
@@ -48,6 +49,33 @@ class TestDrone(TestCase):
 
     def test_batch_system_agent(self):
         self.assertEqual(self.drone.batch_system_agent, self.mock_batch_system_agent)
+
+    def test_database(self):
+        self.assertIsNone(self.drone._database)
+
+        sql_registry = MagicMock(spec=SqliteRegistry)
+        self.drone.register_plugins(sql_registry)
+        self.drone.__dict__.pop("_database")  # reset cached_property's cache
+
+        self.assertEqual(self.drone._database, sql_registry)
+
+    def test_database_state(self):
+        self.assertIsNone(run_async(self.drone.database_state))
+
+        sql_registry = MagicMock(spec=SqliteRegistry)
+        self.drone.register_plugins(sql_registry)
+        self.drone.__dict__.pop("_database")  # reset cached_property's cache
+        sql_registry.get_resource_state.return_value = [{"state": "DrainState"}]
+
+        self.assertIsInstance(run_async(self.drone.database_state), DrainState)
+
+        # testing IndexError
+        sql_registry.get_resource_state.return_value = []
+        self.assertIsNone(run_async(self.drone.database_state))
+
+        # testing AttributeError
+        delattr(self.drone.resource_attributes, "drone_uuid")
+        self.assertIsNone(run_async(self.drone.database_state))
 
     def test_demand(self):
         self.assertEqual(self.drone.demand, 8)

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -1,4 +1,4 @@
-from ..utilities.utilities import async_return, run_async
+from ..utilities.utilities import async_return, run_async, set_awaitable_return_value
 
 from tardis.interfaces.plugin import Plugin
 from tardis.interfaces.state import State
@@ -65,12 +65,14 @@ class TestDrone(TestCase):
         sql_registry = MagicMock(spec=SqliteRegistry)
         self.drone.register_plugins(sql_registry)
         self.drone.__dict__.pop("_database")  # reset cached_property's cache
-        sql_registry.get_resource_state.return_value = [{"state": "DrainState"}]
+        set_awaitable_return_value(
+            sql_registry.get_resource_state, [{"state": "DrainState"}]
+        )
 
         self.assertIsInstance(run_async(self.drone.database_state), DrainState)
 
         # testing IndexError
-        sql_registry.get_resource_state.return_value = []
+        set_awaitable_return_value(sql_registry.get_resource_state, [])
         self.assertIsNone(run_async(self.drone.database_state))
 
         # testing AttributeError

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -3,7 +3,6 @@ from tardis.resources.poolfactory import create_composite_pool
 from tardis.resources.poolfactory import create_drone
 from tardis.resources.poolfactory import get_drones_to_restore
 from tardis.resources.poolfactory import load_plugins
-from tardis.resources.poolfactory import str_to_state
 from tardis.utilities.attributedict import AttributeDict
 
 from unittest import TestCase
@@ -43,12 +42,6 @@ class TestPoolFactory(TestCase):
         self.config.BatchSystem = AttributeDict(adapter="TestBatchSystem")
         sqlite_registry = self.mock_sqliteregistry.return_value
         sqlite_registry.get_resources.return_value = [{"state": "RequestState"}]
-
-    def test_str_to_state(self):
-        test = [{"state": "RequestState", "drone_uuid": "test-abc123"}]
-        converted_test = str_to_state(test)
-        self.assertTrue(converted_test[0]["state"], RequestState)
-        self.assertEqual(converted_test[0]["drone_uuid"], "test-abc123")
 
     @patch("tardis.resources.poolfactory.FactoryPool")
     @patch("tardis.resources.poolfactory.Logger")

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -1,4 +1,5 @@
 from tardis.utilities.attributedict import AttributeDict
+
 import asyncio
 import socket
 
@@ -39,3 +40,13 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
 def run_async(coroutine, *args, **kwargs):
     loop = asyncio.get_event_loop_policy().get_event_loop()
     return loop.run_until_complete(coroutine(*args, **kwargs))
+
+
+def set_awaitable_return_value(mocked_coroutine, return_value):
+    # isinstance does not work due to inheritance
+    # iswaitable, iscoroutine not because RuntimeWarning (not awaited)
+    # comparing type(...) did not solve the problem as well.
+    if not mocked_coroutine.__class__.__name__ == "MagicMock":
+        mocked_coroutine.return_value = return_value
+    else:  # pass test on Python 3.6 and 3.7
+        mocked_coroutine.return_value = async_return(return_value=return_value)

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,10 +1,12 @@
 import logging
 
+from tardis.resources.dronestates import RequestState
 from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.utils import (
     csv_parser,
     disable_logging,
     htcondor_cmd_option_formatter,
+    str_to_state,
     submit_cmd_option_formatter,
 )
 
@@ -114,6 +116,14 @@ class TestDisableLogging(TestCase):
             with self.assertLogs(level=logging.DEBUG):
                 with disable_logging(logging.DEBUG):
                     logging.debug("Test")
+
+
+class TestStrToState(TestCase):
+    def test_str_to_state(self):
+        test = [{"state": "RequestState", "drone_uuid": "test-abc123"}]
+        converted_test = str_to_state(test)
+        self.assertTrue(converted_test[0]["state"], RequestState)
+        self.assertEqual(converted_test[0]["drone_uuid"], "test-abc123")
 
 
 class TestSlurmCMDOptionFormatter(TestCase):

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -6,7 +6,7 @@ from tardis.utilities.utils import (
     csv_parser,
     disable_logging,
     htcondor_cmd_option_formatter,
-    str_to_state,
+    load_states,
     submit_cmd_option_formatter,
 )
 
@@ -121,7 +121,7 @@ class TestDisableLogging(TestCase):
 class TestStrToState(TestCase):
     def test_str_to_state(self):
         test = [{"state": "RequestState", "drone_uuid": "test-abc123"}]
-        converted_test = str_to_state(test)
+        converted_test = load_states(test)
         self.assertTrue(converted_test[0]["state"], RequestState)
         self.assertEqual(converted_test[0]["drone_uuid"], "test-abc123")
 


### PR DESCRIPTION
This pull request enables the possibilty to drain drones in `AvailableState` via the REST interface in connection with #250. 

- [x] Add `get_resource_state` method to `SqliteRegistry`
- [x] Add `database` property to `Drone`
- [x] Add `database_state` coroutine to `Drone`
- [x] Introduce a `check_remote_draining` function
- [x] Add this function to the pipeline of `AvailableState`
- [x] Add changelog for this feature