### PR TITLE
Fix broken deployment docker builds

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
@@ -1,8 +1,7 @@
 FROM rockylinux:8
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN yum -y install epel-release && yum clean all
-RUN yum -y install curl && yum clean all
+RUN yum -y install epel-release && yum -y install curl && yum clean all
 
 RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux8
@@ -1,7 +1,8 @@
 FROM rockylinux:8
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN yum -y install epel-release curl && yum clean all
+RUN yum -y install epel-release && yum clean all
+RUN yum -y install curl && yum clean all
 
 RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
@@ -1,8 +1,7 @@
 FROM rockylinux:9
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN yum -y install epel-release && yum clean all
-RUN yum -y install curl && yum clean all
+RUN yum -y install epel-release && yum -y install curl && yum clean all
 
 RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
@@ -1,7 +1,8 @@
 FROM rockylinux:9
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN yum -y install epel-release curl && yum clean all
+RUN yum -y install epel-release && yum clean all
+RUN yum -y install curl && yum clean all
 
 RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2022-12-07, command
+.. Created by changelog.py at 2023-01-09, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2022-12-07
+[Unreleased] - 2023-01-09
 =========================
 
 Added


### PR DESCRIPTION
Currently, the docker builds of rocky linux containers used for deployment tests is currently broken. This can be fixed by installing `epel-release` before installing `curl`. This pull request simply change the order to install `curl` on rocky linux.