### PR TITLE
Use Python3.10 on macos since 3.11 is not yet supported by TARDIS

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -58,9 +58,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .[contrib]
-          python3 -m pip install coverage codecov
+          python3.10 -m pip install --upgrade pip
+          python3.10 -m pip install .[contrib]
+          python3.10 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
           coverage run -m unittest -v

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-09-16, command
+.. Created by changelog.py at 2022-11-11, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-09-16
+[Unreleased] - 2022-11-11
 =========================
 
 Added


### PR DESCRIPTION
Since some dependencies of `TARDIS` do not yet support Python3.11, the default version on `macos-latest`, I have forced to run deployment tests on `macos-latest` using Python3.10.