### PR TITLE
Fix readthedocs documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
    os: ubuntu-22.04
    tools:


### PR DESCRIPTION
According to https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/ readthedocs now requires to configure the sphinx configuration inside `.readthedocs.yml`.

```yaml
sphinx:
  configuration: docs/source/conf.py
```