### PR TITLE
Pin pyauditor to version to 0.0.6

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-02-15, command
+.. Created by changelog.py at 2023-02-16, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-02-15
+[Unreleased] - 2023-02-16
 =========================
 
 Added

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "asyncstdlib",
         "typing_extensions",
         "backports.cached_property",
-        "python-auditor>=0.0.5",
+        "python-auditor==0.0.6",
         "pytz",
         "tzlocal",
         "aiolancium",


### PR DESCRIPTION
Due to #283 I have pinned the pyauditor version to 0.0.6 for the time being, until the Auditor plugin has been fixed.