### PR TITLE
Fix Python3.6 unittest by using ubuntu 20.04

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
     -   id: black
         args:
         -   --target-version=py36
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.2
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
 -   repo: https://github.com/Matterminers/dev-tools

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-11-23, command
+.. Created by changelog.py at 2022-12-07, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-11-23
+[Unreleased] - 2022-12-07
 =========================
 
 Added

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -112,7 +112,7 @@ class AsyncBulkCall(Generic[T, R]):
     async def _bulk_dispatch(self):
         """Collect tasks into bulks and dispatch them for command execution"""
         while not self._queue.empty():
-            bulk = list(zip(*(await self._get_bulk())))
+            bulk = list(zip(*(await self._get_bulk())))  # noqa B905
             if not bulk:
                 continue
             tasks, futures = bulk
@@ -171,5 +171,5 @@ class AsyncBulkCall(Generic[T, R]):
             for future in futures:
                 future.set_exception(task_exception)
         else:
-            for future, result in zip(futures, results):
+            for future, result in zip(futures, results):  # noqa B905
                 future.set_result(result)

--- a/tests/plugins_t/test_prometheusmonitoring.py
+++ b/tests/plugins_t/test_prometheusmonitoring.py
@@ -74,7 +74,9 @@ class TestPrometheusMonitoring(TestCase):
         assert all(
             [
                 gauge.get({}) == result
-                for (gauge, result) in zip(self.plugin._gauges.values(), values)
+                for (gauge, result) in zip(
+                    self.plugin._gauges.values(), values
+                )  # noqa B905
             ]
         )
 

--- a/tests/plugins_t/test_prometheusmonitoring.py
+++ b/tests/plugins_t/test_prometheusmonitoring.py
@@ -74,9 +74,9 @@ class TestPrometheusMonitoring(TestCase):
         assert all(
             [
                 gauge.get({}) == result
-                for (gauge, result) in zip(
+                for (gauge, result) in zip(  # noqa B905
                     self.plugin._gauges.values(), values
-                )  # noqa B905
+                )
             ]
         )
 

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -145,7 +145,7 @@ class TestSqliteRegistry(TestCase):
         # Database content has to be checked several times
         # Define inline function to re-use code
         def check_db_content():
-            for row, site_name in zip(
+            for row, site_name in zip(  # noqa B905
                 self.execute_db_query("SELECT site_name FROM Sites"), test_site_names
             ):
                 self.assertEqual(row[0], site_name)


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/6399 GitHub's run-on `ubuntu-latest` tag is now pointing to Ubuntu 22.04. However, this version does not offer a Python 3.6 interpreter according to https://github.com/actions/setup-python/issues/544. This will break our unittest for the good old Python 3.6 version. 

This pull request forces GitHub actions to use Ubuntu 20.04 instead, which still supports Python 3.6. Just another hint that it is time to get rid of it. 😌

In addition, the newest flake checks for [PEP-618](https://peps.python.org/pep-0618/), which is only supported for Python>=3.10. Hence, I have disabled the checks on the concerned lines.