### PR TITLE
Use pydantic version 1

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-05-17, command
+.. Created by changelog.py at 2023-07-17, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         "elasticsearch>=7.17,<8.0.0",
         "aioprometheus>=21.9.0",
         "kubernetes_asyncio",
-        "pydantic",
+        "pydantic<2.0.0",
         "asyncstdlib",
         "typing_extensions",
         "backports.cached_property",


### PR DESCRIPTION
TARDIS is only compatible with pydantic version 1. Since the default is now version `2.0.3`, I would like to pin the use of version 1 in `setup.py`.