### PR TITLE
Fix updated timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,8 +116,11 @@ test_scripts/
 cobald*.yml
 *tardis.yml
 
-#Ignore cloudinit files
+# Ignore cloudinit files
 cloudinit/
 
-#Ignore logs
-*.log*
+# Ignore logs
+*.log
+
+# Igonre vscode
+.vscode*

--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -316,7 +316,13 @@ Available adapter configuration options
     +----------------+------------------------------------------------------------------------------------------------+-----------------+
     | Option         | Short Description                                                                              | Requirement     |
     +================+================================================================================================+=================+
-    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                         |  **Required**   |
+    | bulk_size      | Maximum number of jobs to handle per bulk invocation of the ``showq`` command.                 |  **Optional**   |
+    +                +                                                                                                +                 +
+    |                | Default: 100                                                                                   |                 |
+    +----------------+------------------------------------------------------------------------------------------------+-----------------+
+    | bulk_delay     | Maximum duration in seconds to wait per bulk invocation of the ``showq`` command.              |  **Optional**   |
+    +                +                                                                                                +                 +
+    |                | Default: 1.0                                                                                   |                 |
     +----------------+------------------------------------------------------------------------------------------------+-----------------+
     | StartupCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!)    |  **Deprecated** |
     +----------------+------------------------------------------------------------------------------------------------+-----------------+
@@ -347,7 +353,6 @@ Available adapter configuration options
             username: clown
             client_keys:
               - /opt/tardis/ssh/tardis
-          StatusUpdate: 2
           MachineTypes:
             - singularity_d2.large
             - singularity_d1.large
@@ -468,7 +473,13 @@ Available adapter configuration options
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
     | Option         | Short Description                                                                           | Requirement     |
     +================+=============================================================================================+=================+
-    | StatusUpdate   | The result of the status call is cached for `StatusUpdate` in minutes.                      |  **Required**   |
+    | bulk_size      | Maximum number of jobs to handle per bulk invocation of the ``squeue`` command.             |  **Optional**   |
+    +                +                                                                                             +                 +
+    |                | Default: 100                                                                                |                 |
+    +----------------+---------------------------------------------------------------------------------------------+-----------------+
+    | bulk_delay     | Maximum duration in seconds to wait per bulk invocation of the ``squeue`` command.          |  **Optional**   |
+    +                +                                                                                             +                 +
+    |                | Default: 1.0                                                                                |                 |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
     | StartUpCommand | The command executed in the batch job. (**Deprecated:** Moved to MachineTypeConfiguration!) |  **Deprecated** |
     +----------------+---------------------------------------------------------------------------------------------+-----------------+
@@ -511,7 +522,6 @@ Available machine type configuration options
             username: billy
             client_keys:
              - /opt/tardis/ssh/tardis
-          StatusUpdate: 2
           MachineTypes:
             - one_day
             - twelve_hours

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-08-14, command
+.. Created by changelog.py at 2023-10-04, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-08-14
+[Unreleased] - 2023-10-04
 =========================
 
 Deprecated

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -12,7 +12,6 @@ from CloudStackAIO.CloudStack import CloudStack
 from CloudStackAIO.CloudStack import CloudStackClientException
 
 from contextlib import contextmanager
-from datetime import datetime
 from functools import partial
 
 import asyncio
@@ -37,8 +36,6 @@ class CloudStackAdapter(SiteAdapter):
         )
 
         translator_functions = StaticMapping(
-            created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
-            updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
             state=lambda x, translator=StaticMapping(
                 Present=ResourceStatus.Booting,
                 Running=ResourceStatus.Running,

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -51,7 +51,13 @@ class FakeSiteAdapter(SiteAdapter):
         # check if resource should already run
         if (datetime.now() - created_time) > timedelta(
             seconds=resource_boot_time
-        ) and resource_attributes.resource_status is ResourceStatus.Booting:
+        ) and resource_attributes.get(
+            "resource_status",
+            ResourceStatus.Booting
+            # When cobald is restarted, "resource_status" is not set. Since this is a
+            # FakeAdapter, when can safely start the cycle again by assuming
+            # ResourceStatus.Booting and let TARDIS manage the drone's life cycle
+        ) is ResourceStatus.Booting:
             return self.handle_response(
                 AttributeDict(resource_status=ResourceStatus.Running)
             )

--- a/tardis/adapters/sites/fakesite.py
+++ b/tardis/adapters/sites/fakesite.py
@@ -23,9 +23,6 @@ class FakeSiteAdapter(SiteAdapter):
         key_translator = StaticMapping(
             remote_resource_uuid="remote_resource_uuid",
             resource_status="resource_status",
-            created="created",
-            updated="updated",
-            resource_boot_time="resource_boot_time",
         )
 
         self.handle_response = partial(
@@ -34,72 +31,43 @@ class FakeSiteAdapter(SiteAdapter):
             translator_functions=StaticMapping(),
         )
 
-        self._stopped_n_terminated_resources = {}
-
     async def deploy_resource(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         await asyncio.sleep(self._api_response_delay.get_value())
-        now = datetime.now()
         response = AttributeDict(
             remote_resource_uuid=uuid4().hex,
             resource_status=ResourceStatus.Booting,
-            created=now,
-            updated=now,
-            resource_boot_time=self._resource_boot_time.get_value(),
         )
         return self.handle_response(response)
-
-    def get_resource_boot_time(self, resource_attributes: AttributeDict) -> float:
-        try:
-            return resource_attributes.resource_boot_time
-        except AttributeError:
-            # In case tardis is restarted, resource_boot_time is not set, so re-set
-            resource_boot_time = resource_attributes[
-                "resource_boot_time"
-            ] = self._resource_boot_time.get_value()
-            return resource_boot_time
 
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         await asyncio.sleep(self._api_response_delay.get_value())
-        try:  # check if resource has been stopped or terminated
-            resource_status = self._stopped_n_terminated_resources[
-                resource_attributes.drone_uuid
-            ]
-        except KeyError:
-            pass
-        else:
-            return self.handle_response(AttributeDict(resource_status=resource_status))
-
         created_time = resource_attributes.created
 
-        resource_boot_time = self.get_resource_boot_time(resource_attributes)
-        # check if resource is already running
-        if (datetime.now() - created_time) > timedelta(seconds=resource_boot_time):
+        resource_boot_time = self._resource_boot_time.get_value()
+        # check if resource should already run
+        if (datetime.now() - created_time) > timedelta(
+            seconds=resource_boot_time
+        ) and resource_attributes.resource_status is ResourceStatus.Booting:
             return self.handle_response(
                 AttributeDict(resource_status=ResourceStatus.Running)
             )
-        return self.handle_response(resource_attributes)
+        return AttributeDict()  # do not change anything
 
-    async def stop_resource(self, resource_attributes: AttributeDict):
+    async def stop_resource(self, resource_attributes: AttributeDict) -> None:
         await asyncio.sleep(self._api_response_delay.get_value())
-        self._stopped_n_terminated_resources[
-            resource_attributes.drone_uuid
-        ] = ResourceStatus.Stopped
-        return self.handle_response(
-            AttributeDict(resource_status=ResourceStatus.Stopped)
-        )
+        # update resource status manually to ResourceStatus.Stopped, so that
+        # the life cycle comes to an end.
+        resource_attributes.resource_status = ResourceStatus.Stopped
 
-    async def terminate_resource(self, resource_attributes: AttributeDict):
+    async def terminate_resource(self, resource_attributes: AttributeDict) -> None:
         await asyncio.sleep(self._api_response_delay.get_value())
-        self._stopped_n_terminated_resources[
-            resource_attributes.drone_uuid
-        ] = ResourceStatus.Deleted
-        return self.handle_response(
-            AttributeDict(resource_status=ResourceStatus.Deleted)
-        )
+        # update resource status manually to ResourceStatus.Deleted, so that
+        # the life cycle is ended.
+        resource_attributes.resource_status = ResourceStatus.Deleted
 
     @contextmanager
     def handle_exceptions(self) -> None:

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,11 +1,10 @@
-from typing import Iterable, Tuple, Awaitable
+from typing import Iterable, Tuple, Awaitable, Mapping
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...exceptions.tardisexceptions import TardisError
 from ...exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from ...interfaces.siteadapter import SiteAdapter
 from ...interfaces.siteadapter import ResourceStatus
 from ...interfaces.executor import Executor
-from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
 from ...utilities.staticmapping import StaticMapping
 from ...utilities.executors.shellexecutor import ShellExecutor
@@ -35,18 +34,23 @@ def _job_id(resource_uuid: str) -> str:
     return resource_uuid if "." in resource_uuid else f"{resource_uuid}.0"
 
 
-async def htcondor_queue_updater(executor):
-    attributes = dict(
-        Owner="Owner", JobStatus="JobStatus", ClusterId="ClusterId", ProcId="ProcId"
-    )
+async def condor_q(
+    *resource_attributes: Tuple[AttributeDict, ...], executor: Executor
+) -> Iterable[Mapping]:
+    attributes = dict(JobStatus="JobStatus", ClusterId="ClusterId", ProcId="ProcId")
     attributes_string = " ".join(attributes.values())
-    queue_command = f"condor_q -af:t {attributes_string}"
+
+    remote_resource_ids = " ".join(
+        _job_id(resource.remote_resource_uuid) for resource in resource_attributes
+    )
+
+    queue_command = f"condor_q {remote_resource_ids} -af:t {attributes_string}"
 
     htcondor_queue = {}
     try:
         condor_queue = await executor.run_command(queue_command)
     except CommandExecutionFailure as cf:
-        logger.warning(f"htcondor_queue_update failed: {cf}")
+        logger.warning(f"{queue_command} failed with: {cf}")
         raise
     else:
         for row in csv_parser(
@@ -57,7 +61,18 @@ async def htcondor_queue_updater(executor):
         ):
             row["JobId"] = f"{row['ClusterId']}.{row['ProcId']}"
             htcondor_queue[row["JobId"]] = row
-        return htcondor_queue
+
+        return (
+            htcondor_queue.get(
+                _job_id(resource.remote_resource_uuid),
+                # assume that jobs that do not show up (anymore) in condor_q have
+                # JobStatus 4 (Deleted)
+                {
+                    "JobStatus": "4",
+                },
+            )
+            for resource in resource_attributes
+        )
 
 
 JDL = str
@@ -208,6 +223,11 @@ class HTCondorAdapter(SiteAdapter):
             )
             for tool in (condor_submit, condor_suspend, condor_rm)
         )
+        self._condor_q = AsyncBulkCall(
+            partial(condor_q, executor=self._executor),
+            size=bulk_size,
+            delay=bulk_delay,
+        )
 
         key_translator = StaticMapping(
             remote_resource_uuid="JobId",
@@ -227,11 +247,6 @@ class HTCondorAdapter(SiteAdapter):
             self.handle_response,
             key_translator=key_translator,
             translator_functions=translator_functions,
-        )
-
-        self._htcondor_queue = AsyncCacheMap(
-            update_coroutine=partial(htcondor_queue_updater, self._executor),
-            max_age=self.configuration.max_age * 60,
         )
 
     async def deploy_resource(
@@ -267,32 +282,7 @@ class HTCondorAdapter(SiteAdapter):
     async def resource_status(
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
-        await self._htcondor_queue.update_status()
-        try:
-            resource_uuid = _job_id(resource_attributes.remote_resource_uuid)
-            resource_status = self._htcondor_queue[resource_uuid]
-        except KeyError:
-            # In case the created timestamp is after last update timestamp of the
-            # asynccachemap plus a grace period of max(10, bulk_delay) seconds, no
-            # decision about the current state can be given, since map is updated
-            # asynchronously.
-            bulk_delay = getattr(self.configuration, "bulk_delay", 1)
-            if (
-                self._htcondor_queue.last_update - resource_attributes.created
-            ).total_seconds() < max(bulk_delay, 10):
-                logger.debug(
-                    "Time difference between drone creation and last_update of"
-                    f"htcondor_queue is less then {max(bulk_delay, 10)} s."
-                )
-                raise TardisResourceStatusUpdateFailed from None
-            else:
-                logger.debug(
-                    f"Cannot find {resource_uuid} in htcondor_queue assuming"
-                    "drone is already deleted."
-                )
-                return AttributeDict(resource_status=ResourceStatus.Deleted)
-        else:
-            return self.handle_response(resource_status)
+        return self.handle_response(await self._condor_q(resource_attributes))
 
     async def stop_resource(self, resource_attributes: AttributeDict) -> None:
         """

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -85,22 +85,20 @@ class OpenStackAdapter(SiteAdapter):
         logger.debug(f"{self.site_name} servers get returned {response}")
         return self.handle_response(response["server"])
 
-    async def stop_resource(self, resource_attributes: AttributeDict):
+    async def stop_resource(self, resource_attributes: AttributeDict) -> None:
         await self.nova.init_api(timeout=60)
         params = {"os-stop": None}
         response = await self.nova.servers.run_action(
             resource_attributes.remote_resource_uuid, **params
         )
         logger.debug(f"{self.site_name} servers stop returned {response}")
-        return response
 
-    async def terminate_resource(self, resource_attributes: AttributeDict):
+    async def terminate_resource(self, resource_attributes: AttributeDict) -> None:
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.force_delete(
             resource_attributes.remote_resource_uuid
         )
         logger.debug(f"{self.site_name} servers terminate returned {response}")
-        return response
 
     @contextmanager
     def handle_exceptions(self):

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -18,7 +18,6 @@ from tardis.utilities.staticmapping import StaticMapping
 
 from asyncio import TimeoutError
 from contextlib import contextmanager
-from datetime import datetime
 from functools import partial
 
 import logging
@@ -54,8 +53,6 @@ class OpenStackAdapter(SiteAdapter):
         )
 
         translator_functions = StaticMapping(
-            created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
-            updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
             status=lambda x, translator=StaticMapping(
                 BUILD=ResourceStatus.Booting,
                 ACTIVE=ResourceStatus.Running,

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -273,27 +273,25 @@ class SiteAdapter(metaclass=ABCMeta):
             ) from ae
 
     @abstractmethod
-    async def stop_resource(self, resource_attributes: AttributeDict):
+    async def stop_resource(self, resource_attributes: AttributeDict) -> None:
         """
         Abstract method to define the interface to stop resources at a resource
         provider.
         :param resource_attributes: Contains describing attributes of the resource,
         defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
         :type resource_attributes: AttributeDict
-        :return: Contains updated describing attributes of the resource.
-        :rtype: AttributeDict
+        :return: None
         """
         raise NotImplementedError
 
     @abstractmethod
-    async def terminate_resource(self, resource_attributes: AttributeDict):
+    async def terminate_resource(self, resource_attributes: AttributeDict) -> None:
         """
         Abstract method to define the interface to terminate resources at a
         resource provider.
         :param resource_attributes: Contains describing attributes of the resource,
         defined in the :py:class:`~tardis.resources.drone.Drone` implementation!
         :type resource_attributes: AttributeDict
-        :return: Contains updated describing attributes of the resource.
-        :rtype: AttributeDict
+        :return: None
         """
         raise NotImplementedError

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -45,8 +45,8 @@ class Drone(Pool):
             machine_type=self.site_agent.machine_type,
             obs_machine_meta_data_translation_mapping=self.batch_system_agent.machine_meta_data_translation_mapping,  # noqa B950
             remote_resource_uuid=remote_resource_uuid,
-            created=created or datetime.now(),
-            updated=updated or datetime.now(),
+            created=created or datetime.now(),  # timestamp drone creation
+            updated=updated or datetime.now(),  # timestamp last drone state update
             drone_uuid=drone_uuid or self.site_agent.drone_uuid(uuid.uuid4().hex[:10]),
         )
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -165,8 +165,6 @@ class TestHTCondorSiteAdapter(TestCase):
             ),
         )
         self.assertEqual(response.remote_resource_uuid, "1351043.0")
-        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
-        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
         _, kwargs = self.mock_executor.return_value.run_command.call_args
         self.assertEqual(
@@ -361,7 +359,7 @@ class TestHTCondorSiteAdapter(TestCase):
         response = run_async(
             self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043.0")
         )
-        self.assertEqual(response.remote_resource_uuid, "1351043.0")
+        self.assertIsNone(response)
 
     @mock_executor_run_command(
         stdout="",
@@ -403,7 +401,7 @@ class TestHTCondorSiteAdapter(TestCase):
             self.adapter.terminate_resource,
             AttributeDict(remote_resource_uuid="1351043.0"),
         )
-        self.assertEqual(response.remote_resource_uuid, "1351043.0")
+        self.assertIsNone(response)
 
     @mock_executor_run_command(stdout=CONDOR_RM_FAILED_OUTPUT)
     def test_terminate_resource_failed_redo(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -127,7 +127,7 @@ class TestHTCondorSiteAdapter(TestCase):
         test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         test_site_config.executor = self.mock_executor.return_value
         test_site_config.bulk_size = 100
-        test_site_config.bulk_delay = 0.1
+        test_site_config.bulk_delay = 0.01
         test_site_config.max_age = 10
 
         self.adapter = HTCondorAdapter(machine_type="test2large", site_name="TestSite")

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -167,7 +167,6 @@ class TestKubernetesStackAdapter(TestCase):
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
-                drone_uuid="testsite-089123",
                 resource_status=ResourceStatus.Booting,
             ),
         )
@@ -199,7 +198,6 @@ class TestKubernetesStackAdapter(TestCase):
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
-                drone_uuid="testsite-089123",
                 resource_status=ResourceStatus.Running,
             ),
         )
@@ -216,7 +214,6 @@ class TestKubernetesStackAdapter(TestCase):
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
-                drone_uuid="testsite-089123",
                 resource_status=ResourceStatus.Stopped,
             ),
         )
@@ -230,7 +227,6 @@ class TestKubernetesStackAdapter(TestCase):
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
-                drone_uuid="testsite-089123",
                 resource_status=ResourceStatus.Booting,
             ),
         )
@@ -244,7 +240,6 @@ class TestKubernetesStackAdapter(TestCase):
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
-                drone_uuid="testsite-089123",
                 resource_status=ResourceStatus.Deleted,
             ),
         )

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -6,8 +6,7 @@ from tardis.exceptions.tardisexceptions import TardisTimeout
 from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.utilities.attributedict import AttributeDict
 from tardis.interfaces.siteadapter import ResourceStatus
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
+from tests.utilities.utilities import async_return, run_async
 
 from aiohttp import ClientConnectionError
 from aiohttp import ContentTypeError
@@ -71,7 +70,11 @@ class TestOpenStackAdapter(TestCase):
 
         self.get_return_value = AttributeDict(
             server=AttributeDict(
-                name="testsite-089123", id="029312-1231-123123", status="ACTIVE"
+                name="testsite-089123",
+                id="029312-1231-123123",
+                status="ACTIVE",
+                created="2023-07-31T12:46:24Z",
+                updated="2023-07-31T12:46:50Z",
             )
         )
         openstack_api.servers.get.return_value = async_return(
@@ -147,7 +150,9 @@ class TestOpenStackAdapter(TestCase):
             run_async(
                 self.openstack_adapter.resource_status,
                 resource_attributes=AttributeDict(
-                    remote_resource_uuid="029312-1231-123123"
+                    drone_uuid="testsite-089123",
+                    remote_resource_uuid="029312-1231-123123",
+                    resource_status=ResourceStatus.Booting,
                 ),
             ),
             AttributeDict(

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -1,7 +1,5 @@
 from tardis.utilities.attributedict import AttributeDict
 
-from datetime import datetime
-
 import asyncio
 import socket
 
@@ -19,10 +17,6 @@ def get_free_port():  # from https://gist.github.com/dbrgn/3979133
     port = s.getsockname()[1]
     s.close()
     return port
-
-
-def get_fixed_datetime():
-    return datetime.fromtimestamp(12345689)
 
 
 def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -1,5 +1,7 @@
 from tardis.utilities.attributedict import AttributeDict
 
+from datetime import datetime
+
 import asyncio
 import socket
 
@@ -17,6 +19,10 @@ def get_free_port():  # from https://gist.github.com/dbrgn/3979133
     port = s.getsockname()[1]
     s.close()
     return port
+
+
+def get_fixed_datetime():
+    return datetime.fromtimestamp(12345689)
 
 
 def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):


### PR DESCRIPTION
The original idea was that `created` and `updated` timestamps indicate a change of the `DroneState`. However, in the meantime it was also updated in some `SiteAdapters`, when the resource status changed, e.g. through a `resource_status` call on certain `SiteAdapters`. Through the `drone_minimum_lifetime` setting seems to be ignored, because `resource_status` is called every minute, while `drone_minimum_lifetime` is usually in the order of hours. 

- [x] Remove all updates of the `created` and `updated` timestamp from adapters
- [x] Update all adapters:  Do not update the `resource_attributes` dictionary, this is only done in the `DroneStates`
- [x] Update all adapters: `deploy_resource` and `resource_status` should return only translated dictionaries of values to eventually modify the `resource_attributes` dictionary
- [x] Update all adapters: `stop_resource` and `terminate_resource` should return `None`
- [x] Use `AsyncBulkCall` for the `HTCondor`, `Moab` and `Slurm` site adpter as discussed below.

Fixes #296 