### PR TITLE
Update unittest and deployment to upstream code changes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
-.. Created by changelog.py at 2025-04-28, command
-   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
+.. Created by changelog.py at 2025-07-08, command
+   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.13/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/tardis/rest/app/routers/resources.py
+++ b/tardis/rest/app/routers/resources.py
@@ -9,7 +9,7 @@ router = APIRouter(prefix="/resources", tags=["resources"])
 
 @router.get("/{drone_uuid}/state", description="Get current state of a resource")
 async def get_resource_state(
-    drone_uuid: str = Path(..., regex=r"^\S+-[A-Fa-f0-9]{10}$"),
+    drone_uuid: str = Path(..., pattern=r"^\S+-[A-Fa-f0-9]{10}$"),
     sql_registry: SqliteRegistry = Depends(database.get_sql_registry()),
     _: AuthJWT = Security(security.check_authorization, scopes=[Resources.get]),
 ):
@@ -34,7 +34,7 @@ async def get_resources(
 
 @router.patch("/{drone_uuid}/drain", description="Gently shut shown drone")
 async def drain_drone(
-    drone_uuid: str = Path(..., regex=r"^\S+-[A-Fa-f0-9]{10}$"),
+    drone_uuid: str = Path(..., pattern=r"^\S+-[A-Fa-f0-9]{10}$"),
     sql_registry: SqliteRegistry = Depends(database.get_sql_registry()),
     _: AuthJWT = Security(security.check_authorization, scopes=[Resources.patch]),
 ):

--- a/tests/rest_t/hash_credentials_t/test_hash_credentials.py
+++ b/tests/rest_t/hash_credentials_t/test_hash_credentials.py
@@ -15,7 +15,7 @@ class TestHashCredentials(TestCase):
     def test_hash_credentials(self):
         result = self.runner.invoke(self.app)
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Missing argument 'PASSWORD'.", result.stdout)
+        self.assertIn("Missing argument 'PASSWORD'.", result.stderr)
 
         result = self.runner.invoke(self.app, "test_password")
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
This pull request updates the unittests and deployment tests to upstream code changes

- [ ] The click package now captures `stderr`separately, so that errors appear in the `stderr` stream
- [ ] FastApi has deprecated to use of the `regex` parameter, which is now called `pattern`