### PR TITLE
Add error handling when updating non-existing record

### DIFF
--- a/tardis/plugins/auditor.py
+++ b/tardis/plugins/auditor.py
@@ -85,7 +85,18 @@ class Auditor(Plugin):
                 .replace(tzinfo=self._local_timezone)
                 .astimezone(pytz.utc)
             )
-            await self._client.update(record)
+            try:
+                await self._client.update(record)
+            except RuntimeError as e:
+                if str(e).startswith(
+                    "Reqwest Error: HTTP status client error (400 Bad Request)"
+                ):
+                    self.logger.debug(
+                        f"Could not update record {record.record_id}, "
+                        "it probably does not exist in the database"
+                    )
+                else:
+                    raise
 
     def construct_record(self, resource_attributes: AttributeDict):
         """

--- a/tests/plugins_t/test_auditor.py
+++ b/tests/plugins_t/test_auditor.py
@@ -165,6 +165,14 @@ class TestAuditor(TestCase):
                 resource_attributes=self.test_param,
             )
 
+        self.client.update.side_effect = RuntimeError("Does not match RegEx")
+        with self.assertRaises(RuntimeError):
+            run_async(
+                self.plugin.notify,
+                state=DownState(),
+                resource_attributes=self.test_param,
+            )
+
         self.client.update.side_effect = ValueError("Other exception")
         with self.assertRaises(ValueError):
             run_async(


### PR DESCRIPTION
This is my proposed solution to fix #305 

I tried to only catch this specific exception. All other exceptions should still be passed along.

Please let me know if we should do things differently.

Also, I was not sure how I can create a unit test for this specific case, because the auditor server is not directly mocked if I understood the test setup correctly.

I tested this in Freiburg in production and found no issues with this fix so far.