### PR TITLE
Nodejs18 not supported anymore on Ubuntu 18.04

### DIFF
--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu18_04
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get install -y nodejs \
     && apt-get clean \


### PR DESCRIPTION
According to https://github.com/nodesource/distributions/issues/1392 Nodejs18 is not supported anymore on Ubuntu 18.04, so this pull request downgrades the version used to Nodejs16, like for Centos7. 

Anyhow Ubuntu 18.04 will be depracted in April 2023 and therefore removed from deployment tests. See #288.