### PR TITLE
Add lancium site adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,7 @@ test_scripts/
 *.db
 
 # Ignore configurations
-cobald.yml
+cobald*.yml
 *tardis.yml
 
 #Ignore cloudinit files

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias J. Schnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
+LGTM Migrator <lgtm-migrator@users.noreply.github.com>
 Matthias Schnepf <maschnepf@schnepf-net.de>
 PSchuhmacher <leon_schuhmacher@yahoo.de>
 Peter Wienemann <peter.wienemann@uni-bonn.de>

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -298,6 +298,66 @@ Available adapter configuration options
     The ``Arguments`` contains the following command line arguments, ``--cores``. ``--memory``. ``--disk`` and
     ``--uuid``.
 
+Lancium Site Adapter
+--------------------
+
+.. content-tabs:: left-col
+
+    The :py:class:`~tardis.adapters.sites.lancium.LanciumAdapter` implements an interface to `Lancium`_ Compute API.
+    The following general adapter configuration options are available.
+
+    .. _Lancium: https://lancium.github.io
+
+Available adapter configuration options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. content-tabs:: left-col
+
+    +---------------------+------------------------------------------------------------------------+-----------------+
+    | Option              | Short Description                                                      | Requirement     |
+    +=====================+========================================================================+=================+
+    | api_url             | The end point of the Lancium API to contact.                           |  **Required**   |
+    +---------------------+------------------------------------------------------------------------+-----------------+
+    | api_key             | API Token to access the Lancium API.                                   |  **Required**   |
+    +---------------------+------------------------------------------------------------------------+-----------------+
+    | max_age             | The output of the `show_jobs` API call is cached for `max_age` minutes |  **Required**   |
+    +---------------------+------------------------------------------------------------------------+-----------------+
+
+    All configuration entries in the `MachineTypeConfiguration` section of the machine types are
+    directly added to the body of Lancium API `create_job` call. All available options are
+    described in the `Lancium documentation`_
+
+    .. _Lancium documentation: https://lancium.github.io/compute-api-docs/api.html#tag/Jobs/operation/create_job
+
+.. content-tabs:: right-col
+
+    .. rubric:: Example configuration
+
+    .. code-block:: yaml
+
+          Sites:
+            - name: Lancium
+              adapter: Lancium
+              quota: 1 # CPU core quota
+
+          Lancium:
+            api_url: https://portal.lancium.com/api/v1/
+            api_key: "top_secret"
+            max_age: 1
+            MachineTypes:
+              - m1.small
+            MachineTypeConfiguration:
+              m1.small:
+                qos: "high"
+                image: "lancium/ubuntu"
+                command_line: "sleep 500"
+                max_run_time: 600
+            MachineMetaData:
+              m1.small:
+                Cores: 2
+                Memory: 4
+                Disk: 20
+
 Moab Site Adapter
 -----------------
 
@@ -621,5 +681,4 @@ Available machine type configuration options
 .. content-tabs:: left-col
 
     Your favorite site is currently not supported?
-    Please, have a look at
-    :ref:`how to contribute.<ref_contribute_site_adapter>`
+    Please, have a look at how to contribute.

--- a/docs/source/api/tardis.adapters.sites.lancium.rst
+++ b/docs/source/api/tardis.adapters.sites.lancium.rst
@@ -1,0 +1,7 @@
+tardis.adapters.sites.lancium module
+====================================
+
+.. automodule:: tardis.adapters.sites.lancium
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.adapters.sites.rst
+++ b/docs/source/api/tardis.adapters.sites.rst
@@ -16,6 +16,7 @@ Submodules
    tardis.adapters.sites.fakesite
    tardis.adapters.sites.htcondor
    tardis.adapters.sites.kubernetes
+   tardis.adapters.sites.lancium
    tardis.adapters.sites.moab
    tardis.adapters.sites.openstack
    tardis.adapters.sites.slurm

--- a/docs/source/api/tardis.plugins.auditor.rst
+++ b/docs/source/api/tardis.plugins.auditor.rst
@@ -1,0 +1,7 @@
+tardis.plugins.auditor module
+=============================
+
+.. automodule:: tardis.plugins.auditor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.plugins.rst
+++ b/docs/source/api/tardis.plugins.rst
@@ -12,6 +12,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   tardis.plugins.auditor
    tardis.plugins.elasticsearchmonitoring
    tardis.plugins.prometheusmonitoring
    tardis.plugins.sqliteregistry

--- a/docs/source/api/tardis.rest.app.routers.rst
+++ b/docs/source/api/tardis.rest.app.routers.rst
@@ -12,5 +12,6 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
-   tardis.rest.app.routers.login
    tardis.rest.app.routers.resources
+   tardis.rest.app.routers.types
+   tardis.rest.app.routers.user

--- a/docs/source/api/tardis.rest.app.routers.types.rst
+++ b/docs/source/api/tardis.rest.app.routers.types.rst
@@ -1,0 +1,7 @@
+tardis.rest.app.routers.types module
+====================================
+
+.. automodule:: tardis.rest.app.routers.types
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.rest.app.routers.user.rst
+++ b/docs/source/api/tardis.rest.app.routers.user.rst
@@ -1,0 +1,7 @@
+tardis.rest.app.routers.user module
+===================================
+
+.. automodule:: tardis.rest.app.routers.user
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.rest.app.rst
+++ b/docs/source/api/tardis.rest.app.rst
@@ -23,4 +23,5 @@ Submodules
    tardis.rest.app.crud
    tardis.rest.app.database
    tardis.rest.app.main
+   tardis.rest.app.scopes
    tardis.rest.app.security

--- a/docs/source/api/tardis.rest.app.scopes.rst
+++ b/docs/source/api/tardis.rest.app.scopes.rst
@@ -1,0 +1,7 @@
+tardis.rest.app.scopes module
+=============================
+
+.. automodule:: tardis.rest.app.scopes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tardis.rest.rst
+++ b/docs/source/api/tardis.rest.rst
@@ -14,7 +14,6 @@ Subpackages
 
    tardis.rest.app
    tardis.rest.hash_credentials
-   tardis.rest.token_generator
 
 Submodules
 ----------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-11-11, command
+.. Created by changelog.py at 2022-11-17, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-11-11
+[Unreleased] - 2022-11-17
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-11-17, command
+.. Created by changelog.py at 2022-11-23, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-11-17
+[Unreleased] - 2022-11-23
 =========================
 
 Added

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ Added
 * Introduce a TARDIS REST API to query the state of resources from SqlRegistry
 * Added support for manual draining of drones using the REST API
 * Add support for passing environment variables as executable arguments to support HTCondor grid universe
+* Added a new site adapter to use Lancium compute as resource provider
 
 Changed
 -------

--- a/docs/source/changes/267.add_lancium_site_adapter.yaml
+++ b/docs/source/changes/267.add_lancium_site_adapter.yaml
@@ -1,0 +1,6 @@
+category: added
+summary: "Added a new site adapter to use Lancium compute as resource provider"
+description: |
+  A new Lancium compute site adapter has been added to `TARDIS` to use resources provided by the Lancium compute cluster.
+pull requests:
+- 267

--- a/docs/source/plugins/plugins.rst
+++ b/docs/source/plugins/plugins.rst
@@ -220,5 +220,4 @@ Available configuration options
 .. content-tabs:: left-col
 
     Your favorite monitoring is currently not supported?
-    Please, have a look at
-    :ref:`how to contribute.<ref_contribute_plugin>`
+    Please, have a look at how to contribute.

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
         "python-auditor>=0.0.5",
         "pytz",
         "tzlocal",
+        "aiolancium",
     ],
     extras_require={
         "docs": [

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -114,7 +114,7 @@ class LanciumAdapter(SiteAdapter):
                     "status": "deleted",
                 }
         logger.debug(f"{self.site_name} has status {resource_status}.")
-        resource_attributes["updated"]=datetime.now()
+        resource_attributes["updated"] = datetime.now()
         return convert_to_attribute_dict(
             {**resource_attributes, **self.handle_response(resource_status)}
         )

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -73,9 +73,14 @@ class LanciumAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        create_response = await self.client.create_job(
-            job=self.machine_type_configuration
+        specs = dict(name=resource_attributes.drone_uuid)
+        specs["resources"] = dict(
+            core_count=self.machine_meta_data.Cores,
+            memory=self.machine_meta_data.Memory,
+            scratch=self.machine_meta_data.Disk,
         )
+        specs.update(self.machine_type_configuration)
+        create_response = await self.client.create_job(job=specs)
         logger.debug(f"{self.site_name} create job returned {create_response}")
         submit_response = await self.client.submit_job(id=create_response["job"]["id"])
         logger.debug(f"{self.site_name} submit job returned {submit_response}")

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -1,0 +1,127 @@
+from aiolancium.client import Authenticator, LanciumClient
+
+from ...exceptions.tardisexceptions import TardisError, TardisResourceStatusUpdateFailed
+from ...interfaces.siteadapter import SiteAdapter, ResourceStatus
+from ...utilities.attributedict import AttributeDict, convert_to_attribute_dict
+from ...utilities.asynccachemap import AsyncCacheMap
+from ...utilities.staticmapping import StaticMapping
+
+from contextlib import contextmanager
+from datetime import datetime
+from functools import partial
+from typing import Dict
+
+import logging
+
+logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.lancium")
+
+
+async def lancium_status_updater(client: LanciumClient) -> Dict:
+    response = client.jobs.show_jobs()
+    logger.debug(f"Show jobs returned {response}")
+    return {job["id"]: job for job in response["jobs"]}
+
+
+class LanciumAdapter(SiteAdapter):
+    # space in last key requires dict expansion in `__init__` `translation_functions`
+    resource_status_translation = {
+        "created": ResourceStatus.Booting,
+        "submitted": ResourceStatus.Booting,
+        "queued": ResourceStatus.Booting,
+        "ready": ResourceStatus.Booting,
+        "running": ResourceStatus.Running,
+        "error": ResourceStatus.Error,
+        "finished": ResourceStatus.Stopped,
+        "delete pending": ResourceStatus.Stopped,
+        "deleted": ResourceStatus.Deleted,
+    }
+
+    def __init__(self, machine_type: str, site_name: str):
+        self._machine_type = machine_type
+        self._site_name = site_name
+
+        auth = Authenticator(api_key=self.configuration.api_key)
+        self.client = LanciumClient(api_url=self.configuration.api_url, auth=auth)
+
+        key_translator = StaticMapping(
+            remote_resource_uuid="id",
+            drone_uuid="name",
+            resource_status="status",
+            created="created_at",
+            updated="updated_at",
+        )
+
+        translator_functions = StaticMapping(
+            created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
+            updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
+            status=lambda x, translator=StaticMapping(
+                **self.resource_status_translation
+            ): translator[x],
+        )
+
+        self.handle_response = partial(
+            self.handle_response,
+            key_translator=key_translator,
+            translator_functions=translator_functions,
+        )
+
+        self._lancium_status = AsyncCacheMap(
+            update_coroutine=partial(lancium_status_updater, self.client),
+            max_age=self.configuration.max_age * 60,
+        )
+
+    async def deploy_resource(
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
+        create_response = await self.client.create_job(
+            job=self.machine_type_configuration
+        )
+        logger.debug(f"{self.site_name} create job returned {create_response}")
+        submit_response = await self.client.submit_job(id=create_response["job"]["id"])
+        logger.debug(f"{self.site_name} submit job returned {submit_response}")
+        return self.handle_response(create_response)
+
+    async def resource_status(
+        self, resource_attributes: AttributeDict
+    ) -> AttributeDict:
+        await self._lancium_status.update_status()
+        # In case the created timestamp is after last update timestamp of the
+        # asynccachemap, no decision about the current state can be given,
+        # since map is updated asynchronously.
+        try:
+            resource_uuid = resource_attributes.remote_resource_uuid
+            resource_status = self._lancium_status[str(resource_uuid)]
+        except KeyError as err:
+            if (
+                self._lancium_status._last_update - resource_attributes.created
+            ).total_seconds() < 0:
+                raise TardisResourceStatusUpdateFailed from err
+            else:
+                resource_status = {
+                    "id": resource_attributes.remote_resource_uuid,
+                    "status": "deleted",
+                }
+        logger.debug(f"{self.site_name} has status {resource_status}.")
+        resource_attributes.update(updated=datetime.now())
+        return convert_to_attribute_dict(
+            {**resource_attributes, **self.handle_response(resource_status)}
+        )
+
+    async def stop_resource(self, resource_attributes: AttributeDict):
+        response = self.client.terminate_job(
+            id=resource_attributes.remote_resource_uuid
+        )
+        logger.debug(f"{self.site_name} stop resource returned {response}")
+        return response
+
+    async def terminate_resource(self, resource_attributes: AttributeDict):
+        response = self.client.delete_job(id=resource_attributes.remote_resource_uuid)
+        logger.debug(f"{self.site_name} terminate resource returned {response}")
+        return response
+
+    @contextmanager
+    def handle_exceptions(self):
+        try:
+            yield
+        except Exception as ex:
+            raise TardisError from ex

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -77,6 +77,13 @@ class LanciumAdapter(SiteAdapter):
             memory=self.machine_meta_data.Memory,
             scratch=self.machine_meta_data.Disk,
         )
+        specs["environment"] = [
+            {"variable": f"TardisDrone{key}", "value": str(value)}
+            for key, value in self.drone_environment(
+                resource_attributes.drone_uuid,
+                resource_attributes.obs_machine_meta_data_translation_mapping,
+            ).items()
+        ]
         specs.update(self.machine_type_configuration)
         create_response = await self.client.jobs.create_job(job=specs)
         logger.debug(f"{self.site_name} create job returned {create_response}")

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -105,7 +105,7 @@ class LanciumAdapter(SiteAdapter):
             resource_status = self._lancium_status[resource_uuid]
         except KeyError as err:
             if (
-                self._lancium_status._last_update - resource_attributes.created
+                self._lancium_status.last_update - resource_attributes.created
             ).total_seconds() < 0:
                 raise TardisResourceStatusUpdateFailed from err
             else:
@@ -114,7 +114,7 @@ class LanciumAdapter(SiteAdapter):
                     "status": "deleted",
                 }
         logger.debug(f"{self.site_name} has status {resource_status}.")
-        resource_attributes.update(updated=datetime.now())
+        resource_attributes["updated"]=datetime.now()
         return convert_to_attribute_dict(
             {**resource_attributes, **self.handle_response(resource_status)}
         )

--- a/tests/adapters_t/sites_t/test_lancium.py
+++ b/tests/adapters_t/sites_t/test_lancium.py
@@ -1,4 +1,10 @@
 from tardis.adapters.sites.lancium import LanciumAdapter
+from tardis.interfaces.siteadapter import ResourceStatus
+from tardis.utilities.attributedict import AttributeDict
+
+from simple_rest_client.exceptions import AuthError
+
+from ...utilities.utilities import run_async, set_awaitable_return_value
 
 from unittest import TestCase
 from unittest.mock import patch
@@ -15,7 +21,7 @@ class TestLanciumAdapter(TestCase):
         cls.mock_lancium_api_patcher = patch(
             "tardis.adapters.sites.lancium.LanciumClient"
         )
-        cls.mock_openstack_api = cls.mock_lancium_api_patcher.start()
+        cls.mock_lancium_api = cls.mock_lancium_api_patcher.start()
 
     @classmethod
     def tearDownClass(cls):
@@ -23,4 +29,108 @@ class TestLanciumAdapter(TestCase):
         cls.mock_lancium_api_patcher.stop()
 
     def setUp(self) -> None:
+        self.mock_configuration()
+        self.mock_lancium_adapter()
         self.adapter = LanciumAdapter(machine_type="test2large", site_name="TestSite")
+
+    def mock_configuration(self):
+        config = self.mock_config.return_value
+        test_site_config = config.TestSite
+        test_site_config.api_url = "https://test.site.api"
+        test_site_config.api_key = "top_secret_test"
+        test_site_config.max_age = 1
+        test_site_config.MachineTypeConfiguration = AttributeDict(
+            test2large=AttributeDict(
+                qos="high",
+                image="lancium/ubuntu",
+                command_line="sleep 500",
+                max_run_time=600,
+            )
+        )
+        test_site_config.MachineMetaData = AttributeDict(
+            test2large=AttributeDict(Cores=8, Memory=20, Disk=20)
+        )
+
+    def mock_lancium_adapter(self):
+        self.mocked_lancium_api = self.mock_lancium_api.return_value
+        set_awaitable_return_value(
+            self.mocked_lancium_api.jobs.create_job,
+            {"job": {"id": 123, "status": "created", "name": "testsite-089123"}},
+        )
+        set_awaitable_return_value(self.mocked_lancium_api.jobs.submit_job, {})
+
+    def test_deploy_resource(self):
+        self.assertEqual(
+            AttributeDict(
+                drone_uuid="testsite-089123",
+                remote_resource_uuid=123,
+                resource_status=ResourceStatus.Booting,
+            ),
+            run_async(
+                self.adapter.deploy_resource,
+                resource_attributes=AttributeDict(
+                    drone_uuid="testsite-089123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1,
+                        Disk=1,
+                    ),
+                ),
+            ),
+        )
+
+        self.assertDictEqual(
+            {
+                "name": "testsite-089123",
+                "qos": "high",
+                "image": "lancium/ubuntu",
+                "command_line": "sleep 500",
+                "max_run_time": 600,
+                "resources": {"core_count": 8, "memory": 20, "scratch": 20},
+                "environment": [
+                    {"variable": "TardisDroneCores", "value": "8"},
+                    {"variable": "TardisDroneMemory", "value": "20"},
+                    {"variable": "TardisDroneDisk", "value": "20"},
+                    {"variable": "TardisDroneUuid", "value": "testsite-089123"},
+                ],
+            },
+            self.mocked_lancium_api.jobs.create_job.call_args.kwargs["job"],
+        )
+        self.mocked_lancium_api.jobs.submit_job.assert_called_with(id=123)
+
+        self.mocked_lancium_api.jobs.create_job.side_effect = AuthError(
+            "operation=auth_error", {}
+        )
+        with self.assertRaises(AuthError):
+            run_async(
+                self.adapter.deploy_resource,
+                resource_attributes=AttributeDict(
+                    drone_uuid="testsite-089123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1,
+                        Disk=1,
+                    ),
+                ),
+            )
+
+    def test_machine_meta_data(self):
+        ...
+
+    def test_machine_type(self):
+        ...
+
+    def test_site_name(self):
+        ...
+
+    def test_resource_status(self):
+        ...
+
+    def test_stop_resource(self):
+        ...
+
+    def test_terminate_resource(self):
+        ...
+
+    def test_exception_handling(self):
+        ...

--- a/tests/adapters_t/sites_t/test_lancium.py
+++ b/tests/adapters_t/sites_t/test_lancium.py
@@ -120,7 +120,7 @@ class TestLanciumAdapter(TestCase):
                     {"variable": "TardisDroneUuid", "value": "testsite-089123"},
                 ],
             },
-            self.mocked_lancium_api.jobs.create_job.call_args.kwargs["job"],
+            self.mocked_lancium_api.jobs.create_job.call_args[1]["job"],
         )
         self.mocked_lancium_api.jobs.submit_job.assert_called_with(id=123)
 

--- a/tests/adapters_t/sites_t/test_lancium.py
+++ b/tests/adapters_t/sites_t/test_lancium.py
@@ -1,0 +1,26 @@
+from tardis.adapters.sites.lancium import LanciumAdapter
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestLanciumAdapter(TestCase):
+    mock_config_patcher = None
+    mock_lancium_api_patcher = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mock_config_patcher = patch("tardis.interfaces.siteadapter.Configuration")
+        cls.mock_config = cls.mock_config_patcher.start()
+        cls.mock_lancium_api_patcher = patch(
+            "tardis.adapters.sites.lancium.LanciumClient"
+        )
+        cls.mock_openstack_api = cls.mock_lancium_api_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_config_patcher.stop()
+        cls.mock_lancium_api_patcher.stop()
+
+    def setUp(self) -> None:
+        self.adapter = LanciumAdapter(machine_type="test2large", site_name="TestSite")


### PR DESCRIPTION
This pull request adds support for the [Lancium Compute](https://portal.lancium.com/) site utilizing the [aiolancium](https://github.com/giffels/aiolancium) client. 

P.S.: Due to running `generate_apidoc.sh` some additional `rst` files in the documentation have been updated.