### PR TITLE
Fix deployment tests

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2024-10-21, command
+.. Created by changelog.py at 2024-12-18, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/tests/rest_t/routers_t/base_test_case_routers.py
+++ b/tests/rest_t/routers_t/base_test_case_routers.py
@@ -2,7 +2,7 @@ from tardis.rest.app.security import get_user
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import run_async
 
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 from unittest import TestCase
 from unittest.mock import patch
@@ -44,7 +44,9 @@ class TestCaseRouters(TestCase):
             app,
         )  # has to be imported after SqliteRegistry patch
 
-        self.client = AsyncClient(app=app, base_url="http://test")
+        self.client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
         self.test_user = {
             "user_name": "test1",
             "password": "test",


### PR DESCRIPTION
The used syntax of `AsyncClient` has been deprecated a while ago and has been removed in the latest `httpx` release. This pull request replaces `AsyncClient(app=app, ...)` by `AsyncClient(transport=ASGITransport(app=app),...)` in the unittest.

See for example: https://github.com/encode/httpx/pull/3315