### PR TITLE
Use curl-minimum on rockylinux 9 deployment env container

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.rockylinux9
@@ -1,7 +1,7 @@
 FROM rockylinux:9
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
-RUN yum -y install epel-release && yum -y install curl && yum clean all
+RUN yum -y install epel-release && yum -y install curl-minimal && yum clean all
 
 RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-01-09, command
+.. Created by changelog.py at 2023-01-11, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-01-09
+[Unreleased] - 2023-01-11
 =========================
 
 Added


### PR DESCRIPTION
Since RockyLinux 9 docker builds are again broken, now the  `curl-minimum` package is used, which is sufficient for the purpose of installing `nodejs` in the container.