### PR TITLE
Fix type of sshexecutor stdin parameter

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -58,9 +58,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .[contrib]
-          python3 -m pip install coverage codecov
+          python3.11 -m pip install --upgrade pip
+          python3.11 -m pip install .[contrib]
+          python3.11 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
           coverage run -m unittest -v

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -58,9 +58,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
-          python3.11 -m pip install --upgrade pip
-          python3.11 -m pip install .[contrib]
-          python3.11 -m pip install coverage codecov
+          export PATH=/Library/Frameworks/Python.framework/Versions/3.11/bin:$PATH
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .[contrib]
+          python3 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
           coverage run -m unittest -v

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-10-10, command
+.. Created by changelog.py at 2023-11-09, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-11-09, command
+.. Created by changelog.py at 2023-11-10, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-11-09
+[Unreleased] - 2023-11-10
 =========================
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,14 @@
 CHANGELOG
 #########
 
+[Unreleased] - 2023-11-09
+=========================
+
+Fixed
+-----
+
+* Fix type of sshexecutor stdin parameter
+
 [0.8.0] - 2023-10-05
 ====================
 

--- a/docs/source/changes/314.fix_sshexecutor_stdin_parameter_type.yaml
+++ b/docs/source/changes/314.fix_sshexecutor_stdin_parameter_type.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: "Fix type of sshexecutor stdin parameter"
+description: |
+  In the SSHExecutor it was assumed that asyncssh requires stdin to be in bytes format. 
+  However, according to the documentation it is required to be in string format. Therefore, the type of stdin parameter 
+  has been changed from byte format into string format.
+pull requests:
+- 314

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -90,7 +90,7 @@ class SSHExecutor(Executor):
         async with self.bounded_connection as ssh_connection:
             try:
                 response = await ssh_connection.run(
-                    command, check=True, input=stdin_input and stdin_input
+                    command, check=True, input=stdin_input
                 )
             except asyncssh.ProcessError as pe:
                 raise CommandExecutionFailure(

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -90,7 +90,7 @@ class SSHExecutor(Executor):
         async with self.bounded_connection as ssh_connection:
             try:
                 response = await ssh_connection.run(
-                    command, check=True, input=stdin_input and stdin_input.encode()
+                    command, check=True, input=stdin_input and stdin_input
                 )
             except asyncssh.ProcessError as pe:
                 raise CommandExecutionFailure(

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -42,9 +42,7 @@ class MockConnection(object):
                 await asyncio.sleep(float(duration))
             elif command != "Test":
                 raise ValueError(f"Unsupported mock command: {command}")
-            return AttributeDict(
-                stdout=input and input, stderr="TestError", exit_status=0
-            )
+            return AttributeDict(stdout=input, stderr="TestError", exit_status=0)
 
     async def create_process(self):
         @asynccontextmanager

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -43,7 +43,7 @@ class MockConnection(object):
             elif command != "Test":
                 raise ValueError(f"Unsupported mock command: {command}")
             return AttributeDict(
-                stdout=input and input.decode(), stderr="TestError", exit_status=0
+                stdout=input and input, stderr="TestError", exit_status=0
             )
 
     async def create_process(self):


### PR DESCRIPTION
During migration of our active C/T instances to a different host, we are using the first time the `HTCondorSiteAdapter` in combination with the `SSHExecutor`. In addition, the `HTCondorSiteAdapter` is the only adapter that uses the `stdin` to add input to the `condor_submit`. 

That triggered a bug in the `SSHExecutor`, which assumed that `asyncssh` requires `stdin` to be in bytes format. However, according to the [documentation](https://asyncssh.readthedocs.io/en/latest/#i-o-redirection), it is required to be in string format.

This pull request changes the type of `SSHExecutor` from byte format  to string format.