### PR TITLE
Fix handling of squeue call with invalid jobid

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,14 @@
 CHANGELOG
 #########
 
+[Unreleased] - 2023-12-18
+=========================
+
+Fixed
+-----
+
+* Fix handling of squeue call with invalid jobid
+
 [0.8.1] - 2023-11-29
 ====================
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2023-12-16, command
+.. Created by changelog.py at 2023-12-18, command
    '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changes/326.fix_handling_squeue_call_w_invalid_jobid.yaml
+++ b/docs/source/changes/326.fix_handling_squeue_call_w_invalid_jobid.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: "Fix handling of squeue call with invalid jobid"
+description: |
+  In case a job is already completed and only one non-existing job id is provided
+  the `squeue` command is failing with exit code 1 and it prints 
+  "Invalid job id specified" to stderr.
+pull requests:
+- 326

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -304,7 +304,31 @@ class TestSlurmAdapter(TestCase):
             self.mock_executor.reset_mock()
 
     @mock_executor_run_command("")
-    def test_resource_status_of_completed_jobs(self):
+    def test_resource_status_of_completed_jobs_w_empty_reply(self):
+        response = run_async(
+            self.slurm_adapter.resource_status,
+            AttributeDict(
+                resource_id="1390065",
+                remote_resource_uuid="1351043",
+            ),
+        )
+
+        self.assertEqual(response.resource_status, ResourceStatus.Deleted)
+
+        self.mock_executor.return_value.run_command.assert_called_with(
+            'squeue -o "%A|%N|%T" -h -t all --job=1351043'
+        )
+
+    @mock_executor_run_command(
+        stdout="",
+        raise_exception=CommandExecutionFailure(
+            message="Run command squeue --job=1351043 via SSHExecutor failed",
+            stdout="",
+            stderr="slurm_load_jobs error: Invalid job id specified",
+            exit_code=1,
+        ),
+    )
+    def test_resource_status_of_completed_jobs_w_raised_exception(self):
         response = run_async(
             self.slurm_adapter.resource_status,
             AttributeDict(


### PR DESCRIPTION
In case a job is already completed and only **one** non-existing job id is provided the `squeue` command  is failing with exit code 1 and it prints "Invalid job id specified" to stderr. If two or more non-existing job ids  or a mixture of existing ones and non-existings jobs are provided, `squeue` command succeeds. 

This pull request is adjusting the handling of failed `squeue` commands correspondigly.

Thanks to @rodwalker for reporting it.