### PR TITLE
Add support for openstack application credentials

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -447,19 +447,28 @@ Available adapter configuration options
 
 .. content-tabs:: left-col
 
-    +---------------------+---------------------------------------------------------------------+-----------------+
-    | Option              | Short Description                                                   | Requirement     |
-    +=====================+=====================================================================+=================+
-    | auth_url            | The end point of the OpenStack API to contact.                      |  **Required**   |
-    +---------------------+---------------------------------------------------------------------+-----------------+
-    | username            | Your OpenStack API username to authenticate yourself.               |  **Required**   |
-    +---------------------+---------------------------------------------------------------------+-----------------+
-    | password            | Your OpenStack API password to authenticate yourself.               |  **Required**   |
-    +---------------------+---------------------------------------------------------------------+-----------------+
-    | user_domain_name    | The name of the OpenStack user domain.                              |  **Required**   |
-    +---------------------+---------------------------------------------------------------------+-----------------+
-    | project_domain_name | The name of the OpenStack project domain.                           |  **Required**   |
-    +---------------------+---------------------------------------------------------------------+-----------------+
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | Option                        | Short Description                                                   | Requirement     |
+    +===============================+=====================================================================+=================+
+    | auth_url                      | The end point of the OpenStack API to contact.                      |  **Required**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | username                      | Your OpenStack API username to authenticate yourself.               |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | password                      | Your OpenStack API password to authenticate yourself.               |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | user_domain_name              | The name of the OpenStack user domain.                              |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | project_domain_name           | The name of the OpenStack project domain.                           |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | application_credential_id     | Your application credential ID to authenticate yourself.            |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+    | application_credential_secret | Your application credential secret to authenticate yourself.        |  **Optional**   |
+    +-------------------------------+---------------------------------------------------------------------+-----------------+
+
+    .. note::
+        Either ``username``, ``password`` , ``user_domain_name`` and ``project_domain_name`` or
+        ``application_credential_id`` and ``application_credential_secret`` are mandatory to authenticate against the
+        OpenStack endpoint.
 
     All configuration entries in the `MachineTypeConfiguration` section of the machine types are
     directly added as keyword arguments to the OpenStack API `create-server` call. All available options are

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ Added
 * Introduce a TARDIS REST API to query the state of resources from SqlRegistry
 * Added support for manual draining of drones using the REST API
 * Add support for passing environment variables as executable arguments to support HTCondor grid universe
+* Added support for application credentials of the OpenStack site adapter
 * Added a new site adapter to use Lancium compute as resource provider
 
 Changed

--- a/docs/source/changes/274.add_openstack_application_cred_support.yaml
+++ b/docs/source/changes/274.add_openstack_application_cred_support.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: "Added support for application credentials of the OpenStack site adapter"
+description: |
+  Newer versions of OpenStack support the creation of application credentials for specific projects. So, the pair of
+  application_credential_id and application_credential_secret is only valid of a specific project. The OpenStack site
+  adapter now fully supports the utilization of application credentials to authenticate against the OpenStack API 
+  endpoint.
+pull requests:
+- 274

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         get_cryptography_version(),
         "CloudStackAIO>=0.0.8",
         "PyYAML",
-        "AsyncOpenStackClient",
+        "git+https://github.com/giffels/AsyncOpenStackClient@feature/support_application_credentials",  # noqa B950
         "cobald>=0.12.3",
         "asyncssh",
         "aiotelegraf",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         get_cryptography_version(),
         "CloudStackAIO>=0.0.8",
         "PyYAML",
-        "git+https://github.com/giffels/AsyncOpenStackClient@feature/support_application_credentials",  # noqa B950
+        "AsyncOpenStackClient>=0.9.0",
         "cobald>=0.12.3",
         "asyncssh",
         "aiotelegraf",

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -38,7 +38,7 @@ class OpenStackAdapter(SiteAdapter):
             user_domain_name=self.configuration.user_domain_name,
             project_domain_name=self.configuration.project_domain_name,
             application_credential_id=self.configuration.application_credential_id,
-            application_credential_secret=self.configuration.application_credential_secret,
+            application_credential_secret=self.configuration.application_credential_secret,  # noqa B950
         )
 
         self.nova = NovaClient(session=auth)

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -37,6 +37,8 @@ class OpenStackAdapter(SiteAdapter):
             project_name=self.configuration.project_name,
             user_domain_name=self.configuration.user_domain_name,
             project_domain_name=self.configuration.project_domain_name,
+            application_credential_id=self.configuration.application_credential_id,
+            application_credential_secret=self.configuration.application_credential_secret,
         )
 
         self.nova = NovaClient(session=auth)


### PR DESCRIPTION
This pull request enables support for OpenStack [application credentials ](https://docs.openstack.org/keystone/queens/user/application_credentials.html). The OpenStack now supports the traditional authentication using `username` and `password` as well as `application_credential_id` and `application_credential_secret`.

This change was actual part of #231. So, in case miss a corresponding unittest, it will be part of #231 since it relies on the migration to Pydantic for input validation.