### PR TITLE
Added missing httpx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "python-multipart",
         "typing_extensions",
         "backports.cached_property",
+        "httpx",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
`pytest` fails after a fresh install of TARDIS in an empty environment because of a missing `httpx` dependency. 