### PR TITLE
AUDITOR plugin: fix for config without components

### DIFF
--- a/tardis/plugins/auditor.py
+++ b/tardis/plugins/auditor.py
@@ -41,9 +41,12 @@ class Auditor(Plugin):
                     self._resources[site.name][machine_type][resource] = getattr(
                         config, site.name
                     ).MachineMetaData[machine_type][resource]
-                    self._components[site.name][machine_type][resource] = getattr(
-                        config_auditor.components, machine_type
-                    ).get(resource, {})
+                    try:
+                        self._components[site.name][machine_type][resource] = getattr(
+                            config_auditor.components, machine_type
+                        ).get(resource, {})
+                    except AttributeError:
+                        continue
 
         self._user = getattr(config_auditor, "user", "tardis")
         self._group = getattr(config_auditor, "group", "tardis")

--- a/tests/plugins_t/test_auditor.py
+++ b/tests/plugins_t/test_auditor.py
@@ -163,3 +163,8 @@ class TestAuditor(TestCase):
         self.assertEqual(len(record.components[1].scores), 1)
         self.assertEqual(record.components[1].scores[0].name, "BLUBB")
         self.assertEqual(record.components[1].scores[0].value, 1.4)
+
+    def test_missing_components(self):
+        del self.config.Plugins.Auditor.components
+        plugin = Auditor()
+        self.assertEqual(plugin._components, {"testsite": {"test_machine_type": {}}})


### PR DESCRIPTION
The AUDITOR plugin currently crashes when no components are defined in the config, despite being marked as "optional" in the documentation.
This PR fixes this by simply continuing in such cases.