### PR TITLE
Fix race conditions when establishing SSH connections

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,6 +13,7 @@ R. Florian von Cube <florian.voncube@gmail.com>
 Benjamin Rottler <benjamin.rottler@cern.ch>
 Sebastian Wozniewski <sebastian.wozniewski@uni-goettingen.de>
 mschnepf <matthias.schnepf@kit.edu>
+Max Kühn <maxfischer2781@gmail.com>
 swozniewski <sebastian.wozniewski@uni-goettingen.de>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 Dirk Sammel <dirk.sammel@cern.ch>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2025-04-08, command
+.. Created by changelog.py at 2025-04-16, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2025-04-08
+[Unreleased] - 2025-04-16
 =========================
 
 Added

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -119,7 +119,7 @@ class SSHExecutor(Executor):
         self,
         ssh_connection: asyncssh.SSHClientConnection,
         command: str,
-        chained_exception: Exception = None,
+        chained_exception: "Exception | None" = None,
     ):
         # clear broken connection to get it replaced
         # by a new connection during next command

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -146,9 +146,12 @@ class SSHExecutor(Executor):
             async with self.lock:
                 # check that connection has not been initialized in a different task
                 while self._ssh_connection is None:
-                    self._ssh_connection = await self._establish_connection()
-                    max_session = await probe_max_session(self._ssh_connection)
-                    self._session_bound = asyncio.Semaphore(value=max_session)
+                    connection = await self._establish_connection()
+                    max_session = await probe_max_session(connection)
+                    self._ssh_connection, self._session_bound = (
+                        connection,
+                        asyncio.Semaphore(value=max_session),
+                    )
         assert self._ssh_connection is not None
         assert self._session_bound is not None
         bound, session = self._session_bound, self._ssh_connection

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, NamedTuple
 from ...configuration.utilities import enable_yaml_load
 from ...exceptions.tardisexceptions import TardisAuthError
 from ...exceptions.executorexceptions import CommandExecutionFailure
@@ -86,6 +86,15 @@ class MFASSHClient(SSHClient):
             raise TardisAuthError(msg) from ke
 
 
+class ConnectionState(NamedTuple):
+    """State associated with an active SSH connection"""
+
+    #: the SSH connection itself
+    connection: asyncssh.SSHClientConnection
+    #: bound on concurrent sessions over the connection
+    bound: asyncio.Semaphore
+
+
 @enable_yaml_load("!SSHExecutor")
 @yaml_tag(eager=True)
 class SSHExecutor(Executor):
@@ -96,10 +105,8 @@ class SSHExecutor(Executor):
             self._parameters["client_factory"] = partial(
                 MFASSHClient, mfa_config=mfa_config
             )
-        # the current SSH connection and bound unless it must be (re-)established
-        self._ssh_connection: (
-            "tuple[asyncssh.SSHClientConnection, asyncio.Semaphore] | None"
-        ) = None
+        # the current SSH connection unless it must be (re-)established
+        self._connection_state: "ConnectionState | None" = None
         self._lock = None
 
     async def _establish_connection(self):
@@ -124,10 +131,10 @@ class SSHExecutor(Executor):
         # clear broken connection to get it replaced
         # by a new connection during next command
         if (
-            self._ssh_connection is not None
-            and ssh_connection is self._ssh_connection[0]
+            self._connection_state is not None
+            and ssh_connection is self._connection_state.connection
         ):
-            self._ssh_connection = None
+            self._connection_state = None
         raise CommandExecutionFailure(
             message=(f"Could not run command {command} due to a connection loss!"),
             exit_code=255,
@@ -145,18 +152,17 @@ class SSHExecutor(Executor):
         :py:class:`~asyncssh.SSHClientConnection`
         so that only `MaxSessions` commands run at once.
         """
-        if self._ssh_connection is None:
+        if self._connection_state is None:
             async with self.lock:
                 # check that connection has not been initialized in a different task
-                while self._ssh_connection is None:
+                while self._connection_state is None:
                     connection = await self._establish_connection()
                     max_session = await probe_max_session(connection)
-                    self._ssh_connection = (
-                        connection,
-                        asyncio.Semaphore(value=max_session),
+                    self._connection_state = ConnectionState(
+                        connection, asyncio.Semaphore(value=max_session)
                     )
-        assert self._ssh_connection is not None
-        session, bound = self._ssh_connection
+        assert self._connection_state is not None
+        session, bound = self._connection_state
         async with bound:
             yield session
 

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -205,6 +205,35 @@ class TestSSHExecutor(TestCase):
         # make sure the connection is not needlessly replaced
         self.assertEqual(self.executor._ssh_connection, current_ssh_connection)
 
+    def test_connection_race(self):
+        # see https://github.com/MatterMiners/tardis/issues/369
+        waiter = asyncio.Event()
+
+        async def mocked_probe_max_session(connection):
+            await waiter.wait()
+            return 10
+
+        async def run_bounded_connection():
+            async with self.executor.bounded_connection as connection:
+                return connection
+
+        async def run_race_condition():
+            first_connection = asyncio.ensure_future(run_bounded_connection())
+            await asyncio.sleep(0.1)  # give some time to hit the waiter
+            self.assertIsNone(self.executor._ssh_connection)
+            second_connection = asyncio.ensure_future(run_bounded_connection())
+            await asyncio.sleep(0.1)  # give some time to schedule the second tasks
+            waiter.set()
+            # check that no new connection is established
+            self.assertEqual(await first_connection, await second_connection)
+
+        # monkey patch prob session
+        with patch(
+            "tardis.utilities.executors.sshexecutor.probe_max_session",
+            mocked_probe_max_session,
+        ):
+            run_async(run_race_condition)
+
     def test_lock(self):
         self.assertIsInstance(self.executor.lock, asyncio.Lock)
 

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -199,7 +199,7 @@ class TestSSHExecutor(TestCase):
 
         self.assertIsNone(self.executor._ssh_connection)
         run_async(force_connection)
-        self.assertIsInstance(self.executor._ssh_connection, MockConnection)
+        self.assertIsInstance(self.executor._ssh_connection[0], MockConnection)
         current_ssh_connection = self.executor._ssh_connection
         run_async(force_connection)
         # make sure the connection is not needlessly replaced


### PR DESCRIPTION
This PR addresses two race conditions around SSH connections. Major changes include:

- The state of bound and connection is now handled as a single entity.

This fixes using an SSH connection before any bound has been created (#369) as well as using a bound of a previous connection. Closes #370.