### PR TITLE
Fix handling of job ids in Lancium adapter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-01-16, command
+.. Created by changelog.py at 2023-01-26, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-01-16
+[Unreleased] - 2023-01-26
 =========================
 
 Added

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -109,7 +109,7 @@ class LanciumAdapter(SiteAdapter):
         # since map is updated asynchronously.
         try:
             resource_uuid = resource_attributes.remote_resource_uuid
-            resource_status = self._lancium_status[resource_uuid]
+            resource_status = self._lancium_status[int(resource_uuid)]
         except KeyError as err:
             if (
                 self._lancium_status.last_update - resource_attributes.created

--- a/tardis/adapters/sites/lancium.py
+++ b/tardis/adapters/sites/lancium.py
@@ -128,14 +128,14 @@ class LanciumAdapter(SiteAdapter):
 
     async def stop_resource(self, resource_attributes: AttributeDict):
         response = await self.client.jobs.terminate_job(
-            id=resource_attributes.remote_resource_uuid
+            id=int(resource_attributes.remote_resource_uuid)
         )
         logger.debug(f"{self.site_name} stop resource returned {response}")
         return response
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         response = await self.client.jobs.delete_job(
-            id=resource_attributes.remote_resource_uuid
+            id=int(resource_attributes.remote_resource_uuid)
         )
         logger.debug(f"{self.site_name} terminate resource returned {response}")
         return response

--- a/tests/adapters_t/sites_t/test_lancium.py
+++ b/tests/adapters_t/sites_t/test_lancium.py
@@ -238,37 +238,40 @@ class TestLanciumAdapter(TestCase):
             )
 
     def test_stop_resource(self):
-        def run_it():
+        def run_it(job_id):
             return run_async(
                 self.adapter.stop_resource,
-                resource_attributes=AttributeDict(remote_resource_uuid=123),
+                resource_attributes=AttributeDict(remote_resource_uuid=job_id),
             )
 
-        run_it()
-
-        self.mocked_lancium_api.jobs.terminate_job.assert_called_with(id=123)
+        for job_id in (123, "123"):
+            run_it(job_id)
+            self.mocked_lancium_api.jobs.terminate_job.assert_called_with(
+                id=int(job_id)
+            )
 
         self.mocked_lancium_api.jobs.terminate_job.side_effect = AuthError(
             "operation=auth_error", {}
         )
         with self.assertRaises(AuthError):
-            run_it()
+            run_it(123)
 
     def test_terminate_resource(self):
-        def run_it():
+        def run_it(job_id):
             return run_async(
                 self.adapter.terminate_resource,
-                resource_attributes=AttributeDict(remote_resource_uuid=123),
+                resource_attributes=AttributeDict(remote_resource_uuid=job_id),
             )
 
-        run_it()
-        self.mocked_lancium_api.jobs.delete_job.assert_called_with(id=123)
+        for job_id in (123, "123"):
+            run_it(job_id)
+            self.mocked_lancium_api.jobs.delete_job.assert_called_with(id=int(job_id))
 
         self.mocked_lancium_api.jobs.delete_job.side_effect = AuthError(
             "operation=auth_error", {}
         )
         with self.assertRaises(AuthError):
-            run_it()
+            run_it(123)
 
     def test_exception_handling(self):
         with self.assertRaises(TardisError):


### PR DESCRIPTION
Job id's at Lancium are integers and the Lancium adapter is treating them also as integers. In addition, the job id is used as `remote_resource_uuid` in `TARDIS` and is therefore stored in the persistent drone registry. 
In the drone registry the `remote_resource_uuid` is handled as `VARCHAR(255)`. Thus. when `TARDIS` is restarted after a shutdown, the `remote_resource_uuid` is treated as a string in TARDIS. 

This pull request fixes the handling of jobd ids in the Lancium adapter by always converting the `remote_resource_uuid` to an integer before actually checking the status of the corresponding job in Lancium.