### PR TITLE
Fix docker image builds and uploads for new releases

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -3,7 +3,7 @@ name: Docker Builds
 on:
   push:
     branches:
-      - '**'
+      - 'master'
     tags:
       - '*.*.*'
   pull_request:
@@ -52,7 +52,7 @@ jobs:
               type=raw,value=latest
             images: matterminers/${{ matrix.containers }}
         - name: Login to DockerHub
-          if: github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master'
+          if: github.repository == 'MatterMiners/tardis' && github.event_name != 'pull_request'
           uses: docker/login-action@v2
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -62,7 +62,7 @@ jobs:
           uses: docker/build-push-action@v4
           with:
             context: containers/${{ matrix.containers }}
-            push: ${{ github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master' }}
+            push: ${{ github.repository == 'MatterMiners/tardis' && github.event_name != 'pull_request' }}
             file: containers/${{ matrix.containers }}/Dockerfile
             tags: ${{ steps.meta.outputs.tags }}
             build-args: |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-10-10, command
+.. Created by changelog.py at 2023-11-10, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 


### PR DESCRIPTION
Currently, docker image are build on new tags, but not pushed to docker due to the following buggy constraint.

```
if github.repository == 'MatterMiners/tardis' && github.ref == 'refs/heads/master'
```

However, tags are in `refs/tags`. The constraint was added in order avoid uploading docker images build for each pull request. This pull request achieves the same by using the following contraint instead.

```
if: github.repository == 'MatterMiners/tardis' && github.event_name != 'pull_request'
```

In addtion, I have switched building and uploading of docker images for branches other then master. Since we solely work with pull requests so far.

Thanks to @QuantumDancer for reporting that issue.