### PR TITLE
Catch littered status feedback in csv_parser

### DIFF
--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -60,10 +60,9 @@ async def squeue(
     else:
         # Not all lines returned in slurm_status.stdout belong to the actual squeue output
         # Only keep lines containing the delimiter
-        cleaned_stdout = []
-        for row in slurm_status.stdout.splitlines():
-            if "|" in row:
-                cleaned_stdout.append(row)
+        cleaned_stdout = [
+            row for row in slurm_status.stdout.splitlines() if "|" in row
+        ]
         for row in csv_parser(
             "\n".join(cleaned_stdout), fieldnames=tuple(attributes.keys()), delimiter="|"
         ):

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -58,8 +58,14 @@ async def squeue(
         raise
 
     else:
+        # Not all lines returned in slurm_status.stdout belong to the actual squeue output
+        # Only keep lines containing the delimiter
+        cleaned_stdout = []
+        for row in slurm_status.stdout.splitlines():
+            if "|" in row:
+                cleaned_stdout.append(row)
         for row in csv_parser(
-            slurm_status.stdout, fieldnames=tuple(attributes.keys()), delimiter="|"
+            "\n".join(cleaned_stdout), fieldnames=tuple(attributes.keys()), delimiter="|"
         ):
             row["State"] = row["State"].strip()
             slurm_resource_status[row["JobId"]] = row

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -60,9 +60,10 @@ async def squeue(
     else:
         # Not all lines returned in slurm_status.stdout belong to the actual squeue output
         # Only keep lines containing the delimiter
-        cleaned_stdout = [
-            row for row in slurm_status.stdout.splitlines() if "|" in row
-        ]
+        cleaned_stdout = []
+        for row in slurm_status.stdout.splitlines():
+            if "|" in row:
+                cleaned_stdout.append(row)
         for row in csv_parser(
             "\n".join(cleaned_stdout), fieldnames=tuple(attributes.keys()), delimiter="|"
         ):

--- a/tardis/adapters/sites/slurm.py
+++ b/tardis/adapters/sites/slurm.py
@@ -58,14 +58,8 @@ async def squeue(
         raise
 
     else:
-        # Not all lines returned in slurm_status.stdout belong to the actual squeue output
-        # Only keep lines containing the delimiter
-        cleaned_stdout = []
-        for row in slurm_status.stdout.splitlines():
-            if "|" in row:
-                cleaned_stdout.append(row)
         for row in csv_parser(
-            "\n".join(cleaned_stdout), fieldnames=tuple(attributes.keys()), delimiter="|"
+            slurm_status.stdout, fieldnames=tuple(attributes.keys()), delimiter="|"
         ):
             row["State"] = row["State"].strip()
             slurm_resource_status[row["JobId"]] = row

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -51,6 +51,8 @@ def csv_parser(
     if skiptrailingspace:
         input_csv = "\n".join((line.strip() for line in input_csv.splitlines()))
 
+    input_csv = "\n".join((line for line in input_csv.splitlines() if delimiter in line))
+
     replacements = replacements or {}
     with StringIO(input_csv) as csv_input:
         csv_reader = csv.DictReader(

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -51,8 +51,9 @@ def csv_parser(
     if skiptrailingspace:
         input_csv = "\n".join((line.strip() for line in input_csv.splitlines()))
 
-    if len(fieldnames)>1:
-        input_csv = "\n".join((line for line in input_csv.splitlines() if delimiter in line))
+    if len(fieldnames) > 1:
+        input_csv = "\n".join((line for line in input_csv.splitlines()
+                               if delimiter in line))
 
     replacements = replacements or {}
     with StringIO(input_csv) as csv_input:

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -51,7 +51,8 @@ def csv_parser(
     if skiptrailingspace:
         input_csv = "\n".join((line.strip() for line in input_csv.splitlines()))
 
-    input_csv = "\n".join((line for line in input_csv.splitlines() if delimiter in line))
+    if len(fieldnames)>1:
+        input_csv = "\n".join((line for line in input_csv.splitlines() if delimiter in line))
 
     replacements = replacements or {}
     with StringIO(input_csv) as csv_input:

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -52,8 +52,9 @@ def csv_parser(
         input_csv = "\n".join((line.strip() for line in input_csv.splitlines()))
 
     if len(fieldnames) > 1:
-        input_csv = "\n".join((line for line in input_csv.splitlines()
-                               if delimiter in line))
+        input_csv = "\n".join(
+            (line for line in input_csv.splitlines() if delimiter in line)
+        )
 
     replacements = replacements or {}
     with StringIO(input_csv) as csv_input:

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -165,6 +165,43 @@ class TestCSVParser(TestCase):
             ),
         )
 
+    def test_csv_parser_cleaning(self):
+        littered_input = "\n".join(
+            [
+                "Site-Admins wish you happy holidays!",
+                "5545112||PENDING",
+                "Services will be unavailable.",
+                "5545113||PENDING",
+            ]
+        )
+
+        parsed_rows = csv_parser(
+            input_csv=littered_input,
+            fieldnames=("JobId", "Host", "State"),
+            replacements=dict(undefined=None),
+            delimiter="|",
+            skipinitialspace=True,
+            skiptrailingspace=True,
+        )
+
+        self.assertEqual(
+            next(parsed_rows),
+            dict(
+                JobId="5545112",
+                Host="",
+                State="PENDING",
+            ),
+        )
+
+        self.assertEqual(
+            next(parsed_rows),
+            dict(
+                JobId="5545113",
+                Host="",
+                State="PENDING",
+            ),
+        )
+
 
 class TestDisableLogging(TestCase):
     def test_disable_logging(self):


### PR DESCRIPTION
I observed a case where the ssh-executor running the squeue command returned slurm_status.stdout containing

Switch to work directory on corresponding scratch directory.
Switch to work directory on corresponding scratch directory.
Switch to work directory on corresponding scratch directory.
5545112||PENDING

where only the last line is expected to be returned from squeue. The other lines might be some system messages (?).
This PR adds a filter that only keeps lines with "|" before feeding them into the csv-Parser.