### PR TITLE
Add Dependabot for outdated actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "giffels"
+      - "MatterMiners/review"


### PR DESCRIPTION
This PR configures dependabot to watch and update GitHub actions. No other dependencies are tracked at this point.

The configuration corresponds to the one used by COBalD as per matterminers/cobald#129 and matterminers/cobald#133. The default reviewer is @giffels as the de-facto code owner.