### PR TITLE
Deprecate Ubuntu 20.04 and Python 3.8

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -49,9 +49,11 @@ jobs:
           python3 -m pip install .[contrib]
           python3 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.os_container }}
+        shell: bash
+        env:
+          LANG: en_US.utf8
         run: |
-          export LANG=en_US.utf8
-          export PATH=$PATH:test_env/bin
+          source test_env/bin/activate
           coverage run -m unittest -v
   deployment-macos:
     strategy:
@@ -71,6 +73,7 @@ jobs:
           python3.12 -m pip install .[contrib]
           python3.12 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
+        shell: bash
         run: |
-          export PATH=$PATH:test_env/bin
+          source test_env/bin/activate
           coverage run -m unittest -v

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
+        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu22_04', 'ubuntu24_04']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu20_04', 'ubuntu22_04']
+        os_container: ['rockylinux8', 'rockylinux9', 'ubuntu22_04', 'ubuntu24_04']
     container: matterminers/cobald-tardis-deployment-test-env:${{ matrix.os_container }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -41,13 +41,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies on ${{ matrix.os_container }}
+        shell: bash
         run: |
+          python3 -m venv test_env
+          source test_env/bin/activate
           python3 -m pip install --upgrade pip
           python3 -m pip install .[contrib]
           python3 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.os_container }}
         run: |
           export LANG=en_US.utf8
+          export PATH=$PATH:test_env/bin
           coverage run -m unittest -v
   deployment-macos:
     strategy:
@@ -59,10 +63,14 @@ jobs:
       - name: Add Python 3.12 to GITHUB_PATH
         run: echo "/Library/Frameworks/Python.framework/Versions/3.12/bin" >> $GITHUB_PATH
       - name: Install dependencies on ${{ matrix.platform }}
+        shell: bash
         run: |
+          python3.12 -m venv test_env
+          source test_env/bin/activate
           python3.12 -m pip install --upgrade pip
           python3.12 -m pip install .[contrib]
           python3.12 -m pip install coverage codecov
       - name: Test with unittest on ${{ matrix.platform }}
         run: |
+          export PATH=$PATH:test_env/bin
           coverage run -m unittest -v

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu22_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu22_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip language-pack-en git\
+    python3 python3-pip python3-venv language-pack-en git\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu24_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu24_04
@@ -4,7 +4,7 @@ LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y gcc g++ make curl dirmngr \
     apt-transport-https lsb-release ca-certificates \
-    python3 python3-pip language-pack-en git\
+    python3 python3-pip python3-venv language-pack-en git\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu24_04
+++ b/containers/cobald-tardis-deployment-test-env/Dockerfile.ubuntu24_04
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 LABEL maintainer="Manuel Giffels <giffels@gmail.com>"
 
 RUN apt-get update && apt-get upgrade -y \

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,5 @@
 .. Created by changelog.py at 2025-07-08, command
-   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.13/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
+   '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
 #########

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2025-07-08, command
+.. Created by changelog.py at 2025-07-09, command
    '/Users/giffler/.cache/pre-commit/repoecmh3ah8/py_env-python3.12/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "Topic :: Utilities",
         "Framework :: AsyncIO",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- [x] Python 3.8 has been removed from uniitests and supported Python versions
- [x] Deployment tests are now executed within a dedicated venv, since Ubuntu 24.04 uses `externally-managed-environment` (PEP 668)
- [x] Ubuntu 20.04 has been removed from deployment tests, since it is EOL
- [x] Ubuntu 24.04 has been added to the deployment tests