### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -15,15 +15,15 @@ jobs:
         os_container: ['centos7', 'centosstream8', 'rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu18_04', 'ubuntu22_04']
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           file: containers/cobald-tardis-deployment-test-env/Dockerfile.${{ matrix.os_container }}
@@ -39,7 +39,7 @@ jobs:
         os_container: ['centos7', 'centosstream8', 'rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu18_04', 'ubuntu22_04']
     container: matterminers/cobald-tardis-deployment-test-env:${{ matrix.os_container }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies on ${{ matrix.os_container }}
         run: |
           python3 -m pip install --upgrade pip
@@ -55,7 +55,7 @@ jobs:
         platform: ['macos-latest']
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
           python3.10 -m pip install --upgrade pip

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -14,7 +14,7 @@ jobs:
   setup-docker-builds:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get containers to build
         id: get_containers
         run: |
@@ -40,12 +40,12 @@ jobs:
           containers: ${{ fromJSON(needs.setup-docker-builds.outputs.containers) }}
       steps:
         - name: Checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v1
+          uses: docker/setup-buildx-action@v2
         - name: Docker meta
           id: meta
-          uses: docker/metadata-action@v3
+          uses: docker/metadata-action@v4
           with:
             tags: |
               type=pep440,pattern={{version}}
@@ -53,13 +53,13 @@ jobs:
             images: matterminers/${{ matrix.containers }}
         - name: Login to DockerHub
           if: github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master'
-          uses: docker/login-action@v1
+          uses: docker/login-action@v2
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: Build
           id: docker_build
-          uses: docker/build-push-action@v2
+          uses: docker/build-push-action@v4
           with:
             context: containers/${{ matrix.containers }}
             push: ${{ github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -22,13 +22,13 @@ jobs:
            import json
            import pathlib
            print(
-               "::set-output name=containers::%s"
+               "containers=%s"
                % json.dumps([
                        str(path.parent.relative_to("containers"))
                        for path in pathlib.Path("containers").glob("**/Dockerfile")
                    ]
            ))
-           '
+           ' >> $GITHUB_OUTPUT
     outputs:
       containers: ${{ steps.get_containers.outputs.containers }}
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,4 +24,4 @@ jobs:
       run: |
         coverage run -m unittest -v
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-01-26, command
+.. Created by changelog.py at 2023-02-07, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-01-26
+[Unreleased] - 2023-02-07
 =========================
 
 Added


### PR DESCRIPTION
This pull requests addresses warnings about the migration of GitHub actions from `nodejs:12` to `nodejs:16`.

Like
```
setup-docker-builds
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. 
For more information see: 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

and

```
 setup-docker-builds
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```