### PR TITLE
Ensure meaningful default for resource_status on new drones

### DIFF
--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -3,9 +3,9 @@ from typing import List, Union, Optional, Type
 from tardis.agents.batchsystemagent import BatchSystemAgent
 from tardis.agents.siteagent import SiteAgent
 from tardis.interfaces.plugin import Plugin
+from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.interfaces.state import State
-from .dronestates import RequestState
-from .dronestates import DownState
+from .dronestates import DownState, RequestState
 from ..plugins.sqliteregistry import SqliteRegistry
 from ..utilities.attributedict import AttributeDict
 from ..utilities.utils import load_states
@@ -32,8 +32,8 @@ class Drone(Pool):
         remote_resource_uuid=None,
         drone_uuid=None,
         state: Optional[State] = None,
-        created: float = None,
-        updated: float = None,
+        created: Optional[float] = None,
+        updated: Optional[float] = None,
     ):
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
@@ -117,6 +117,12 @@ class Drone(Pool):
             # to be notified on the first state change. As calling the
             # ``set_state`` coroutine is not possible in the constructor, we
             # initiate the first state change here
+            #
+            # In addition, all necessary attributes in `resource_attributes`
+            # `AttributeDict` need to be present and have meaningful defaults.
+            # `resource_status` should be set to `ResourceStatus.Booting` on
+            # newly created drones by default.
+            self.resource_attributes.resource_status = ResourceStatus.Booting
             await self.set_state(RequestState())
         while True:
             current_state = self.state

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -1,9 +1,10 @@
 from ..utilities.utilities import async_return, run_async, set_awaitable_return_value
 
 from tardis.interfaces.plugin import Plugin
+from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.interfaces.state import State
 from tardis.resources.drone import Drone
-from tardis.resources.dronestates import DrainState, DownState
+from tardis.resources.dronestates import DrainState, DownState, RequestState
 from tardis.plugins.sqliteregistry import SqliteRegistry
 from tardis.utilities.attributedict import AttributeDict
 
@@ -111,6 +112,24 @@ class TestDrone(TestCase):
 
     def test_site_agent(self):
         self.assertEqual(self.drone.site_agent, self.mock_site_agent)
+
+    @patch("tardis.resources.drone.RequestState", spec=RequestState)
+    def test_first_run_of_initialized_drone(self, mocked_request_state):
+        # self.drone.run() is executed in an endless loop, therefore an
+        # EndOfLoop exception is thrown, which then can be caught. Throwing
+        # StopIteration does not work in a while loop
+        class EndOfLoop(Exception):
+            pass
+
+        mocked_request_state.return_value.run.side_effect = EndOfLoop
+        with self.assertRaises(EndOfLoop):
+            run_async(self.drone.run)
+
+        # Actual test code
+        self.assertIsInstance(self.drone.state, RequestState)
+        self.assertEqual(
+            self.drone.resource_attributes.resource_status, ResourceStatus.Booting
+        )
 
     @patch("tardis.resources.drone.asyncio.sleep")
     def test_run(self, mocked_asyncio_sleep):


### PR DESCRIPTION
On newly created drones, the `resource_status` attribute is missing in the `resource_attributes` `AttributeDict`. This pull request adds the missing attribute, explicitly if the `state` is none, which means newly created drone. Therefore the attribute is set in https://github.com/MatterMiners/tardis/blob/0df932c86aa64b4e58f4db5c58c9322650810421/tardis/resources/drone.py#L125

Fixes #297 