### PR TITLE
Remove Centos7 deployment tests

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
+        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['centos7', 'rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
+        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
     container: matterminers/cobald-tardis-deployment-test-env:${{ matrix.os_container }}
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 Benjamin Rottler <benjamin.rottler@cern.ch>
 mschnepf <matthias.schnepf@kit.edu>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
 Dirk Sammel <dirk.sammel@cern.ch>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,12 +1,12 @@
-.. Created by changelog.py at 2023-12-18, command
-   '/Users/giffler/.cache/pre-commit/repor6pnmwlm/py_env-python3.10/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2024-01-19, command
+   '/Users/giffler/.cache/pre-commit/repohwjkpq_d/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
 
-[Unreleased] - 2023-12-18
+[Unreleased] - 2024-01-19
 =========================
 
 Fixed


### PR DESCRIPTION
Since we have deprecated `python3.6` sometime ago, we do not need to run deployment tests on `centos:7` anymore. `centos:7` only provides `python3.6` and therefore is not supported anymore as well.