### PR TITLE
Add status and terminate command line options to SLURM adapter

### DIFF
--- a/docs/source/adapters/site.rst
+++ b/docs/source/adapters/site.rst
@@ -516,17 +516,21 @@ Available machine type configuration options
 
 .. content-tabs:: left-col
 
-    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
-    | Option         | Short Description                                                                                | Requirement     |
-    +================+==================================================================================================+=================+
-    | Walltime       | Expected walltime of drone                                                                       |  **Required**   |
-    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
-    | Partition      | Name of the Slurm partition to run in                                                            |  **Required**   |
-    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
-    | StartupCommand | The command to execute at job start                                                              |  **Required**   |
-    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
-    | SubmitOptions  | Options to add to the `sbatch` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
-    +----------------+--------------------------------------------------------------------------------------------------+-----------------+
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | Option           | Short Description                                                                                 | Requirement     |
+    +==================+===================================================================================================+=================+
+    | Walltime         | Expected walltime of drone                                                                        |  **Required**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | Partition        | Name of the Slurm partition to run in                                                             |  **Required**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | StartupCommand   | The command to execute at job start                                                               |  **Required**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | SubmitOptions    | Options to add to the `sbatch` command. `long` and `short` arguments are supported (see example)  |  **Optional**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | StatusOptions    | Options to add to the `squeue` command. `long` and `short` arguments are supported (see example)  |  **Optional**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
+    | TerminateOptions | Options to add to the `scancel` command. `long` and `short` arguments are supported (see example) |  **Optional**   |
+    +------------------+---------------------------------------------------------------------------------------------------+-----------------+
 
 .. content-tabs:: right-col
 
@@ -569,6 +573,16 @@ Available machine type configuration options
               Walltime: '720'
               Partition: normal
               StartupCommand: 'pilot_clean.sh'
+              StatusOptions:
+                long:
+                  cluster: "cm4"
+                short:
+                  p: "cm4_tiny"
+              TerminateOptions:
+                long:
+                  cluster: "cm4"
+                short:
+                  p: "cm4_tiny"
           MachineMetaData:
             one_day:
               Cores: 20

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Added
 -----
 
 * Add support for Python 3.12
+* Add status and terminate command line options to SLURM adapter
 
 Fixed
 -----

--- a/docs/source/changes/365.adding_status_terminate_cmd_options_slurm.yaml
+++ b/docs/source/changes/365.adding_status_terminate_cmd_options_slurm.yaml
@@ -1,0 +1,9 @@
+category: added
+summary: "Add status and terminate command line options to SLURM adapter"
+description: |
+  Depending on the setup of the SLURM clusters, some might need to also add specific command line options to the 
+  `squeue` and `scancel` in order to work correctly. For example: `squeue -M cm4 -p cm4_tiny`. Therefore, a general
+  approach has been implemented to allow for using arbitary command line options for the status update and termination 
+  of jobs.
+pull requests:
+- 365


### PR DESCRIPTION
For the integration of the CoolMuc-4 cluster at LRZ, additional command line options for `squeue` and `scancel` are necessary, since the options `-M cm4 -p cm4_tiny` are necessary due to the setup of the SLURM batch system. 

For example:

```bash
squeue -M cm4 -p cm4_tiny
```

This pull request implements a general approach to allow for using arbitary command line options for the status update and termination of jobs.