### PR TITLE
Update pyauditor to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "pydantic<2.0.0",
         "asyncstdlib",
         "typing_extensions",
-        "python-auditor==0.2.0",
+        "python-auditor==0.3.0",
         "tzlocal",
         *REST_REQUIRES,
     ],


### PR DESCRIPTION
We have finally released [Auditor v0.3.0](https://github.com/ALU-Schumacher/AUDITOR/releases/tag/v0.3.0). This PR updates the pyauditor version in tardis. 

The v0.2.0 pyauditor client is not compatible with a v0.3.0 auditor server. Same for the other way around. However, these breaking changes are only internal to auditor/pyauditor, so we do not need to update any code in tardis.