### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -56,13 +56,13 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
-      - name: Add Python 3.11 to GITHUB_PATH
-        run: echo "/Library/Frameworks/Python.framework/Versions/3.11/bin" >> $GITHUB_PATH
+      - name: Add Python 3.12 to GITHUB_PATH
+        run: echo "/Library/Frameworks/Python.framework/Versions/3.12/bin" >> $GITHUB_PATH
       - name: Install dependencies on ${{ matrix.platform }}
         run: |
-          python3.11 -m pip install --upgrade pip
-          python3.11 -m pip install .[contrib]
-          python3.11 -m pip install coverage codecov
+          python3.12 -m pip install --upgrade pip
+          python3.12 -m pip install .[contrib]
+          python3.12 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
           coverage run -m unittest -v

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,18 @@
-.. Created by changelog.py at 2025-03-25, command
+.. Created by changelog.py at 2025-03-26, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########
 CHANGELOG
 #########
+
+[Unreleased] - 2025-03-26
+=========================
+
+Added
+-----
+
+* Add support for Python 3.12
 
 [0.8.4] - 2025-03-17
 ====================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
-.. Created by changelog.py at 2025-03-18, command
-   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.13/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2025-03-25, command
+   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/docs/source/changes/366.add_support_for_python3_12.yaml
+++ b/docs/source/changes/366.add_support_for_python3_12.yaml
@@ -1,0 +1,6 @@
+category: added
+summary: "Add support for Python 3.12"
+description: |
+  TARDIS including tests is now working with Pythin 3.12
+pull requests:
+- 366

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={
         "console_scripts": [

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -295,7 +295,7 @@ class TestSlurmAdapter(TestCase):
             )
             self.assertEqual(returned_resource_attributes.resource_status, value)
 
-            self.mock_executor.return_value.run_command.called_once()
+            self.assertTrue(self.mock_executor.return_value.run_command.called)
 
             self.mock_executor.return_value.run_command.assert_called_with(
                 f'squeue -o "%A|%N|%T" -h -t all --job={job_id}'

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -103,11 +103,11 @@ class TestPoolFactory(TestCase):
             ],
         )
 
-        mock_weighted_composite.has_calls(
+        mock_weighted_composite.assert_has_calls(
             [
+                call(mock_logger(), weight="utilisation"),
                 call(mock_standardiser(), weight="utilisation"),
-                call(mock_weighted_composite(), weight="utilisation"),
-            ]
+            ],
         )
 
     @patch("tardis.resources.poolfactory.Drone")


### PR DESCRIPTION
TARDIS and tests is working with Python 3.12 as well.