### PR TITLE
Fix hash credentials test for new typer version

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,7 +11,9 @@ Rene Caspart <rene.caspart@cern.ch>
 Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>
 Benjamin Rottler <benjamin.rottler@cern.ch>
+Sebastian Wozniewski <sebastian.wozniewski@uni-goettingen.de>
 mschnepf <matthias.schnepf@kit.edu>
+swozniewski <sebastian.wozniewski@uni-goettingen.de>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 mschnepf <maschnepf@schnepf-net.de>
 Dirk Sammel <dirk.sammel@cern.ch>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2024-04-15, command
+.. Created by changelog.py at 2024-04-16, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2024-04-15
+[Unreleased] - 2024-04-16
 =========================
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2024-02-05, command
+.. Created by changelog.py at 2024-04-15, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2024-02-05
+[Unreleased] - 2024-04-15
 =========================
 
 Fixed

--- a/tests/rest_t/hash_credentials_t/test_hash_credentials.py
+++ b/tests/rest_t/hash_credentials_t/test_hash_credentials.py
@@ -15,7 +15,7 @@ class TestHashCredentials(TestCase):
     def test_hash_credentials(self):
         result = self.runner.invoke(self.app)
         self.assertNotEqual(result.exit_code, 0)
-        self.assertTrue("Error: Missing argument 'PASSWORD'." in result.stdout)
+        self.assertTrue("Missing argument 'PASSWORD'." in result.stdout)
 
         result = self.runner.invoke(self.app, "test_password")
         self.assertEqual(result.exit_code, 0)

--- a/tests/rest_t/hash_credentials_t/test_hash_credentials.py
+++ b/tests/rest_t/hash_credentials_t/test_hash_credentials.py
@@ -15,7 +15,7 @@ class TestHashCredentials(TestCase):
     def test_hash_credentials(self):
         result = self.runner.invoke(self.app)
         self.assertNotEqual(result.exit_code, 0)
-        self.assertTrue("Missing argument 'PASSWORD'." in result.stdout)
+        self.assertIn("Missing argument 'PASSWORD'.", result.stdout)
 
         result = self.runner.invoke(self.app, "test_password")
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Due to a new typer version one of the `hash_credentials` unittest was broken, which is fixed in this pull request.