### PR TITLE
Fix broken yaml tags in the documentation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,10 +13,10 @@ R. Florian von Cube <florian.voncube@gmail.com>
 mschnepf <matthias.schnepf@kit.edu>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
+Benjamin Rottler <benjamin.rottler@cern.ch>
 Dirk Sammel <dirk.sammel@cern.ch>
 Matthias J. Schnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>
-Benjamin Rottler <benjamin.rottler@cern.ch>
 LGTM Migrator <lgtm-migrator@users.noreply.github.com>
 Matthias Schnepf <maschnepf@schnepf-net.de>
 PSchuhmacher <leon_schuhmacher@yahoo.de>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-08-08, command
+.. Created by changelog.py at 2023-08-10, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,7 +113,7 @@ Configuration of TARDIS
         BatchSystem:
           adapter: FakeBatchSystem
           allocation: 1.0
-          utilisation: !PeriodicValue
+          utilisation: !TardisPeriodicValue
                        period: 3600
                        amplitude: 0.5
                        offset: 0.5
@@ -126,10 +126,10 @@ Configuration of TARDIS
             quota: 8000 # CPU core quota
 
         Fake:
-          api_response_delay: !RandomGauss
+          api_response_delay: !TardisRandomGauss
                               mu: 0.1
                               sigma: 0.01
-          resource_boot_time: !RandomGauss
+          resource_boot_time: !TardisRandomGauss
                               mu: 60
                               sigma: 10
           MachineTypes:
@@ -182,7 +182,7 @@ Unified Configuration
             BatchSystem:
               adapter: FakeBatchSystem
               allocation: 1.0
-              utilization: !PeriodicValue
+              utilization: !TardisPeriodicValue
                            period: 3600
                            amplitude: 0.5
                            offset: 0.5
@@ -195,10 +195,10 @@ Unified Configuration
                 quota: 8000 # CPU core quota
 
             Fake:
-              api_response_delay: !RandomGauss
+              api_response_delay: !TardisRandomGauss
                                   mu: 0.1
                                   sigma: 0.01
-              resource_boot_time: !RandomGauss
+              resource_boot_time: !TardisRandomGauss
                                   mu: 60
                                   sigma: 10
               MachineTypes:


### PR DESCRIPTION
Since we migrated to `cobald.config.yaml_constructors`, the old-style yaml tags are not working anymore. This pull request fixes broken old-stlye yaml tags in the documentation. Thanks to @harrypuuter for reporting this issue.