### PR TITLE
Disable change of drone_uuid after resource deployment in Moab adapter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-02-24, command
+.. Created by changelog.py at 2023-03-30, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,18 @@
-.. Created by changelog.py at 2023-03-31, command
+.. Created by changelog.py at 2023-04-03, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
+
+[Unreleased] - 2023-04-03
+=========================
+
+Fixed
+-----
+
+* Disable change of drone_uuid after resource deployment in Moab adapter
 
 [0.7.0] - 2023-02-24
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-03-30, command
+.. Created by changelog.py at 2023-03-31, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changes/292.fixed_moab_site_adapater.yaml
+++ b/docs/source/changes/292.fixed_moab_site_adapater.yaml
@@ -1,0 +1,12 @@
+category: fixed
+summary: "Disable change of drone_uuid after resource deployment in Moab adapter"
+description: |
+  The Moab site adapter is changing the drone_uuid after the resource has been deployed to name-<moab_job_id>. Due to
+  this the SqliteRegistry is not updated anymore (since #247 ), so that TARDIS forgets about deployed resources in case
+  of a restart of the service. This pull requests removes that feature from the Moab adapter and deploys the standard
+  TardisDrone environments variables in the job environment instead, so that the drone can take care of setting the
+  right attributes to the OBS, so that TARDIS can associate drones to running jobs.
+issues:
+- 291
+pull requests:
+- 292

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -129,7 +129,6 @@ class MoabAdapter(SiteAdapter):
             remote_resource_uuid=remote_resource_uuid,
             created=datetime.now(),
             updated=datetime.now(),
-            drone_uuid=self.drone_uuid(remote_resource_uuid),
             resource_status=ResourceStatus.Booting,
         )
         return resource_attributes

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -9,7 +9,11 @@ from ...utilities.attributedict import AttributeDict
 from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
-from ...utilities.utils import convert_to, submit_cmd_option_formatter
+from ...utilities.utils import (
+    convert_to,
+    drone_environment_to_str,
+    submit_cmd_option_formatter,
+)
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -216,11 +220,11 @@ class MoabAdapter(SiteAdapter):
         mem = self.machine_meta_data.Memory
         node_type = self.machine_type_configuration.NodeType
 
-        drone_environment = ",".join(
-            f"TardisDrone{key}={convert_to(value, int, value)}"
-            for key, value in self.drone_environment(
-                drone_uuid, machine_meta_data_translation_mapping
-            ).items()
+        drone_environment = drone_environment_to_str(
+            self.drone_environment(drone_uuid, machine_meta_data_translation_mapping),
+            seperator=",",
+            prefix="TardisDrone",
+            customize_value=lambda x: convert_to(x, int, x),
         )
 
         return submit_cmd_option_formatter(

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -9,7 +9,7 @@ from ...utilities.attributedict import AttributeDict
 from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
-from ...utilities.utils import submit_cmd_option_formatter
+from ...utilities.utils import convert_to, submit_cmd_option_formatter
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -120,7 +120,11 @@ class MoabAdapter(SiteAdapter):
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        request_command = f"msub {self.msub_cmdline_options()} {self._startup_command}"
+        msub_cmdline_option_string = self.msub_cmdline_options(
+            resource_attributes.drone_uuid,
+            resource_attributes.obs_machine_meta_data_translation_mapping,
+        )
+        request_command = f"msub {msub_cmdline_option_string} {self._startup_command}"
         result = await self._executor.run_command(request_command)
         logger.debug(f"{self.site_name} servers create returned {result}")
 
@@ -203,7 +207,7 @@ class MoabAdapter(SiteAdapter):
         logger.debug("MOAB jobs cannot be stopped gracefully. Terminating instead.")
         return await self.terminate_resource(resource_attributes)
 
-    def msub_cmdline_options(self):
+    def msub_cmdline_options(self, drone_uuid, machine_meta_data_translation_mapping):
         sbatch_options = self.machine_type_configuration.get(
             "SubmitOptions", AttributeDict()
         )
@@ -212,6 +216,13 @@ class MoabAdapter(SiteAdapter):
         mem = self.machine_meta_data.Memory
         node_type = self.machine_type_configuration.NodeType
 
+        drone_environment = ",".join(
+            f"TardisDrone{key}={convert_to(value, int, value)}"
+            for key, value in self.drone_environment(
+                drone_uuid, machine_meta_data_translation_mapping
+            ).items()
+        )
+
         return submit_cmd_option_formatter(
             AttributeDict(
                 short=AttributeDict(
@@ -219,6 +230,7 @@ class MoabAdapter(SiteAdapter):
                     j="oe",
                     m="p",
                     l=f"walltime={walltime},mem={mem}gb,nodes={node_type}",
+                    v=f"{drone_environment}",
                 ),
                 long=AttributeDict(
                     **sbatch_options.get("long", AttributeDict()),

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -9,7 +9,12 @@ from ...utilities.attributedict import AttributeDict
 from ...utilities.attributedict import convert_to_attribute_dict
 from ...utilities.executors.shellexecutor import ShellExecutor
 from ...utilities.asynccachemap import AsyncCacheMap
-from ...utilities.utils import convert_to, csv_parser, submit_cmd_option_formatter
+from ...utilities.utils import (
+    convert_to,
+    drone_environment_to_str,
+    csv_parser,
+    submit_cmd_option_formatter,
+)
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
@@ -173,11 +178,11 @@ class SlurmAdapter(SiteAdapter):
 
         walltime = self.machine_type_configuration.Walltime
 
-        drone_environment = ",".join(
-            f"TardisDrone{key}={convert_to(value, int, value)}"
-            for key, value in self.drone_environment(
-                drone_uuid, machine_meta_data_translation_mapping
-            ).items()
+        drone_environment = drone_environment_to_str(
+            self.drone_environment(drone_uuid, machine_meta_data_translation_mapping),
+            seperator=",",
+            prefix="TardisDrone",
+            customize_value=lambda x: convert_to(x, int, x),
         )
 
         return AttributeDict(

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -2,7 +2,7 @@ from .attributedict import AttributeDict
 
 from contextlib import contextmanager
 from io import StringIO
-from typing import Any, Callable, List, TypeVar, Tuple
+from typing import Any, Callable, Dict, List, TypeVar, Tuple
 
 
 import csv
@@ -142,3 +142,16 @@ def convert_to(
         return convert_to_type(value)
     except ValueError:
         return default
+
+
+def drone_environment_to_str(
+    drone_environment: Dict,
+    seperator: str,
+    prefix: str,
+    customize_key: Callable = lambda x: x,
+    customize_value: Callable = lambda x: x,
+) -> str:
+    return seperator.join(
+        f"{prefix}{customize_key(key)}={customize_value(value)}"
+        for key, value in drone_environment.items()
+    )

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -198,7 +198,7 @@ class TestMoabAdapter(TestCase):
             updated=datetime.strptime(
                 "Wed Jan 23 2019 15:02:17", "%a %b %d %Y %H:%M:%S"
             ),
-            drone_uuid="testsite-4761849",
+            drone_uuid="testsite-abcdef",
         )
 
     def test_start_up_command_deprecation_warning(self):
@@ -227,7 +227,9 @@ class TestMoabAdapter(TestCase):
         return_resource_attributes = run_async(
             self.moab_adapter.deploy_resource,
             resource_attributes=AttributeDict(
-                machine_type="test2large", site_name="TestSite"
+                drone_uuid="testsite-abcdef",
+                machine_type="test2large",
+                site_name="TestSite",
             ),
         )
         if (

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -175,7 +175,7 @@ class TestMoabAdapter(TestCase):
 
     @property
     def machine_meta_data(self):
-        return AttributeDict(test2large=AttributeDict(Cores=128, Memory="120"))
+        return AttributeDict(test2large=AttributeDict(Cores=128, Memory=120, Disk=100))
 
     @property
     def machine_type_configuration(self):
@@ -199,6 +199,11 @@ class TestMoabAdapter(TestCase):
                 "Wed Jan 23 2019 15:02:17", "%a %b %d %Y %H:%M:%S"
             ),
             drone_uuid="testsite-abcdef",
+            obs_machine_meta_data_translation_mapping=AttributeDict(
+                Cores=1,
+                Memory=1,
+                Disk=1,
+            ),
         )
 
     def test_start_up_command_deprecation_warning(self):
@@ -226,11 +231,7 @@ class TestMoabAdapter(TestCase):
         )
         return_resource_attributes = run_async(
             self.moab_adapter.deploy_resource,
-            resource_attributes=AttributeDict(
-                drone_uuid="testsite-abcdef",
-                machine_type="test2large",
-                site_name="TestSite",
-            ),
+            resource_attributes=self.resource_attributes,
         )
         if (
             return_resource_attributes.created - expected_resource_attributes.created
@@ -247,7 +248,7 @@ class TestMoabAdapter(TestCase):
         )
         self.assertEqual(return_resource_attributes, expected_resource_attributes)
         self.mock_executor.return_value.run_command.assert_called_with(
-            "msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 startVM.py"  # noqa: B950
+            "msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 -v TardisDroneCores=128,TardisDroneMemory=120,TardisDroneDisk=100,TardisDroneUuid=testsite-abcdef startVM.py"  # noqa: B950
         )
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
@@ -263,13 +264,10 @@ class TestMoabAdapter(TestCase):
 
         run_async(
             moab_adapter.deploy_resource,
-            resource_attributes=AttributeDict(
-                machine_type="test2large",
-                site_name="TestSite",
-            ),
+            resource_attributes=self.resource_attributes,
         )
         self.mock_executor.return_value.run_command.assert_called_with(
-            "msub -M someone@somewhere.com -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 --timeout=60 startVM.py"  # noqa: B950
+            "msub -M someone@somewhere.com -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 -v TardisDroneCores=128,TardisDroneMemory=120,TardisDroneDisk=100,TardisDroneUuid=testsite-abcdef --timeout=60 startVM.py"  # noqa: B950
         )
 
     def test_machine_meta_data(self):


### PR DESCRIPTION
Currently, the Moab site adapter is changing the `drone_uuid` after the resource has been deployed to `name-<moab_job_id>`. Due to this the `SqliteRegistry` is not updated anymore (since #247 ), so that `TARDIS` forgets about deployed resources in case of a restart of the service. 

This pull requests removes that feature from the Moab adapter and deploys the standard `TardisDrone` environments variables in the job environment instead, so that the drone can take care of setting the right attributes to the OBS, so that `TARDIS` can associate drones to running jobs. In SLURM that is done via a `Feature`, while on HTCondor it is done via setting a `TardisDroneUuid` ClassAd. Now the almost all site adapters use the very same mechanism. 

Fixes #291.