### PR TITLE
Add MFA support for SSHExecutor

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2024-05-15, command
+.. Created by changelog.py at 2024-05-23, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2024-05-23, command
+.. Created by changelog.py at 2024-05-24, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/executors/executors.rst
+++ b/docs/source/executors/executors.rst
@@ -46,6 +46,14 @@ SSH Executor
     directly passed as keyword arguments to `asyncssh` `connect` call. You can find all available parameters in the
     `asyncssh documentation`_
 
+    Additionally the ``SSHExecutor`` supports Multi-factor Authentication (MFA). In order to activate it, you need to
+    add ``mfa_secrets`` as parameter to the ``SSHExecutor`` containing a list of command line prompt to TOTP secrets
+    mappings.
+
+    .. note::
+        The prompt can be obtained by connecting to the server via ssh in a terminal. The prompt is the text the
+        terminal is showing in order to obtain the second factor for the ssh connection. (e.g. "Enter 2FA Token:")
+
     .. _asyncssh documentation: https://asyncssh.readthedocs.io/en/latest/api.html#connect
 
 .. content-tabs:: right-col
@@ -59,6 +67,20 @@ SSH Executor
         username: clown
         client_keys:
           - /opt/tardis/ssh/tardis
+
+    .. rubric:: Example configuration (Using Multi-factor Authentication)
+
+    .. code-block:: yaml
+
+      !TardisSSHExecutor
+        host: login.dorie.somewherein.de
+        username: clown
+        client_keys:
+          - /opt/tardis/ssh/tardis
+        mfa_secrets:
+          - prompt: "Enter 2FA Token:"
+            secret: "IMIZDDO2I45ZSTR6XDGFSPFDUY"
+
 
     .. rubric:: Example configuration (`COBalD` legacy object initialisation)
 

--- a/docs/source/executors/executors.rst
+++ b/docs/source/executors/executors.rst
@@ -47,7 +47,7 @@ SSH Executor
     `asyncssh documentation`_
 
     Additionally the ``SSHExecutor`` supports Multi-factor Authentication (MFA). In order to activate it, you need to
-    add ``mfa_secrets`` as parameter to the ``SSHExecutor`` containing a list of command line prompt to TOTP secrets
+    add ``mfa_config`` as parameter to the ``SSHExecutor`` containing a list of command line prompt to TOTP secrets
     mappings.
 
     .. note::
@@ -77,9 +77,9 @@ SSH Executor
         username: clown
         client_keys:
           - /opt/tardis/ssh/tardis
-        mfa_secrets:
+        mfa_config:
           - prompt: "Enter 2FA Token:"
-            secret: "IMIZDDO2I45ZSTR6XDGFSPFDUY"
+            totp: "IMIZDDO2I45ZSTR6XDGFSPFDUY"
 
 
     .. rubric:: Example configuration (`COBalD` legacy object initialisation)

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         "typing_extensions",
         "python-auditor==0.5.0",
         "tzlocal",
+        "pyotp",
         *REST_REQUIRES,
     ],
     extras_require={

--- a/tardis/configuration/utilities.py
+++ b/tardis/configuration/utilities.py
@@ -1,17 +1,19 @@
+from cobald.daemon.plugins import YAMLTagSettings
 import yaml
 
 
 def enable_yaml_load(tag):
     def yaml_load_decorator(cls):
         def class_factory(loader, node):
+            settings = YAMLTagSettings.fetch(cls)
             new_cls = cls
             if isinstance(node, yaml.nodes.MappingNode):
-                parameters = loader.construct_mapping(node)
+                parameters = loader.construct_mapping(node, deep=settings.eager)
                 new_cls = cls(**parameters)
             elif isinstance(node, yaml.nodes.ScalarNode):
                 new_cls = cls()
             elif isinstance(node, yaml.nodes.SequenceNode):
-                parameters = loader.construct_sequence(node)
+                parameters = loader.construct_sequence(node, deep=settings.eager)
                 new_cls = cls(*parameters)
             return new_cls
 

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -92,7 +92,7 @@ class MFASSHClient(SSHClient):
 @yaml_tag(eager=True)
 class SSHExecutor(Executor):
     def __init__(self, **parameters):
-        self._parameters = dict(parameters)
+        self._parameters = parameters
         # enable Multi-factor Authentication if required
         if mfa_secrets := self._parameters.pop("mfa_secrets", None):
             self._parameters["client_factory"] = partial(

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -4,6 +4,7 @@ from ...exceptions.tardisexceptions import TardisAuthError
 from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...interfaces.executor import Executor
 from ..attributedict import AttributeDict
+from cobald.daemon.plugins import yaml_tag
 
 import asyncio
 import asyncssh
@@ -88,6 +89,7 @@ class MFASSHClient(SSHClient):
 
 
 @enable_yaml_load("!SSHExecutor")
+@yaml_tag(eager=True)
 class SSHExecutor(Executor):
     def __init__(self, **parameters):
         self._parameters = dict(parameters)

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -102,9 +102,7 @@ class TestSSHExecutor(TestCase):
             run_async(self.executor._establish_connection), MockConnection
         )
 
-        self.mock_asyncssh.connect.assert_called_with(
-            client_factory=None, **self.test_asyncssh_params
-        )
+        self.mock_asyncssh.connect.assert_called_with(**self.test_asyncssh_params)
 
         test_exceptions = [
             ConnectionResetError(),
@@ -165,10 +163,7 @@ class TestSSHExecutor(TestCase):
     def test_run_command(self):
         self.assertIsNone(run_async(self.executor.run_command, command="Test").stdout)
         self.mock_asyncssh.connect.assert_called_with(
-            client_factory=None,
-            host="test_host",
-            username="test",
-            client_keys=["TestKey"],
+            host="test_host", username="test", client_keys=["TestKey"]
         )
         self.mock_asyncssh.reset_mock()
 
@@ -228,8 +223,5 @@ class TestSSHExecutor(TestCase):
             "Test",
         )
         self.mock_asyncssh.connect.assert_called_with(
-            client_factory=None,
-            host="test_host",
-            username="test",
-            client_keys=["TestKey"],
+            host="test_host", username="test", client_keys=["TestKey"]
         )

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -102,7 +102,9 @@ class TestSSHExecutor(TestCase):
             run_async(self.executor._establish_connection), MockConnection
         )
 
-        self.mock_asyncssh.connect.assert_called_with(**self.test_asyncssh_params)
+        self.mock_asyncssh.connect.assert_called_with(
+            client_factory=None, **self.test_asyncssh_params
+        )
 
         test_exceptions = [
             ConnectionResetError(),
@@ -163,7 +165,10 @@ class TestSSHExecutor(TestCase):
     def test_run_command(self):
         self.assertIsNone(run_async(self.executor.run_command, command="Test").stdout)
         self.mock_asyncssh.connect.assert_called_with(
-            host="test_host", username="test", client_keys=["TestKey"]
+            client_factory=None,
+            host="test_host",
+            username="test",
+            client_keys=["TestKey"],
         )
         self.mock_asyncssh.reset_mock()
 
@@ -223,5 +228,8 @@ class TestSSHExecutor(TestCase):
             "Test",
         )
         self.mock_asyncssh.connect.assert_called_with(
-            host="test_host", username="test", client_keys=["TestKey"]
+            client_factory=None,
+            host="test_host",
+            username="test",
+            client_keys=["TestKey"],
         )

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -1,7 +1,12 @@
 from tests.utilities.utilities import async_return, run_async
 from tardis.utilities.attributedict import AttributeDict
-from tardis.utilities.executors.sshexecutor import SSHExecutor, probe_max_session
+from tardis.utilities.executors.sshexecutor import (
+    SSHExecutor,
+    probe_max_session,
+    MFASSHClient,
+)
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
+from tardis.exceptions.tardisexceptions import TardisAuthError
 
 from asyncssh import ChannelOpenError, ConnectionLost, DisconnectError, ProcessError
 
@@ -11,6 +16,7 @@ from unittest.mock import patch
 import asyncio
 import yaml
 import contextlib
+import logging
 from asyncstdlib import contextmanager as asynccontextmanager
 
 
@@ -65,6 +71,63 @@ class TestSSHExecutorUtilities(TestCase):
                     expected,
                     run_async(probe_max_session, MockConnection(None, expected)),
                 )
+
+
+class TestMFASSHClient(TestCase):
+    def setUp(self):
+        mfa_secrets = [
+            {
+                "prompt": "Enter MFA token:",
+                "secret": "EJL2DAWFOH7QPJ3D6I2DK2ARTBEJDBIB",
+            },
+            {
+                "prompt": "Yet another token:",
+                "secret": "D22246GDKKEDK7AAM77ZH5VRDRL7Z6W7",
+            },
+        ]
+        self.mfa_ssh_client = MFASSHClient(mfa_secrets=mfa_secrets)
+
+    def test_kbdint_auth_requested(self):
+        self.assertEqual(run_async(self.mfa_ssh_client.kbdint_auth_requested), "")
+
+    def test_kbdint_challenge_received(self):
+        def test_responses(prompts, num_of_expected_responses):
+            responses = run_async(
+                self.mfa_ssh_client.kbdint_challenge_received,
+                name="test",
+                instructions="no",
+                lang="en",
+                prompts=prompts,
+            )
+
+            self.assertEqual(len(responses), num_of_expected_responses)
+            for response in responses:
+                self.assertTrue(response.isdigit())
+
+        for prompts, num_of_expected_responses in (
+            ([("Enter MFA token:", False)], 1),
+            ([("Enter MFA token:", False), ("Yet another token: ", False)], 2),
+            ([], 0),
+        ):
+            test_responses(
+                prompts=prompts, num_of_expected_responses=num_of_expected_responses
+            )
+
+        prompts_to_fail = [("Enter MFA token:", False), ("Unknown token: ", False)]
+
+        with self.assertRaises(TardisAuthError) as tae:
+            with self.assertLogs(level=logging.ERROR):
+                run_async(
+                    self.mfa_ssh_client.kbdint_challenge_received,
+                    name="test",
+                    instructions="no",
+                    lang="en",
+                    prompts=prompts_to_fail,
+                )
+        self.assertIn(
+            "Keyboard interactive authentication failed: Unexpected Prompt",
+            str(tae.exception),
+        )
 
 
 class TestSSHExecutor(TestCase):
@@ -208,6 +271,17 @@ class TestSSHExecutor(TestCase):
             run_async(raising_executor.run_command, command="Test", stdin_input="Test")
 
     def test_construction_by_yaml(self):
+        def test_yaml_construction(test_executor, *args, **kwargs):
+            self.assertEqual(
+                run_async(
+                    test_executor.run_command, command="Test", stdin_input="Test"
+                ).stdout,
+                "Test",
+            )
+            self.mock_asyncssh.connect.assert_called_with(*args, **kwargs)
+
+            self.mock_asyncssh.reset_mock()
+
         executor = yaml.safe_load(
             """
                    !SSHExecutor
@@ -218,10 +292,30 @@ class TestSSHExecutor(TestCase):
                    """
         )
 
-        self.assertEqual(
-            run_async(executor.run_command, command="Test", stdin_input="Test").stdout,
-            "Test",
+        test_yaml_construction(
+            executor,
+            host="test_host",
+            username="test",
+            client_keys=["TestKey"],
         )
-        self.mock_asyncssh.connect.assert_called_with(
-            host="test_host", username="test", client_keys=["TestKey"]
+
+        mfa_executor = yaml.safe_load(
+            """
+                   !SSHExecutor
+                   host: test_host
+                   username: test
+                   client_keys:
+                     - TestKey
+                   mfa_secrets:
+                     - prompt: 'Token: '
+                       secret: 123TopSecret
+                   """
+        )
+
+        test_yaml_construction(
+            mfa_executor,
+            host="test_host",
+            username="test",
+            client_keys=["TestKey"],
+            client_factory=mfa_executor._parameters["client_factory"],
         )

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -75,17 +75,17 @@ class TestSSHExecutorUtilities(TestCase):
 
 class TestMFASSHClient(TestCase):
     def setUp(self):
-        mfa_secrets = [
+        mfa_config = [
             {
                 "prompt": "Enter MFA token:",
-                "secret": "EJL2DAWFOH7QPJ3D6I2DK2ARTBEJDBIB",
+                "totp": "EJL2DAWFOH7QPJ3D6I2DK2ARTBEJDBIB",
             },
             {
                 "prompt": "Yet another token:",
-                "secret": "D22246GDKKEDK7AAM77ZH5VRDRL7Z6W7",
+                "totp": "D22246GDKKEDK7AAM77ZH5VRDRL7Z6W7",
             },
         ]
-        self.mfa_ssh_client = MFASSHClient(mfa_secrets=mfa_secrets)
+        self.mfa_ssh_client = MFASSHClient(mfa_config=mfa_config)
 
     def test_kbdint_auth_requested(self):
         self.assertEqual(run_async(self.mfa_ssh_client.kbdint_auth_requested), "")
@@ -306,9 +306,9 @@ class TestSSHExecutor(TestCase):
                    username: test
                    client_keys:
                      - TestKey
-                   mfa_secrets:
+                   mfa_config:
                      - prompt: 'Token: '
-                       secret: 123TopSecret
+                       totp: 123TopSecret
                    """
         )
 


### PR DESCRIPTION
This pull request adds support for multi-factor authentication (MFA) to the `SSHExecutor` to be used with clusters enforcing MFA to access login nodes for job submission.