### PR TITLE
Change readthedocs python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+   os: ubuntu-22.04
+   tools:
+      python: "3.11"
+
 python:
-   version: 3
    install:
       - method: pip
         path: .

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-08-11, command
+.. Created by changelog.py at 2023-08-14, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-08-11
+[Unreleased] - 2023-08-14
 =========================
 
 Deprecated

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-08-10, command
+.. Created by changelog.py at 2023-08-11, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-07-31
+[Unreleased] - 2023-08-11
 =========================
 
 Deprecated

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     ],
     extras_require={
         "docs": [
-            "sphinx",
+            "sphinx<7",
             "sphinx_rtd_theme",
             "sphinxcontrib-contentui",
             "myst_parser",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,8 @@ setup(
     ],
     extras_require={
         "docs": [
-            "sphinx<7",
+            "docutils<0.17",  # fixes rendering issue with two column layout
+            "sphinx",
             "sphinx_rtd_theme",
             "sphinxcontrib-contentui",
             "myst_parser",


### PR DESCRIPTION
readthedocs is using Python3.7 to build the documentation by default, which now failing since we require a minium python version of 3.8. This pull request fixes the failing readthedocs build by requesting a build using Python 3.11. 

In addition, the build seem to fail with `sphinx==7`, so that we now require `sphinx<7` in `setup.py`. See https://github.com/readthedocs/readthedocs.org/issues/10279 for details.

In addition, the rendering of the two column layout seems to have problems with newer version of `docutils`. Therefore, we will fix `docutils<0.17` for the time being. Thanks to @mschnepf for the report.