### PR TITLE
Ensure python3.6 compatibilty of fastapi

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-08-29, command
+.. Created by changelog.py at 2022-09-16, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-08-29
+[Unreleased] - 2022-09-16
 =========================
 
 Added

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ with open(os.path.join(repo_base_dir, "README.md"), "r") as read_me:
 TESTS_REQUIRE = ["flake8", "httpx"]
 REST_REQUIRES = [
     "fastapi-jwt-auth",
-    "fastapi",
+    "fastapi<0.84.0; python_version<'3.7'",  # to support python3.6 (Centos 7)
+    "fastapi; python_version>='3.7'",
     "python-jose",
     "uvicorn[standard]<=0.14.0",  # to support python3.6 (Centos 7)
     "typer",


### PR DESCRIPTION
This pull request ensures python3.6 compatibility of the fastapi package. According to
https://twitter.com/fastapi/status/1570123136472940550?s=46&t=vyEKlN_AhlwIp-C4-tTIsw support for python3.6 is dropped in version 0.84.0.