### PR TITLE
Fixing B028 flake warnings

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-02-16, command
+.. Created by changelog.py at 2023-02-23, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-02-16
+[Unreleased] - 2023-02-23
 =========================
 
 Added

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -72,6 +72,7 @@ def _submit_description(resource_jdls: Tuple[JDL, ...]) -> str:
             warnings.warn(
                 "Condor JDL templates may not include queue commands",
                 FutureWarning,
+                stacklevel=2,
             )
         else:
             commands.append("queue 1")

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -60,6 +60,7 @@ class MoabAdapter(SiteAdapter):
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,
+                stacklevel=2,
             )
             self._startup_command = self.configuration.StartupCommand
 

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -58,6 +58,7 @@ class SlurmAdapter(SiteAdapter):
             warnings.warn(
                 "StartupCommand has been moved to the machine_type_configuration!",
                 DeprecationWarning,
+                stacklevel=2,
             )
             self._startup_command = self.configuration.StartupCommand
 


### PR DESCRIPTION
This pull request applies changes to make flake liniting happy again, we now use `stacklevel=2` on warnings as suggested by flake.