### PR TITLE
Update pyauditor to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "asyncstdlib",
         "typing_extensions",
         "backports.cached_property",
-        "python-auditor==0.0.7",
+        "python-auditor==0.1.0",
         "pytz",
         "tzlocal",
         "aiolancium",


### PR DESCRIPTION
We have released a new version of auditor. This PR updates the pyauditor version in tardis to the latest version.