### PR TITLE
Always install requirements for the TARDIS rest interface

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-02-07, command
+.. Created by changelog.py at 2023-02-15, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-02-07
+[Unreleased] - 2023-02-15
 =========================
 
 Added

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,8 @@ setup(
         "pytz",
         "tzlocal",
         "aiolancium",
-    ],
+    ]
+    + REST_REQUIRES,
     extras_require={
         "docs": [
             "sphinx",
@@ -107,15 +108,13 @@ setup(
             "sphinxcontrib-contentui",
             "myst_parser",
         ],
-        "rest": REST_REQUIRES,
         "test": TESTS_REQUIRE,
         "contrib": [
             "flake8",
             "flake8-bugbear",
             "black; implementation_name=='cpython'",
         ]
-        + TESTS_REQUIRE
-        + REST_REQUIRES,
+        + TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ setup(
         "pytz",
         "tzlocal",
         "aiolancium",
-    ]
-    + REST_REQUIRES,
+        *REST_REQUIRES,
+    ],
     extras_require={
         "docs": [
             "sphinx",
@@ -113,8 +113,8 @@ setup(
             "flake8",
             "flake8-bugbear",
             "black; implementation_name=='cpython'",
-        ]
-        + TESTS_REQUIRE,
+            *TESTS_REQUIRE,
+        ],
     },
     tests_require=TESTS_REQUIRE,
     zip_safe=False,


### PR DESCRIPTION
Currently the standard installation of `TARDIS` is broken, since the dependencies of the REST API are only installed on-demand. However, `COBalD` loads all plugins on its startup to check if a configuration for it is available, this causes `TARDIS` to crash, since the necessary dependencies of the REST API are not available. As long as https://github.com/MatterMiners/cobald/issues/119 is not implemented, we will install all dependencies of the REST API also in the standard installation of `TARDIS`.