### PR TITLE
Bug fix for OpenStack adapter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-01-13, command
+.. Created by changelog.py at 2023-01-16, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-01-13
+[Unreleased] - 2023-01-16
 =========================
 
 Added

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -15,6 +15,7 @@ from tardis.interfaces.siteadapter import SiteAdapter
 from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.staticmapping import StaticMapping
 
+
 from asyncio import TimeoutError
 from contextlib import contextmanager
 from datetime import datetime
@@ -30,16 +31,21 @@ class OpenStackAdapter(SiteAdapter):
         self._machine_type = machine_type
         self._site_name = site_name
 
-        auth = AuthPassword(
-            auth_url=self.configuration.auth_url,
-            username=self.configuration.username,
-            password=self.configuration.password,
-            project_name=self.configuration.project_name,
-            user_domain_name=self.configuration.user_domain_name,
-            project_domain_name=self.configuration.project_domain_name,
-            application_credential_id=self.configuration.application_credential_id,
-            application_credential_secret=self.configuration.application_credential_secret,  # noqa B950
-        )
+        try:
+            auth = AuthPassword(
+                auth_url=self.configuration.auth_url,
+                username=self.configuration.username,
+                password=self.configuration.password,
+                project_name=self.configuration.project_name,
+                user_domain_name=self.configuration.user_domain_name,
+                project_domain_name=self.configuration.project_domain_name,
+            )
+        except AttributeError:
+            auth = AuthPassword(
+                auth_url=self.configuration.auth_url,
+                application_credential_id=self.configuration.application_credential_id,
+                application_credential_secret=self.configuration.application_credential_secret,  # noqa B950
+            )
 
         self.nova = NovaClient(session=auth)
 

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -40,19 +40,23 @@ class TestOpenStackAdapter(TestCase):
         cls.mock_openstack_api_patcher.stop()
 
     def setUp(self):
-        config = self.mock_config.return_value
-        test_site_config = config.TestSite
-        test_site_config.auth_url = "https://test.nova.client.local"
-        test_site_config.username = "TestUser"
-        test_site_config.password = "test123"
-        test_site_config.project_name = "TestProject"
-        test_site_config.user_domain_name = "TestDomain"
-        test_site_config.project_domain_name = "TestProjectDomain"
-        test_site_config.MachineTypeConfiguration = AttributeDict(
-            test2large=AttributeDict(imageRef="bc613271-6a54-48ca-9222-47e009dc0c29")
-        )
-        test_site_config.MachineMetaData = AttributeDict(
-            test2large=AttributeDict(Cores=128)
+        self.config = self.mock_config.return_value
+        self.config.TestSite = AttributeDict(
+            auth_url="https://test.nova.client.local",
+            username="TestUser",
+            password="test123",
+            project_name="TestProject",
+            user_domain_name="TestDomain",
+            project_domain_name="TestProjectDomain",
+            MachineTypes=["test2large"],
+            MachineTypeConfiguration=AttributeDict(
+                test2large=AttributeDict(
+                    imageRef="bc613271-6a54-48ca-9222-47e009dc0c29"
+                )
+            ),
+            MachineMetaData=AttributeDict(
+                test2large=AttributeDict(Cores=128, Memory=256, Disk=1000)
+            ),
         )
 
         openstack_api = self.mock_openstack_api.return_value
@@ -90,6 +94,24 @@ class TestOpenStackAdapter(TestCase):
     def tearDown(self):
         self.mock_openstack_api.reset_mock()
 
+    def test_auth_setup(self):
+        # test auth with username, password, etc.
+        OpenStackAdapter(machine_type="test2large", site_name="TestSite")
+
+        for key in (
+            "username",
+            "password",
+            "project_name",
+            "user_domain_name",
+            "project_domain_name",
+        ):
+            delattr(self.config.TestSite, key)
+
+        self.config.TestSite["application_credential_id"] = "TestAppId"
+        self.config.TestSite["application_credential_secret"] = "TestAppSecret"
+        # test auth with application credentials
+        OpenStackAdapter(machine_type="test2large", site_name="TestSite")
+
     def test_deploy_resource(self):
         self.assertEqual(
             run_async(
@@ -110,7 +132,8 @@ class TestOpenStackAdapter(TestCase):
 
     def test_machine_meta_data(self):
         self.assertEqual(
-            self.openstack_adapter.machine_meta_data, AttributeDict(Cores=128)
+            self.openstack_adapter.machine_meta_data,
+            AttributeDict(Cores=128, Disk=1000, Memory=256),
         )
 
     def test_machine_type(self):


### PR DESCRIPTION
Together with #274 a bug has been introduced to the OpenStack adapter, which was not spotted due to not properly configred unittest. Now, a case differention between authentication with regular username, password, project_name, etc. and authentication using application_credentials has been introduced. 

In addition, the way the OpenStack adapter has been configured in the unittest has been improve, so that it fails to access attributed that do not exists. The unittest now also testing explictly the authentication using both mechanism.