### PR TITLE
Enable support for SSH command restrictions due to 2FA at NEMO 

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,8 +10,8 @@ ubdsv <ubdsv@student.kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
-mschnepf <matthias.schnepf@kit.edu>
 Benjamin Rottler <benjamin.rottler@cern.ch>
+mschnepf <matthias.schnepf@kit.edu>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
 Dirk Sammel <dirk.sammel@cern.ch>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-11-25, command
+.. Created by changelog.py at 2023-11-28, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2023-11-25
+[Unreleased] - 2023-11-28
 =========================
 
 Changed

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -31,8 +31,8 @@ logger = logging.getLogger("cobald.runtime.tardis.adapters.sites.moab")
 async def showq(
     *resource_attributes: Tuple[AttributeDict, ...], executor: Executor
 ) -> Iterable[Mapping]:
-    showq_active_cmd = "showq --xml -w user=$(USER)"
-    showq_completed_cmd = "showq -c --xml -w user=$(USER)"
+    showq_active_cmd = "showq --xml -w user=${USER}"
+    showq_completed_cmd = "showq -c --xml -w user=${USER}"
     logger.debug("Moab status update is running.")
     combined_response_stdout = ""
     for cmd in (showq_active_cmd, showq_completed_cmd):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -294,8 +294,8 @@ class TestMoabAdapter(TestCase):
 
             self.mock_executor.return_value.run_command.assert_has_calls(
                 [
-                    call("showq --xml -w user=$(USER)"),
-                    call("showq -c --xml -w user=$(USER)"),
+                    call("showq --xml -w user=${USER}"),
+                    call("showq -c --xml -w user=${USER}"),
                 ]
             )
             self.mock_executor.reset_mock()


### PR DESCRIPTION
Enable support for SSH command restrictions due to 2FA at NEMO, since #322 uses the wrong type of brackets. Sorry.