### PR TITLE
Resolve sqlite3 datetime deprecation and maintain legacy compatibility

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,3 @@
-
 .. Created by changelog.py at 2026-05-13, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,14 @@
 CHANGELOG
 #########
 
+[Unreleased] - 2026-05-13
+=========================
+
+Fixed
+-----
+
+* Resolved `sqlite3` datetime deprecation and maintained legacy string formatting
+
 [0.9.0] - 2026-01-29
 ====================
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,5 @@
-.. Created by changelog.py at 2026-02-06, command
+
+.. Created by changelog.py at 2026-05-13, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2026-05-13, command
+.. Created by changelog.py at 2026-05-28, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2026-05-13
+[Unreleased] - 2026-05-28
 =========================
 
 Fixed

--- a/docs/source/changes/395-fix_sqlite_deprecation_automatic_datetime_conversion.yaml
+++ b/docs/source/changes/395-fix_sqlite_deprecation_automatic_datetime_conversion.yaml
@@ -1,0 +1,9 @@
+category: fixed
+summary: "Resolved `sqlite3` datetime deprecation and maintained legacy string formatting"
+description: |
+  Replaced the deprecated default `sqlite3` datetime adapters with explicit registration functions
+  compatible with Python 3.12+. The implementation uses a space separator in ISO strings to
+  ensure backward compatibility with existing database records and consistency with legacy
+  unit test assertions.
+pull requests:
+  - 395

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -26,12 +26,12 @@ def adapt_datetime(value: datetime):
     )  # space separator to mimic the sqlite legacy behavior
 
 
-def convert_datetime(value: str):
+def convert_datetime(value: bytes):
     """How to convert SQLite format -> datetime"""
     return datetime.fromisoformat(value.decode())
 
 
-sqlite3.register_adapter(datetime, adapt_datetime_iso)  # pragma: no cover
+sqlite3.register_adapter(datetime, adapt_datetime)  # pragma: no cover
 sqlite3.register_converter("timestamp", convert_datetime)  # pragma: no cover
 
 

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -19,15 +19,15 @@ logger = logging.getLogger("cobald.runtime.tardis.plugins.sqliteregistry")
 # datetime objects to and from SQLite format.
 
 
-# Convert datetime -> SQLite format
-def adapt_datetime_iso(value):
+def adapt_datetime(value: datetime):
+    """Convert datetime -> SQLite format"""
     return value.isoformat(
         sep=" "
     )  # space separator to mimic the sqlite legacy behavior
 
 
-# How to convert SQLite format -> datetime
-def convert_datetime(value):
+def convert_datetime(value: str):
+    """How to convert SQLite format -> datetime"""
     return datetime.fromisoformat(value.decode())
 
 

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -5,12 +5,34 @@ from ..interfaces.state import State
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from datetime import datetime
 from typing import List, Dict, Generator
 import asyncio
 import logging
 import sqlite3
 
 logger = logging.getLogger("cobald.runtime.tardis.plugins.sqliteregistry")
+
+
+# The sqlite3 module is moving away from automatically converting datetime objects
+# in versions 3.12 and beyond. So we need to explicitly register how to convert
+# datetime objects to and from SQLite format.
+
+
+# Convert datetime -> SQLite format
+def adapt_datetime_iso(value):
+    return value.isoformat(
+        sep=" "
+    )  # space separator to mimic the sqlite legacy behavior
+
+
+# How to convert SQLite format -> datetime
+def convert_datetime(value):
+    return datetime.fromisoformat(value.decode())
+
+
+sqlite3.register_adapter(datetime, adapt_datetime_iso)
+sqlite3.register_converter("timestamp", convert_datetime)
 
 
 class SqliteRegistry(Plugin):

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -31,8 +31,8 @@ def convert_datetime(value):
     return datetime.fromisoformat(value.decode())
 
 
-sqlite3.register_adapter(datetime, adapt_datetime_iso)
-sqlite3.register_converter("timestamp", convert_datetime)
+sqlite3.register_adapter(datetime, adapt_datetime_iso)  # pragma: no cover
+sqlite3.register_converter("timestamp", convert_datetime)  # pragma: no cover
 
 
 class SqliteRegistry(Plugin):

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -3,7 +3,11 @@ import logging
 from tardis.resources.dronestates import BootingState
 from tardis.resources.dronestates import RequestState, DownState
 from tardis.interfaces.state import State
-from tardis.plugins.sqliteregistry import SqliteRegistry
+from tardis.plugins.sqliteregistry import (
+    SqliteRegistry,
+    adapt_datetime_iso,
+    convert_datetime,
+)
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import run_async
 
@@ -100,6 +104,23 @@ class TestSqliteRegistry(TestCase):
             cursor.execute(sql_query)
 
             return cursor.fetchall()
+
+    def test_datetime_adapter_and_converter(self):
+        """
+        Tests that datetime objects are correctly adapted to strings (with space)
+        and converted back to datetime objects
+        """
+        test_dt = datetime.datetime(2023, 5, 13, 12, 30, 45)
+
+        # Test Adapter (Writing)
+        adapted_value = adapt_datetime_iso(test_dt)
+        self.assertEqual(adapted_value, "2023-05-13 12:30:45")
+
+        # 2. Test Converter (Reading)
+        encoded_value = b"2023-05-13 12:30:45"
+        converted_value = convert_datetime(encoded_value)
+        self.assertEqual(converted_value, test_dt)
+        self.assertIsInstance(converted_value, datetime.datetime)
 
     def test_add_machine_types(self):
         test_site_names = (self.test_site_name, self.other_test_site_name)

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -5,7 +5,7 @@ from tardis.resources.dronestates import RequestState, DownState
 from tardis.interfaces.state import State
 from tardis.plugins.sqliteregistry import (
     SqliteRegistry,
-    adapt_datetime_iso,
+    adapt_datetime,
     convert_datetime,
 )
 from tardis.utilities.attributedict import AttributeDict
@@ -113,7 +113,7 @@ class TestSqliteRegistry(TestCase):
         test_dt = datetime.datetime(2023, 5, 13, 12, 30, 45)
 
         # Test Adapter (Writing)
-        adapted_value = adapt_datetime_iso(test_dt)
+        adapted_value = adapt_datetime(test_dt)
         self.assertEqual(adapted_value, "2023-05-13 12:30:45")
 
         # 2. Test Converter (Reading)


### PR DESCRIPTION
This PR addresses the `DeprecationWarning` introduced in Python 3.12 regarding the default `datetime` adapter in the `sqlite3` module.

Since Python is moving away from built-in magic type conversion, explicit adapters and converters needs to be registered in the `sqlite3` module. 

- [x]  Registered `sqlite3.register_adapter` for `datetime.datetime` objects
- [x] Registered `sqlite3.register_converter` to handle "timestamp" types when reading from the DB.
- [x] Ensured legacy compatibility by forcing `isoformat(sep=' ')` in the adapter. This prevents the default "T" separator  (YYYY-MM-DDTHH:MM:SS) from breaking string-based comparisons and unit tests that expect the legacy space separator (YYYY-MM-DD HH:MM:SS).