### PR TITLE
SSH Executor Retries

### DIFF
--- a/docs/source/executors/executors.rst
+++ b/docs/source/executors/executors.rst
@@ -47,7 +47,7 @@ SSH Executor
     `asyncssh documentation`_
 
     To handle unreliable connections, the ``SSHExecutor`` defaults to retrying commands failed due to lost connections.
-    Use the parameter ``on_disconnect_retry`` to enable/disable this (``True`` / ``False``) or set an integer count
+    Use the parameter ``on_disconnect_retry`` to enable/disable this (``true`` / ``false``) or set an integer count
     how often each failed command may be retried.
 
     Additionally the ``SSHExecutor`` supports Multi-factor Authentication (MFA). In order to activate it, you need to

--- a/docs/source/executors/executors.rst
+++ b/docs/source/executors/executors.rst
@@ -42,9 +42,13 @@ SSH Executor
 .. content-tabs:: left-col
 
     The ssh executor is used to asynchronously execute shell commands remotely via ssh. The actual ssh connection to
-    the host is preserved, recycled and automatically reestablished. All parameters specified in the configuration are
+    the host is preserved, recycled and automatically reestablished. Most parameters specified in the configuration are
     directly passed as keyword arguments to `asyncssh` `connect` call. You can find all available parameters in the
     `asyncssh documentation`_
+
+    To handle unreliable connections, the ``SSHExecutor`` defaults to retrying commands failed due to lost connections.
+    Use the parameter ``on_disconnect_retry`` to enable/disable this (``True`` / ``False``) or set an integer count
+    how often each failed command may be retried.
 
     Additionally the ``SSHExecutor`` supports Multi-factor Authentication (MFA). In order to activate it, you need to
     add ``mfa_config`` as parameter to the ``SSHExecutor`` containing a list of command line prompt to TOTP secrets
@@ -67,6 +71,7 @@ SSH Executor
         username: clown
         client_keys:
           - /opt/tardis/ssh/tardis
+        on_disconnect_retry: true
 
     .. rubric:: Example configuration (Using Multi-factor Authentication)
 

--- a/tardis/exceptions/executorexceptions.py
+++ b/tardis/exceptions/executorexceptions.py
@@ -4,10 +4,10 @@ class CommandExecutionFailure(Exception):
     def __init__(
         self,
         message: str,
-        exit_code: int = None,
-        stdout: str = None,
-        stderr: str = None,
-        stdin: str = None,
+        exit_code: int,
+        stdout: str,
+        stderr: str,
+        stdin: "str | None" = None,
     ):
         self.message = message
         self.exit_code = exit_code

--- a/tardis/exceptions/executorexceptions.py
+++ b/tardis/exceptions/executorexceptions.py
@@ -4,7 +4,7 @@ class CommandExecutionFailure(Exception):
     def __init__(
         self,
         message: str,
-        exit_code: int,
+        exit_code: "int | None",
         stdout: str,
         stderr: str,
         stdin: "str | None" = None,

--- a/tardis/exceptions/executorexceptions.py
+++ b/tardis/exceptions/executorexceptions.py
@@ -1,4 +1,6 @@
 class CommandExecutionFailure(Exception):
+    """A command run by an executor failed"""
+
     def __init__(
         self,
         message: str,
@@ -18,3 +20,16 @@ class CommandExecutionFailure(Exception):
             f"(message={self.message}, exit_code={self.exit_code}, "
             f"stdout={self.stdout}, stderr={self.stderr}, stdin={self.stdin})"
         )
+
+
+class ExecutorFailure(Exception):
+    """An executor itself failed when running a command"""
+
+    def __init__(
+        self,
+        description: str,
+        executor: object,
+    ) -> None:
+        super().__init__(description)
+        self.description = description
+        self.executor = executor

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -1,7 +1,7 @@
 from typing import Optional, NamedTuple
 from ...configuration.utilities import enable_yaml_load
 from ...exceptions.tardisexceptions import TardisAuthError
-from ...exceptions.executorexceptions import CommandExecutionFailure
+from ...exceptions.executorexceptions import CommandExecutionFailure, ExecutorFailure
 from ...interfaces.executor import Executor
 from ..attributedict import AttributeDict
 from cobald.daemon.plugins import yaml_tag
@@ -135,11 +135,9 @@ class SSHExecutor(Executor):
             and ssh_connection is self._connection_state.connection
         ):
             self._connection_state = None
-        raise CommandExecutionFailure(
-            message=(f"Could not run command {command} due to a connection loss!"),
-            exit_code=255,
-            stdout="",
-            stderr="SSH connection lost",
+        raise ExecutorFailure(
+            description="SSH connection lost",
+            executor=self,
         ) from chained_exception
 
     @property

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -129,7 +129,7 @@ class SSHExecutor(Executor):
         self._lock = None
 
     async def _establish_connection(self):
-        for retry in range(1, 10):
+        for retry in range(0, 9):
             try:
                 return await asyncssh.connect(**self._parameters)
             except (
@@ -138,7 +138,7 @@ class SSHExecutor(Executor):
                 asyncssh.ConnectionLost,
                 BrokenPipeError,
             ):
-                await asyncio.sleep(retry * 10)
+                await asyncio.sleep(2**retry)
         return await asyncssh.connect(**self._parameters)
 
     def _handle_broken_ssh_connection(

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -98,6 +98,22 @@ class ConnectionState(NamedTuple):
 @enable_yaml_load("!SSHExecutor")
 @yaml_tag(eager=True)
 class SSHExecutor(Executor):
+    """
+    Execute shell commands via an SSH connection
+
+    This class provides several convenience features over a raw SSH connection:
+
+    - Establishing a connection includes retries for temporary unavailability
+    - An established connection is multiplexed for concurrent commands
+    - Executing commands are used as feedback on the connection state
+    - On connection failure both connection and commands are automatically retried
+
+    Notably, these features work in accord:
+    Once a single command fails due to a broken connection,
+    multiplexing means all commands are queued until the connection is reestablished.
+    Retrying failed commands efficiently waits for the single connection to be retried.
+    """
+
     def __init__(self, **parameters):
         self._parameters = parameters
         # enable Multi-factor Authentication if required

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -129,7 +129,7 @@ class SSHExecutor(Executor):
         self._lock = None
 
     async def _establish_connection(self):
-        for retry in range(0, 9):
+        for retry in range(9):
             try:
                 return await asyncssh.connect(**self._parameters)
             except (

--- a/tardis/utilities/executors/sshexecutor.py
+++ b/tardis/utilities/executors/sshexecutor.py
@@ -125,7 +125,6 @@ class SSHExecutor(Executor):
     def _handle_broken_ssh_connection(
         self,
         ssh_connection: asyncssh.SSHClientConnection,
-        command: str,
         chained_exception: "Exception | None" = None,
     ):
         # clear broken connection to get it replaced
@@ -189,14 +188,14 @@ class SSHExecutor(Executor):
                 ) from pe
             except asyncssh.ChannelOpenError as coe:
                 self._handle_broken_ssh_connection(
-                    ssh_connection, command, chained_exception=coe
+                    ssh_connection, chained_exception=coe
                 )
             else:
                 # In case asyncssh loses the connection while running a command, the
                 # connection loss seems to be silently ignored, however the
                 # exit_status is None in that case.
                 if response.exit_status is None:
-                    self._handle_broken_ssh_connection(ssh_connection, command)
+                    self._handle_broken_ssh_connection(ssh_connection)
                 return AttributeDict(
                     stdout=response.stdout,
                     stderr=response.stderr,

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -108,7 +108,10 @@ class TestHTCondorAdapter(TestCase):
         )
         self.mock_executor.return_value.run_command.side_effect = (
             CommandExecutionFailure(
-                message="Does not exists", exit_code=1, stderr="Does not exists"
+                message="Does not exists",
+                exit_code=1,
+                stderr="Does not exists",
+                stdout="Does not exists",
             )
         )
         with self.assertLogs(level=logging.WARNING):
@@ -118,7 +121,10 @@ class TestHTCondorAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.side_effect = (
             CommandExecutionFailure(
-                message="Unhandled error", exit_code=2, stderr="Unhandled error"
+                message="Unhandled error",
+                exit_code=2,
+                stderr="Unhandled error",
+                stdout="Unhandled error",
             )
         )
 
@@ -257,7 +263,9 @@ class TestHTCondorAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.mock_executor.return_value.run_command.side_effect = (
-            CommandExecutionFailure(message="Test", exit_code=123, stderr="Test")
+            CommandExecutionFailure(
+                message="Test", exit_code=123, stderr="Test", stdout="Test"
+            )
         )
 
         attributes = {

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -178,7 +178,9 @@ class TestSlurmAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.mock_executor.return_value.run_command.side_effect = (
-            CommandExecutionFailure(message="Test", exit_code=123, stderr="Test")
+            CommandExecutionFailure(
+                message="Test", exit_code=123, stderr="Test", stdout="Test"
+            )
         )
 
         attributes = {

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -31,10 +31,10 @@ class MockConnection(object):
     def __init__(
         self,
         exception: "BaseException | None" = None,
-        __max_sessions=DEFAULT_MAX_SESSIONS,
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
     ):
         self.exception = exception
-        self.max_sessions = __max_sessions
+        self.max_sessions = max_sessions
         self.current_sessions = 0
 
     @contextlib.contextmanager
@@ -83,7 +83,7 @@ class TestSSHExecutorUtilities(TestCase):
             with self.subTest(sessions=expected):
                 self.assertEqual(
                     expected,
-                    run_async(probe_max_session, MockConnection(None, expected)),
+                    run_async(probe_max_session, MockConnection(max_sessions=expected)),
                 )
 
 

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -28,8 +28,12 @@ DEFAULT_MAX_SESSIONS = 10
 
 
 class MockConnection(object):
-    def __init__(self, exception=None, __max_sessions=DEFAULT_MAX_SESSIONS, **kwargs):
-        self.exception = exception and exception(**kwargs)
+    def __init__(
+        self,
+        exception: "BaseException | None" = None,
+        __max_sessions=DEFAULT_MAX_SESSIONS,
+    ):
+        self.exception = exception
         self.max_sessions = __max_sessions
         self.current_sessions = 0
 
@@ -292,15 +296,16 @@ class TestSSHExecutor(TestCase):
 
         self.mock_asyncssh.connect.return_value = async_return(
             return_value=MockConnection(
-                exception=ProcessError,
-                env="Test",
-                command="Test",
-                subsystem="Test",
-                exit_status=1,
-                exit_signal=None,
-                returncode=1,
-                stdout="TestError",
-                stderr="TestError",
+                exception=ProcessError(
+                    env="Test",
+                    command="Test",
+                    subsystem="Test",
+                    exit_status=1,
+                    exit_signal=None,
+                    returncode=1,
+                    stdout="TestError",
+                    stderr="TestError",
+                )
             )
         )
 
@@ -311,7 +316,7 @@ class TestSSHExecutor(TestCase):
 
         self.mock_asyncssh.connect.return_value = async_return(
             return_value=MockConnection(
-                exception=ChannelOpenError, reason="test_reason", code=255
+                exception=ChannelOpenError(reason="test_reason", code=255)
             )
         )
 

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -34,6 +34,7 @@ class MockConnection(object):
         max_sessions: int = DEFAULT_MAX_SESSIONS,
     ):
         self.exception = exception
+        # simulate limited multiplex sessions
         self.max_sessions = max_sessions
         self.current_sessions = 0
 


### PR DESCRIPTION
This PR improves the handling of SSH connection losses. Major changes include:

- [x] Configurable retries for commands failed due to connection loss
- [x] More responsive delays when (re)creating connection
  - Now uses exponential (1, 2, 4, …) instead of linear (10, 20, 30, …) delay. The retry count is the same, and the overall delay comparable (511s instead of 450s)

Closes #372.