### PR TITLE
Refactor unittests

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,8 +6,8 @@ Stefan Kroboth <stefan.kroboth@gmail.com>
 Alexander Haas <mail@haas-alexander.com>
 Eileen Kuehn <eileen.kuehn@kit.edu>
 matthias.schnepf <matthias.schnepf@kit.edu>
-ubdsv <ubdsv@student.kit.edu>
 Max Kühn <maxfischer2781@gmail.com>
+ubdsv <ubdsv@student.kit.edu>
 Rene Caspart <rene.caspart@cern.ch>
 Leon Schuhmacher <ji7635@partner.kit.edu>
 R. Florian von Cube <florian.voncube@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ mschnepf <matthias.schnepf@kit.edu>
 swozniewski <sebastian.wozniewski@uni-goettingen.de>
 Alexander Haas <104835302+haasal@users.noreply.github.com>
 Dirk Sammel <dirk.sammel@cern.ch>
+lars <lars23@ymail.com>
 mschnepf <maschnepf@schnepf-net.de>
 Matthias J. Schnepf <maschnepf@schnepf-net.de>
 Matthias Schnepf <matthias.schnepf@kit.edu>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2026-07-10, command
+.. Created by changelog.py at 2026-07-16, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2026-07-10
+[Unreleased] - 2026-07-16
 =========================
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2026-05-28, command
+.. Created by changelog.py at 2026-07-10, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2026-05-28
+[Unreleased] - 2026-07-10
 =========================
 
 Fixed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by changelog.py at 2026-07-16, command
+.. Created by changelog.py at 2026-07-20, command
    '/Users/giffler/.cache/pre-commit/repoojtbdlhs/py_env-python3.14/bin/changelog docs/source/changes compile --categories Added Changed Fixed Security Deprecated --output=docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 
@@ -6,7 +6,7 @@
 CHANGELOG
 #########
 
-[Unreleased] - 2026-07-16
+[Unreleased] - 2026-07-20
 =========================
 
 Fixed

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -51,7 +51,9 @@ class SiteAgent(SiteAdapter):
         self, resource_attributes: AttributeDict
     ) -> AttributeDict:
         with self._site_adapter.handle_exceptions():
-            return await self._site_adapter.resource_status(resource_attributes)
+            return await self._site_adapter.resource_status(
+                resource_attributes=resource_attributes
+            )
 
     @property
     def site_name(self) -> str:
@@ -59,8 +61,12 @@ class SiteAgent(SiteAdapter):
 
     async def stop_resource(self, resource_attributes: AttributeDict):
         with self._site_adapter.handle_exceptions():
-            return await self._site_adapter.stop_resource(resource_attributes)
+            return await self._site_adapter.stop_resource(
+                resource_attributes=resource_attributes
+            )
 
     async def terminate_resource(self, resource_attributes: AttributeDict):
         with self._site_adapter.handle_exceptions():
-            return await self._site_adapter.terminate_resource(resource_attributes)
+            return await self._site_adapter.terminate_resource(
+                resource_attributes=resource_attributes
+            )

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -61,7 +61,7 @@ class AsyncBulkCall(Generic[T, R]):
     :param command: async callable that executes several tasks
     :param size: maximum number of tasks to execute in one bulk
     :param delay: maximum time window for tasks to execute in one bulk
-    :param concurrent: how often the `command` may be executed at the same time
+    :param concurrent: how often the `command` may be executed at once per thread
 
     Given some bulk-task callable ``(T, ...) -> (R, ...)`` (the ``command``),
     :py:class:`~.BulkExecution` represents a single-task callable ``(T) -> R``.
@@ -140,8 +140,7 @@ class AsyncBulkCall(Generic[T, R]):
         # queue item first so that the dispatch task does not finish before
         synchronized_resources.queue.put_nowait((__task, result))
         # ensure there is a worker to dispatch items for command execution
-        worker = self._dispatch_tasks.get(current_loop)
-        if worker is None or worker.done():
+        if self._dispatch_tasks.get(current_loop) is None:
             self._dispatch_tasks[current_loop] = asyncio.ensure_future(
                 self._bulk_dispatch(current_loop)
             )

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -152,26 +152,41 @@ class AsyncBulkCall(Generic[T, R]):
         synchronized_resources = self._loop_synchronization[current_loop]
         queue = synchronized_resources.queue
         semaphore = synchronized_resources.semaphore
-
-        while not queue.empty():
-            bulk = list(zip(*(await self._get_bulk(queue))))  # noqa B905
-            if not bulk:
-                continue
-            tasks, futures = bulk
-            # limit concurrent bulk execution
-            # We must make sure *here* that a new bulk can be launched, but
-            # we must release the claim *in the task* when it is done.
-            await semaphore.acquire()
-            task = asyncio.ensure_future(self._bulk_execute(tuple(tasks), futures))
-            task.add_done_callback(lambda _: semaphore.release())
-            # track tasks via strong references to avoid them being garbage collected.
-            # see bpo#44665
-            self._bulk_tasks.add(task)
-            task.add_done_callback(lambda _, task=task: self._bulk_tasks.discard(task))
-            # yield to the event loop so that the `while True` loop does not arbitrarily
-            # delay other tasks on the fast paths for `_get_bulk` and `acquire`.
-            await asyncio.sleep(0)
-        del self._dispatch_tasks[current_loop]
+        try:
+            while not queue.empty():
+                bulk = list(zip(*(await self._get_bulk(queue))))  # noqa B905
+                if not bulk:
+                    continue
+                tasks, futures = bulk
+                # limit concurrent bulk execution
+                # We must make sure *here* that a new bulk can be launched, but
+                # we must release the claim *in the task* when it is done.
+                await semaphore.acquire()
+                task = asyncio.ensure_future(self._bulk_execute(tuple(tasks), futures))
+                task.add_done_callback(lambda _: semaphore.release())
+                # track tasks via strong references to avoid them being garbage collected. # noqa B950
+                # see bpo#44665
+                self._bulk_tasks.add(task)
+                task.add_done_callback(
+                    lambda _, task=task: self._bulk_tasks.discard(task)
+                )
+                # yield to the event loop so that the `while True` loop does not arbitrarily # noqa B950
+                # delay other tasks on the fast paths for `_get_bulk` and `acquire`.
+                await asyncio.sleep(0)
+        finally:
+            # Check if this worker is still the registered worker for this loop
+            if self._dispatch_tasks.get(current_loop) == asyncio.current_task(
+                current_loop
+            ):
+                self._dispatch_tasks.pop(current_loop, None)
+            # Final Guard: If an item arrived during the final sleep/teardown,
+            # spawn a new worker to ensure it does not get stranded.
+            if not queue.empty() and current_loop in self._loop_synchronization:
+                worker = self._dispatch_tasks.get(current_loop)
+                if worker is None or worker.done():
+                    self._dispatch_tasks[current_loop] = asyncio.ensure_future(
+                        self._bulk_dispatch(current_loop)
+                    )
 
     async def _get_bulk(
         self, queue: asyncio.Queue
@@ -201,7 +216,7 @@ class AsyncBulkCall(Generic[T, R]):
     async def _bulk_execute(
         self, tasks: Tuple[T, ...], futures: "List[asyncio.Future[R]]"
     ) -> None:
-        """Execute several ``tasks`` in bulk and set their ``futures``' result"""
+        """Execute several ``tasks`` in bulk and set their ``futures`` result"""
         try:
             results = await self._command(*tasks)
             # make sure we can cleanly match input to output

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from dataclasses import dataclass
 from typing import TypeVar, Generic, Iterable, List, Tuple, Optional, Set
 from typing_extensions import Protocol
 import asyncio
@@ -7,6 +7,24 @@ import sys
 
 T = TypeVar("T")
 R = TypeVar("R")
+
+
+@dataclass
+class LoopBoundResources:
+    """
+    Container for asyncio primitives bound to a specific event loop lifecycle
+
+    When an event loop is replaced (for example, between separate unit tests using
+    :py:func:`asyncio.run`), any existing queue or semaphore from the old loop
+    becomes stale and unusable. This class bundles those loop-bound resources
+    together so they can be discarded and re-initialized as a single unit.
+
+    :param queue: The active queue of outstanding tasks and their result futures
+    :param concurrent: The semaphore limiting concurrent executions of the bulk command
+    """
+
+    queue: Optional[asyncio.Queue]
+    concurrent: Optional[asyncio.BoundedSemaphore]
 
 
 class BulkCommand(Protocol[T, R]):
@@ -73,17 +91,34 @@ class AsyncBulkCall(Generic[T, R]):
         self._dispatch_task: Optional[asyncio.Task] = None
         # tasks handling individual command executions
         self._bulk_tasks: Set[asyncio.Task] = set()
+
+        # Track active event loop states to safely handle multi-loop runs
+        # (like unittests)
+        self._current_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_resources = LoopBoundResources(queue=None, concurrent=None)
+
         self._verify_settings()
 
-    @cached_property
+    def _get_loop_resources(self) -> LoopBoundResources:
+        """Dynamically ensures resources match the currently running event loop."""
+        current_loop = asyncio.get_running_loop()
+        if self._current_loop != current_loop:
+            self._current_loop = current_loop
+            self._loop_resources = LoopBoundResources(
+                queue=asyncio.Queue(),
+                concurrent=asyncio.BoundedSemaphore(value=self._concurrency),
+            )
+        return self._loop_resources
+
+    @property
     def _concurrent(self) -> "asyncio.BoundedSemaphore":
         """synchronized counter for active commands"""
-        return asyncio.BoundedSemaphore(value=self._concurrency)
+        return self._get_loop_resources().concurrent
 
-    @cached_property
+    @property
     def _queue(self) -> "asyncio.Queue[Tuple[T, asyncio.Future[R]]]":
         """queue of outstanding tasks"""
-        return asyncio.Queue()
+        return self._get_loop_resources().queue
 
     def _verify_settings(self):
         if not isinstance(self._size, int) or self._size <= 0:
@@ -98,11 +133,11 @@ class AsyncBulkCall(Generic[T, R]):
 
     async def __call__(self, __task: T) -> R:
         """Queue a ``task`` for bulk execution and return the result when available"""
-        result: "asyncio.Future[R]" = asyncio.get_event_loop().create_future()
+        result: "asyncio.Future[R]" = asyncio.get_running_loop().create_future()
         # queue item first so that the dispatch task does not finish before
         self._queue.put_nowait((__task, result))
         # ensure there is a worker to dispatch items for command execution
-        if self._dispatch_task is None:
+        if self._dispatch_task is None or self._dispatch_task.done():
             self._dispatch_task = asyncio.ensure_future(self._bulk_dispatch())
         return await result
 
@@ -118,7 +153,7 @@ class AsyncBulkCall(Generic[T, R]):
             # we must release the claim *in the task* when it is done.
             await self._concurrent.acquire()
             task = asyncio.ensure_future(self._bulk_execute(tuple(tasks), futures))
-            task.add_done_callback(lambda _: self._concurrent.release)
+            task.add_done_callback(lambda _, sem=self._concurrent: sem.release())
             # track tasks via strong references to avoid them being garbage collected.
             # see bpo#44665
             self._bulk_tasks.add(task)
@@ -166,7 +201,9 @@ class AsyncBulkCall(Generic[T, R]):
                 )
         except Exception as task_exception:
             for future in futures:
-                future.set_exception(task_exception)
+                if not future.done():
+                    future.set_exception(task_exception)
         else:
             for future, result in zip(futures, results):  # noqa B905
-                future.set_result(result)
+                if not future.done():
+                    future.set_result(result)

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Iterable, List, Tuple, Optional, Set
-from typing_extensions import Protocol
+from typing_extensions import Protocol, Self
 import asyncio
 import time
 import sys
@@ -10,7 +10,7 @@ R = TypeVar("R")
 
 
 @dataclass
-class LoopBoundResources:
+class LoopSynchronization:
     """
     Container for asyncio primitives bound to a specific event loop lifecycle
 
@@ -20,11 +20,24 @@ class LoopBoundResources:
     together so they can be discarded and re-initialized as a single unit.
 
     :param queue: The active queue of outstanding tasks and their result futures
-    :param concurrent: The semaphore limiting concurrent executions of the bulk command
+    :param semaphore: The semaphore limiting concurrent executions of the bulk command
     """
 
     queue: Optional[asyncio.Queue]
-    concurrent: Optional[asyncio.BoundedSemaphore]
+    semaphore: Optional[asyncio.BoundedSemaphore]
+
+    @classmethod
+    def create(cls: "type[Self]", concurrency: int) -> "LoopSynchronization":
+        """
+        Factory method. Must be called within a running event loop context
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError as e:
+            raise RuntimeError(
+                "LoopSynchronization must be initialized within a running event loop."
+            ) from e
+        return cls(asyncio.Queue(), asyncio.BoundedSemaphore(value=concurrency))
 
 
 class BulkCommand(Protocol[T, R]):
@@ -95,30 +108,29 @@ class AsyncBulkCall(Generic[T, R]):
         # Track active event loop states to safely handle multi-loop runs
         # (like unittests)
         self._current_loop: Optional[asyncio.AbstractEventLoop] = None
-        self._loop_resources = LoopBoundResources(queue=None, concurrent=None)
+        self._loop_synchronization = LoopSynchronization(queue=None, semaphore=None)
 
         self._verify_settings()
 
-    def _get_loop_resources(self) -> LoopBoundResources:
+    def _get_loop_synchronization(self) -> LoopSynchronization:
         """Dynamically ensures resources match the currently running event loop."""
         current_loop = asyncio.get_running_loop()
         if self._current_loop != current_loop:
             self._current_loop = current_loop
-            self._loop_resources = LoopBoundResources(
-                queue=asyncio.Queue(),
-                concurrent=asyncio.BoundedSemaphore(value=self._concurrency),
+            self._loop_synchronization = LoopSynchronization.create(
+                concurrency=self._concurrency
             )
-        return self._loop_resources
+        return self._loop_synchronization
 
     @property
     def _concurrent(self) -> "asyncio.BoundedSemaphore":
         """synchronized counter for active commands"""
-        return self._get_loop_resources().concurrent
+        return self._get_loop_synchronization().semaphore
 
     @property
     def _queue(self) -> "asyncio.Queue[Tuple[T, asyncio.Future[R]]]":
         """queue of outstanding tasks"""
-        return self._get_loop_resources().queue
+        return self._get_loop_synchronization().queue
 
     def _verify_settings(self):
         if not isinstance(self._size, int) or self._size <= 0:

--- a/tardis/utilities/asyncbulkcall.py
+++ b/tardis/utilities/asyncbulkcall.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Iterable, List, Tuple, Optional, Set
 from typing_extensions import Protocol, Self
+from weakref import WeakKeyDictionary
 import asyncio
 import time
 import sys
@@ -101,36 +102,19 @@ class AsyncBulkCall(Generic[T, R]):
         self._delay = delay
         self._concurrency = sys.maxsize if concurrent is None else concurrent
         # task handling dispatch from queue to command execution
-        self._dispatch_task: Optional[asyncio.Task] = None
+        self._dispatch_tasks: WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Task
+        ] = WeakKeyDictionary()
         # tasks handling individual command executions
         self._bulk_tasks: Set[asyncio.Task] = set()
 
         # Track active event loop states to safely handle multi-loop runs
-        # (like unittests)
-        self._current_loop: Optional[asyncio.AbstractEventLoop] = None
-        self._loop_synchronization = LoopSynchronization(queue=None, semaphore=None)
+        # like unittests or free-threading
+        self._loop_synchronization: WeakKeyDictionary[
+            asyncio.AbstractEventLoop, LoopSynchronization
+        ] = WeakKeyDictionary()
 
         self._verify_settings()
-
-    def _get_loop_synchronization(self) -> LoopSynchronization:
-        """Dynamically ensures resources match the currently running event loop."""
-        current_loop = asyncio.get_running_loop()
-        if self._current_loop != current_loop:
-            self._current_loop = current_loop
-            self._loop_synchronization = LoopSynchronization.create(
-                concurrency=self._concurrency
-            )
-        return self._loop_synchronization
-
-    @property
-    def _concurrent(self) -> "asyncio.BoundedSemaphore":
-        """synchronized counter for active commands"""
-        return self._get_loop_synchronization().semaphore
-
-    @property
-    def _queue(self) -> "asyncio.Queue[Tuple[T, asyncio.Future[R]]]":
-        """queue of outstanding tasks"""
-        return self._get_loop_synchronization().queue
 
     def _verify_settings(self):
         if not isinstance(self._size, int) or self._size <= 0:
@@ -145,27 +129,41 @@ class AsyncBulkCall(Generic[T, R]):
 
     async def __call__(self, __task: T) -> R:
         """Queue a ``task`` for bulk execution and return the result when available"""
-        result: "asyncio.Future[R]" = asyncio.get_running_loop().create_future()
+        current_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        if current_loop not in self._loop_synchronization:
+            self._loop_synchronization[current_loop] = LoopSynchronization.create(
+                self._concurrency
+            )
+        synchronized_resources = self._loop_synchronization[current_loop]
+        result: "asyncio.Future[R]" = current_loop.create_future()
+
         # queue item first so that the dispatch task does not finish before
-        self._queue.put_nowait((__task, result))
+        synchronized_resources.queue.put_nowait((__task, result))
         # ensure there is a worker to dispatch items for command execution
-        if self._dispatch_task is None or self._dispatch_task.done():
-            self._dispatch_task = asyncio.ensure_future(self._bulk_dispatch())
+        worker = self._dispatch_tasks.get(current_loop)
+        if worker is None or worker.done():
+            self._dispatch_tasks[current_loop] = asyncio.ensure_future(
+                self._bulk_dispatch(current_loop)
+            )
         return await result
 
-    async def _bulk_dispatch(self):
+    async def _bulk_dispatch(self, current_loop: asyncio.AbstractEventLoop) -> None:
         """Collect tasks into bulks and dispatch them for command execution"""
-        while not self._queue.empty():
-            bulk = list(zip(*(await self._get_bulk())))  # noqa B905
+        synchronized_resources = self._loop_synchronization[current_loop]
+        queue = synchronized_resources.queue
+        semaphore = synchronized_resources.semaphore
+
+        while not queue.empty():
+            bulk = list(zip(*(await self._get_bulk(queue))))  # noqa B905
             if not bulk:
                 continue
             tasks, futures = bulk
             # limit concurrent bulk execution
             # We must make sure *here* that a new bulk can be launched, but
             # we must release the claim *in the task* when it is done.
-            await self._concurrent.acquire()
+            await semaphore.acquire()
             task = asyncio.ensure_future(self._bulk_execute(tuple(tasks), futures))
-            task.add_done_callback(lambda _, sem=self._concurrent: sem.release())
+            task.add_done_callback(lambda _: semaphore.release())
             # track tasks via strong references to avoid them being garbage collected.
             # see bpo#44665
             self._bulk_tasks.add(task)
@@ -173,11 +171,13 @@ class AsyncBulkCall(Generic[T, R]):
             # yield to the event loop so that the `while True` loop does not arbitrarily
             # delay other tasks on the fast paths for `_get_bulk` and `acquire`.
             await asyncio.sleep(0)
-        self._dispatch_task = None
+        del self._dispatch_tasks[current_loop]
 
-    async def _get_bulk(self) -> "List[Tuple[T, asyncio.Future[R]]]":
+    async def _get_bulk(
+        self, queue: asyncio.Queue
+    ) -> "List[Tuple[T, asyncio.Future[R]]]":
         """Fetch the next bulk from the internal queue"""
-        max_items, queue = self._size, self._queue
+        max_items = self._size
         # always pull in at least one item asynchronously
         # this avoids stalling for very low delays and efficiently waits for items
         results = [await queue.get()]

--- a/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
+++ b/tests/adapters_t/batchsystems_t/test_fakebatchsystem.py
@@ -2,10 +2,10 @@ from tardis.adapters.batchsystems.fakebatchsystem import FakeBatchSystemAdapter
 from tardis.interfaces.batchsystemadapter import MachineStatus
 from tardis.utilities.attributedict import AttributeDict
 
-from tests.utilities.utilities import run_async
-
 from unittest.mock import patch
 from unittest import TestCase
+
+import asyncio
 
 
 class TestFakeBatchSystemAdapter(TestCase):
@@ -31,39 +31,45 @@ class TestFakeBatchSystemAdapter(TestCase):
         self.fake_adapter = FakeBatchSystemAdapter()
 
     def test_disintegrate_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.disintegrate_machine, "test-123"))
+        self.assertIsNone(
+            asyncio.run(self.fake_adapter.disintegrate_machine("test-123"))
+        )
 
     def test_drain_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.drain_machine, "test-123"))
+        self.assertIsNone(asyncio.run(self.fake_adapter.drain_machine("test-123")))
 
     def test_integrate_machine(self):
-        self.assertIsNone(run_async(self.fake_adapter.integrate_machine, "test-123"))
+        self.assertIsNone(asyncio.run(self.fake_adapter.integrate_machine("test-123")))
 
     def test_get_allocation(self):
-        self.assertEqual(run_async(self.fake_adapter.get_allocation, "test-123"), 1.0)
+        self.assertEqual(asyncio.run(self.fake_adapter.get_allocation("test-123")), 1.0)
 
         self.config.BatchSystem.allocation = AttributeDict(get_value=lambda: 0.9)
         self.fake_adapter = FakeBatchSystemAdapter()
-        self.assertEqual(run_async(self.fake_adapter.get_allocation, "test-123"), 0.9)
+        self.assertEqual(asyncio.run(self.fake_adapter.get_allocation("test-123")), 0.9)
 
     def test_get_machine_status(self):
         self.assertEqual(
-            run_async(self.fake_adapter.get_machine_status, "test-123"),
+            asyncio.run(self.fake_adapter.get_machine_status("test-123")),
             MachineStatus.Available,
         )
 
-        run_async(self.fake_adapter.drain_machine, "test-123")
+        asyncio.run(self.fake_adapter.drain_machine("test-123"))
         self.assertEqual(
-            run_async(self.fake_adapter.get_machine_status, "test-123"),
+            asyncio.run(self.fake_adapter.get_machine_status("test-123")),
             MachineStatus.Drained,
         )
 
     def test_get_utilisation(self):
-        self.assertEqual(run_async(self.fake_adapter.get_utilisation, "test-123"), 1.0)
+        self.assertEqual(
+            asyncio.run(self.fake_adapter.get_utilisation("test-123")), 1.0
+        )
 
         self.config.BatchSystem.utilisation = AttributeDict(get_value=lambda: 0.9)
         self.fake_adapter = FakeBatchSystemAdapter()
-        self.assertEqual(run_async(self.fake_adapter.get_utilisation, "test-123"), 0.9)
+        self.assertEqual(
+            asyncio.run(self.fake_adapter.get_utilisation("test-123")), 0.9
+        )
 
     def test_machine_meta_data_translation_map(self):
         self.assertEqual(

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -1,4 +1,3 @@
-from tests.utilities.utilities import run_async
 from tests.utilities.utilities import mock_executor_run_command_new
 
 from tardis.adapters.batchsystems.htcondor import HTCondorAdapter
@@ -12,12 +11,12 @@ from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.utilities.attributedict import AttributeDict
 
 from datetime import datetime
-from functools import partial
 from shlex import quote
 from types import MappingProxyType
 from unittest.mock import patch
 from unittest import TestCase
 
+import asyncio
 import logging
 
 NOW = int(datetime.now().timestamp())
@@ -207,7 +206,7 @@ class TestHTCondorAdapter(TestCase):
 
     def test_disintegrate_machine(self):
         self.assertIsNone(
-            run_async(self.htcondor_adapter.disintegrate_machine, drone_uuid="test")
+            asyncio.run(self.htcondor_adapter.disintegrate_machine(drone_uuid="test"))
         )
 
     @mock_executor_run_command_new(
@@ -242,14 +241,14 @@ class TestHTCondorAdapter(TestCase):
         ]
     )
     def test_drain_machine(self):
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+        asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -pool my-htcondor.local -test -graceful slot1@test"
         )
 
         self.mock_executor.reset_mock()
 
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test_uuid")
+        asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test_uuid"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -pool my-htcondor.local -test -graceful slot1@test_uuid@test"
         )
@@ -257,7 +256,7 @@ class TestHTCondorAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.assertIsNone(  # should not run self._executor.run_command(cmd)
-            run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists")
+            asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="not_exists"))
         )
         self.mock_executor.return_value.run_command.assert_not_called()
 
@@ -265,7 +264,7 @@ class TestHTCondorAdapter(TestCase):
 
         with self.assertLogs(level=logging.WARNING):
             self.assertIsNone(
-                run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+                asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test"))
             )
 
         self.mock_executor.reset_mock()
@@ -273,7 +272,7 @@ class TestHTCondorAdapter(TestCase):
         with self.assertRaises(CommandExecutionFailure):
             with self.assertLogs(level=logging.CRITICAL):
                 self.assertIsNone(
-                    run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+                    asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test"))
                 )
 
     @mock_executor_run_command_new(
@@ -299,21 +298,21 @@ class TestHTCondorAdapter(TestCase):
         self.setup_config_mock()
         self.htcondor_adapter = HTCondorAdapter()
 
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test")
+        asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -graceful slot1@test"
         )
 
         self.mock_executor.reset_mock()
 
-        run_async(self.htcondor_adapter.drain_machine, drone_uuid="test_uuid")
+        asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test_uuid"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "condor_drain -graceful slot1@test_uuid@test"
         )
 
     def test_integrate_machine(self):
         self.assertIsNone(
-            run_async(self.htcondor_adapter.integrate_machine, drone_uuid="test")
+            asyncio.run(self.htcondor_adapter.integrate_machine(drone_uuid="test"))
         )
 
     @mock_executor_run_command_new(
@@ -332,7 +331,9 @@ class TestHTCondorAdapter(TestCase):
     def test_get_resource_ratios(self):
         self.assertCountEqual(
             list(
-                run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid="test")
+                asyncio.run(
+                    self.htcondor_adapter.get_resource_ratios(drone_uuid="test")
+                )
             ),
             [self.cpu_ratio, self.memory_ratio],
         )
@@ -340,8 +341,8 @@ class TestHTCondorAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_resource_ratios, drone_uuid="not_exists"
+            asyncio.run(
+                self.htcondor_adapter.get_resource_ratios(drone_uuid="not_exists")
             ),
             [],
         )
@@ -349,8 +350,8 @@ class TestHTCondorAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_resource_ratios, drone_uuid="test_undefined"
+            asyncio.run(
+                self.htcondor_adapter.get_resource_ratios(drone_uuid="test_undefined")
             ),
             [],
         )
@@ -358,8 +359,8 @@ class TestHTCondorAdapter(TestCase):
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_resource_ratios, drone_uuid="test_error"
+            asyncio.run(
+                self.htcondor_adapter.get_resource_ratios(drone_uuid="test_error")
             ),
             [],
         )
@@ -384,7 +385,9 @@ class TestHTCondorAdapter(TestCase):
 
         self.assertCountEqual(
             list(
-                run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid="test")
+                asyncio.run(
+                    self.htcondor_adapter.get_resource_ratios(drone_uuid="test")
+                )
             ),
             [self.cpu_ratio, self.memory_ratio],
         )
@@ -408,7 +411,7 @@ class TestHTCondorAdapter(TestCase):
     )
     def test_get_allocation(self):
         self.assertEqual(
-            run_async(self.htcondor_adapter.get_allocation, drone_uuid="test"),
+            asyncio.run(self.htcondor_adapter.get_allocation(drone_uuid="test")),
             max([self.cpu_ratio, self.memory_ratio]),
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
@@ -428,46 +431,48 @@ class TestHTCondorAdapter(TestCase):
     )
     def test_get_machine_status(self):
         self.assertEqual(
-            run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test"),
+            asyncio.run(self.htcondor_adapter.get_machine_status(drone_uuid="test")),
             MachineStatus.Available,
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_machine_status, drone_uuid="not_exists"
+            asyncio.run(
+                self.htcondor_adapter.get_machine_status(drone_uuid="not_exists")
             ),
             MachineStatus.NotAvailable,
         )
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_machine_status, drone_uuid="test_drain"
+            asyncio.run(
+                self.htcondor_adapter.get_machine_status(drone_uuid="test_drain")
             ),
             MachineStatus.Draining,
         )
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_machine_status, drone_uuid="test_drained"
+            asyncio.run(
+                self.htcondor_adapter.get_machine_status(drone_uuid="test_drained")
             ),
             MachineStatus.Drained,
         )
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(
-                self.htcondor_adapter.get_machine_status, drone_uuid="test_owner"
+            asyncio.run(
+                self.htcondor_adapter.get_machine_status(drone_uuid="test_owner")
             ),
             MachineStatus.NotAvailable,
         )
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(self.htcondor_adapter.get_machine_status, drone_uuid="test_uuid"),
+            asyncio.run(
+                self.htcondor_adapter.get_machine_status(drone_uuid="test_uuid")
+            ),
             MachineStatus.Available,
         )
 
@@ -501,9 +506,8 @@ class TestHTCondorAdapter(TestCase):
 
         self.assertDictEqual(
             CONDOR_STATUS_RETURN_DICT,
-            run_async(
-                partial(
-                    htcondor_status_updater,
+            asyncio.run(
+                htcondor_status_updater(
                     self.config.BatchSystem.options,
                     attributes,
                     self.mock_executor.return_value,
@@ -549,9 +553,8 @@ class TestHTCondorAdapter(TestCase):
         # check that no resources have been deleted and cached data is used
         self.assertDictEqual(
             CONDOR_STATUS_RETURN_DICT,
-            run_async(
-                partial(
-                    htcondor_status_updater,
+            asyncio.run(
+                htcondor_status_updater(
                     self.config.BatchSystem.options,
                     attributes,
                     self.mock_executor.return_value,
@@ -593,9 +596,8 @@ class TestHTCondorAdapter(TestCase):
         # check that no resources have been deleted and cached data is used
         self.assertDictEqual(
             CONDOR_STATUS_RETURN_DICT,
-            run_async(
-                partial(
-                    htcondor_status_updater,
+            asyncio.run(
+                htcondor_status_updater(
                     self.config.BatchSystem.options,
                     attributes,
                     self.mock_executor.return_value,
@@ -641,9 +643,8 @@ class TestHTCondorAdapter(TestCase):
 
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(
-                    partial(
-                        htcondor_status_updater,
+                asyncio.run(
+                    htcondor_status_updater(
                         self.config.BatchSystem.options,
                         attributes,
                         self.mock_executor.return_value,
@@ -667,7 +668,7 @@ class TestHTCondorAdapter(TestCase):
     )
     def test_get_utilisation(self):
         self.assertEqual(
-            run_async(self.htcondor_adapter.get_utilisation, drone_uuid="test"),
+            asyncio.run(self.htcondor_adapter.get_utilisation(drone_uuid="test")),
             min([self.cpu_ratio, self.memory_ratio]),
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
@@ -689,7 +690,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collectors, options, executor)
+        result = asyncio.run(htcondor_get_collectors(options, executor))
 
         # Expected: split collector names by newline and strip empty lines
         expected = [
@@ -717,7 +718,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collectors, options, executor)
+        result = asyncio.run(htcondor_get_collectors(options, executor))
 
         expected = [
             "cloud-htcondor-rhel8.gridka.de",
@@ -745,7 +746,7 @@ class TestHTCondorAdapter(TestCase):
 
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(htcondor_get_collectors, options, executor)
+                asyncio.run(htcondor_get_collectors(options, executor))
 
     @mock_executor_run_command_new(
         [
@@ -761,7 +762,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collector_start_dates, options, executor)
+        result = asyncio.run(htcondor_get_collector_start_dates(options, executor))
 
         # We expect only machines from CONDOR_COLLECTOR_STATUS_RETURN to be included
         expected_times = {
@@ -769,7 +770,6 @@ class TestHTCondorAdapter(TestCase):
             "cloud-htcondor.gridka.de": datetime.fromtimestamp(1753947411),
         }
         self.assertEqual(result, expected_times)
-        print(self.mock_executor.return_value.run_command.mock_calls)
         # Ensure both commands were called with proper formatting
         self.mock_executor.return_value.run_command.assert_any_call(
             "condor_status -af:t Machine -pool my-htcondor.local -test -collector"
@@ -794,7 +794,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collector_start_dates, options, executor)
+        result = asyncio.run(htcondor_get_collector_start_dates(options, executor))
 
         expected_times = {
             "cloud-htcondor-rhel8.gridka.de": datetime.fromtimestamp(1753949919),
@@ -823,7 +823,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collector_start_dates, options, executor)
+        result = asyncio.run(htcondor_get_collector_start_dates(options, executor))
 
         # We expect only machines from CONDOR_COLLECTOR_STATUS_RETURN to be included
         datetime_now = datetime.fromtimestamp(NOW)
@@ -855,7 +855,7 @@ class TestHTCondorAdapter(TestCase):
         options = self.config.BatchSystem.options
         executor = self.mock_executor.return_value
 
-        result = run_async(htcondor_get_collector_start_dates, options, executor)
+        result = asyncio.run(htcondor_get_collector_start_dates(options, executor))
 
         # We expect only machines from CONDOR_COLLECTOR_STATUS_RETURN to be included
         expected_times = {
@@ -892,4 +892,4 @@ class TestHTCondorAdapter(TestCase):
 
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(htcondor_get_collector_start_dates, options, executor)
+                asyncio.run(htcondor_get_collector_start_dates(options, executor))

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -1,4 +1,4 @@
-from tests.utilities.utilities import mock_executor_run_command_new
+from tests.utilities.utilities import mock_executor_run_command
 
 from tardis.adapters.batchsystems.htcondor import HTCondorAdapter
 from tardis.adapters.batchsystems.htcondor import (
@@ -209,7 +209,7 @@ class TestHTCondorAdapter(TestCase):
             asyncio.run(self.htcondor_adapter.disintegrate_machine(drone_uuid="test"))
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -275,7 +275,7 @@ class TestHTCondorAdapter(TestCase):
                     asyncio.run(self.htcondor_adapter.drain_machine(drone_uuid="test"))
                 )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -315,7 +315,7 @@ class TestHTCondorAdapter(TestCase):
             asyncio.run(self.htcondor_adapter.integrate_machine(drone_uuid="test"))
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -365,7 +365,7 @@ class TestHTCondorAdapter(TestCase):
             [],
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -396,7 +396,7 @@ class TestHTCondorAdapter(TestCase):
             self.command_wo_options
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -416,7 +416,7 @@ class TestHTCondorAdapter(TestCase):
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -476,7 +476,7 @@ class TestHTCondorAdapter(TestCase):
             MachineStatus.Available,
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -521,7 +521,7 @@ class TestHTCondorAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -565,7 +565,7 @@ class TestHTCondorAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -612,7 +612,7 @@ class TestHTCondorAdapter(TestCase):
             )  # should query the oldest collector using -pool
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -653,7 +653,7 @@ class TestHTCondorAdapter(TestCase):
                 )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -679,7 +679,7 @@ class TestHTCondorAdapter(TestCase):
             self.htcondor_adapter.machine_meta_data_translation_mapping,
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # for call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -704,7 +704,7 @@ class TestHTCondorAdapter(TestCase):
             "condor_status -af:t Machine -pool my-htcondor.local -test -collector"
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # for htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -730,7 +730,7 @@ class TestHTCondorAdapter(TestCase):
             "condor_status -af:t Machine -collector"
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             CommandExecutionFailure(  # simulate failure in htcondor_get_collectors
                 message="Collector not reachable",
@@ -748,7 +748,7 @@ class TestHTCondorAdapter(TestCase):
             with self.assertRaises(CommandExecutionFailure):
                 asyncio.run(htcondor_get_collectors(options, executor))
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -778,7 +778,7 @@ class TestHTCondorAdapter(TestCase):
             'condor_status -af:t Machine DaemonStartTime -constraint \'Machine == "cloud-htcondor-rhel8.gridka.de" || Machine == "cloud-htcondor.gridka.de"\' -pool my-htcondor.local -test -master'  # noqa B950
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -809,7 +809,7 @@ class TestHTCondorAdapter(TestCase):
             'condor_status -af:t Machine DaemonStartTime -constraint \'Machine == "cloud-htcondor-rhel8.gridka.de" || Machine == "cloud-htcondor.gridka.de"\' -master'  # noqa B950
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -841,7 +841,7 @@ class TestHTCondorAdapter(TestCase):
             'condor_status -af:t Machine DaemonStartTime -constraint \'Machine == "cloud-htcondor-rhel8.gridka.de" || Machine == "cloud-htcondor.gridka.de"\' -pool my-htcondor.local -test -master'  # noqa B950
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0
@@ -872,7 +872,7 @@ class TestHTCondorAdapter(TestCase):
             'condor_status -af:t Machine DaemonStartTime -constraint \'Machine == "cloud-htcondor-rhel8.gridka.de" || Machine == "cloud-htcondor.gridka.de"\' -pool my-htcondor.local -test -master'  # noqa B950
         )
 
-    @mock_executor_run_command_new(
+    @mock_executor_run_command(
         [
             AttributeDict(  # call in htcondor_get_collectors
                 stdout=CONDOR_COLLECTOR_STATUS_RETURN, stderr="", exit_code=0

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -79,9 +79,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in drain_machine
+            AttributeDict(return_value=0),  # scontrol call in drain_machine
         ]
-        * 2
     )
     def test_drain_machine(self):
         asyncio.run(self.slurm_adapter.drain_machine(drone_uuid="VM-1"))
@@ -98,7 +98,7 @@ class TestSlurmAdapter(TestCase):
         [
             CommandExecutionFailure(
                 message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-            ),
+            ),  # sinfo call in update_status
         ]
     )
     def test_update_exception(self):
@@ -109,9 +109,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in drain_machine
+            AttributeDict(return_value=0),  # scontrol call in drain_machine
         ]
-        * 2
     )
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
@@ -130,7 +130,7 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in get_resource_ratios
         ]
     )
     def test_get_resource_ratios(self):
@@ -152,7 +152,7 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in get_resource_ratios
         ]
     )
     def test_get_resource_ratios_without_options(self):
@@ -173,7 +173,7 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in get_resource_ratios
         ]
     )
     def test_get_allocation(self):
@@ -190,7 +190,10 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in get_machine_status
+            CommandExecutionFailure(
+                message="Test", exit_code=123, stderr="Test", stdout="Test"
+            ),  # sinfo call in get_machine_status, 2nd call
         ]
     )
     def test_get_machine_status(self):
@@ -210,12 +213,6 @@ class TestSlurmAdapter(TestCase):
             )
 
         self.mock_executor.reset_mock()
-
-        self.mock_executor.return_value.run_command.side_effect = (
-            CommandExecutionFailure(
-                message="Test", exit_code=123, stderr="Test", stdout="Test"
-            )
-        )
 
         attributes = {
             "statelong": "statelong",
@@ -240,7 +237,7 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=SINFO_RETURN),
+            AttributeDict(stdout=SINFO_RETURN),  # sinfo call in get_resource_ratios
         ]
     )
     def test_get_utilisation(self):

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from tests.utilities.utilities import mock_executor_run_command
+
 from tardis.adapters.batchsystems.slurm import SlurmAdapter
 from tardis.utilities.attributedict import AttributeDict
 
@@ -76,7 +77,12 @@ class TestSlurmAdapter(TestCase):
             asyncio.run(self.slurm_adapter.disintegrate_machine(drone_uuid="test"))
         )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+        * 2
+    )
     def test_drain_machine(self):
         asyncio.run(self.slurm_adapter.drain_machine(drone_uuid="VM-1"))
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -89,10 +95,11 @@ class TestSlurmAdapter(TestCase):
         )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-        ),
+        [
+            CommandExecutionFailure(
+                message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+            ),
+        ]
     )
     def test_update_exception(self):
         with self.assertLogs(level=logging.WARNING):
@@ -100,7 +107,12 @@ class TestSlurmAdapter(TestCase):
                 asyncio.run(self.slurm_adapter._slurm_status.update_status())
             )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+        * 2
+    )
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
         self.slurm_adapter = SlurmAdapter()
@@ -116,7 +128,11 @@ class TestSlurmAdapter(TestCase):
             asyncio.run(self.slurm_adapter.integrate_machine(drone_uuid="VM-1"))
         )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+    )
     def test_get_resource_ratios(self):
         self.assertEqual(
             list(
@@ -134,7 +150,11 @@ class TestSlurmAdapter(TestCase):
             {},
         )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+    )
     def test_get_resource_ratios_without_options(self):
         self.setup_config_mock()
         del self.config.BatchSystem.options
@@ -151,7 +171,11 @@ class TestSlurmAdapter(TestCase):
             self.command_wo_options
         )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+    )
     def test_get_allocation(self):
         self.assertEqual(
             asyncio.run(self.slurm_adapter.get_allocation(drone_uuid="VM-1")),
@@ -164,7 +188,11 @@ class TestSlurmAdapter(TestCase):
             0.0,
         )
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+    )
     def test_get_machine_status(self):
         state_mapping = {
             "VM-1": MachineStatus.Available,
@@ -210,7 +238,11 @@ class TestSlurmAdapter(TestCase):
 
         self.mock_executor.return_value.run_command.side_effect = None
 
-    @mock_executor_run_command(stdout=SINFO_RETURN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=SINFO_RETURN),
+        ]
+    )
     def test_get_utilisation(self):
         self.assertEqual(
             asyncio.run(self.slurm_adapter.get_utilisation(drone_uuid="VM-1")),

--- a/tests/adapters_t/batchsystems_t/test_slurm.py
+++ b/tests/adapters_t/batchsystems_t/test_slurm.py
@@ -1,6 +1,6 @@
+import asyncio
 import logging
 
-from tests.utilities.utilities import run_async
 from tests.utilities.utilities import mock_executor_run_command
 from tardis.adapters.batchsystems.slurm import SlurmAdapter
 from tardis.utilities.attributedict import AttributeDict
@@ -9,8 +9,6 @@ from tardis.adapters.batchsystems.slurm import slurm_status_updater
 from tardis.interfaces.batchsystemadapter import MachineStatus
 
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
-
-from functools import partial
 
 from unittest.mock import patch
 from unittest import TestCase
@@ -75,19 +73,19 @@ class TestSlurmAdapter(TestCase):
 
     def test_disintegrate_machine(self):
         self.assertIsNone(
-            run_async(self.slurm_adapter.disintegrate_machine, drone_uuid="test")
+            asyncio.run(self.slurm_adapter.disintegrate_machine(drone_uuid="test"))
         )
 
     @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_drain_machine(self):
-        run_async(self.slurm_adapter.drain_machine, drone_uuid="VM-1")
+        asyncio.run(self.slurm_adapter.drain_machine(drone_uuid="VM-1"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "scontrol update NodeName=host-10-18-1-1 State=DRAIN Reason='COBalD/TARDIS'"
         )
         self.mock_executor.reset_mock()
 
         self.assertIsNone(
-            run_async(self.slurm_adapter.drain_machine, drone_uuid="not_exists")
+            asyncio.run(self.slurm_adapter.drain_machine(drone_uuid="not_exists"))
         )
 
     @mock_executor_run_command(
@@ -98,14 +96,16 @@ class TestSlurmAdapter(TestCase):
     )
     def test_update_exception(self):
         with self.assertLogs(level=logging.WARNING):
-            self.assertIsNone(run_async(self.slurm_adapter._slurm_status.update_status))
+            self.assertIsNone(
+                asyncio.run(self.slurm_adapter._slurm_status.update_status())
+            )
 
     @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_drain_machine_without_options(self):
         self.setup_config_mock()
         self.slurm_adapter = SlurmAdapter()
 
-        run_async(self.slurm_adapter.drain_machine, drone_uuid="VM-1")
+        asyncio.run(self.slurm_adapter.drain_machine(drone_uuid="VM-1"))
         self.mock_executor.return_value.run_command.assert_called_with(
             "scontrol update NodeName=host-10-18-1-1 State=DRAIN Reason='COBalD/TARDIS'"
         )
@@ -113,20 +113,24 @@ class TestSlurmAdapter(TestCase):
 
     def test_integrate_machine(self):
         self.assertIsNone(
-            run_async(self.slurm_adapter.integrate_machine, drone_uuid="VM-1")
+            asyncio.run(self.slurm_adapter.integrate_machine(drone_uuid="VM-1"))
         )
 
     @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_resource_ratios(self):
         self.assertEqual(
-            list(run_async(self.slurm_adapter.get_resource_ratios, drone_uuid="VM-1")),
+            list(
+                asyncio.run(self.slurm_adapter.get_resource_ratios(drone_uuid="VM-1"))
+            ),
             [self.cpu_ratio, self.memory_ratio],
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
         self.mock_executor.reset_mock()
 
         self.assertEqual(
-            run_async(self.slurm_adapter.get_resource_ratios, drone_uuid="not_exists"),
+            asyncio.run(
+                self.slurm_adapter.get_resource_ratios(drone_uuid="not_exists")
+            ),
             {},
         )
 
@@ -137,7 +141,9 @@ class TestSlurmAdapter(TestCase):
         self.slurm_adapter = SlurmAdapter()
 
         self.assertEqual(
-            list(run_async(self.slurm_adapter.get_resource_ratios, drone_uuid="VM-1")),
+            list(
+                asyncio.run(self.slurm_adapter.get_resource_ratios(drone_uuid="VM-1"))
+            ),
             [self.cpu_ratio, self.memory_ratio],
         )
 
@@ -148,13 +154,13 @@ class TestSlurmAdapter(TestCase):
     @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_allocation(self):
         self.assertEqual(
-            run_async(self.slurm_adapter.get_allocation, drone_uuid="VM-1"),
+            asyncio.run(self.slurm_adapter.get_allocation(drone_uuid="VM-1")),
             max([self.cpu_ratio, self.memory_ratio]),
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
         self.assertEqual(
-            run_async(self.slurm_adapter.get_allocation, drone_uuid="not_exists"),
+            asyncio.run(self.slurm_adapter.get_allocation(drone_uuid="not_exists")),
             0.0,
         )
 
@@ -171,7 +177,7 @@ class TestSlurmAdapter(TestCase):
 
         for machine, state in state_mapping.items():
             self.assertEqual(
-                run_async(self.slurm_adapter.get_machine_status, drone_uuid=machine),
+                asyncio.run(self.slurm_adapter.get_machine_status(drone_uuid=machine)),
                 state,
             )
 
@@ -193,9 +199,8 @@ class TestSlurmAdapter(TestCase):
         }
         with self.assertLogs(level="WARN"):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(
-                    partial(
-                        slurm_status_updater,
+                asyncio.run(
+                    slurm_status_updater(
                         self.config.BatchSystem.options,
                         attributes,
                         self.mock_executor.return_value,
@@ -208,13 +213,13 @@ class TestSlurmAdapter(TestCase):
     @mock_executor_run_command(stdout=SINFO_RETURN)
     def test_get_utilisation(self):
         self.assertEqual(
-            run_async(self.slurm_adapter.get_utilisation, drone_uuid="VM-1"),
+            asyncio.run(self.slurm_adapter.get_utilisation(drone_uuid="VM-1")),
             min([self.cpu_ratio, self.memory_ratio]),
         )
         self.mock_executor.return_value.run_command.assert_called_with(self.command)
 
         self.assertEqual(
-            run_async(self.slurm_adapter.get_utilisation, drone_uuid="not_exists"),
+            asyncio.run(self.slurm_adapter.get_utilisation(drone_uuid="not_exists")),
             0.0,
         )
 

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -7,12 +7,9 @@ from tardis.exceptions.tardisexceptions import TardisQuotaExceeded
 from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from CloudStackAIO.CloudStack import CloudStackClientException
 
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
-
 from aiohttp import ClientConnectionError
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import asyncio
 import logging
@@ -59,7 +56,7 @@ class TestCloudStackAdapter(TestCase):
                 name="testsite-089123", id="123456", state="Present"
             )
         )
-        cloudstack_api.deployVirtualMachine.return_value = async_return(
+        cloudstack_api.deployVirtualMachine = AsyncMock(
             return_value=self.deploy_return_value
         )
         self.list_vm_return_value = AttributeDict(
@@ -67,15 +64,13 @@ class TestCloudStackAdapter(TestCase):
                 AttributeDict(name="testsite-089123", id="123456", state="Running")
             ]
         )
-        cloudstack_api.listVirtualMachines.return_value = async_return(
+        cloudstack_api.listVirtualMachines = AsyncMock(
             return_value=self.list_vm_return_value
         )
 
-        cloudstack_api.stopVirtualMachine.return_value = async_return(return_value=None)
+        cloudstack_api.stopVirtualMachine = AsyncMock(return_value=None)
 
-        cloudstack_api.destroyVirtualMachine.return_value = async_return(
-            return_value=None
-        )
+        cloudstack_api.destroyVirtualMachine = AsyncMock(return_value=None)
 
         self.cloudstack_adapter = CloudStackAdapter(
             machine_type="test2large", site_name="TestSite"
@@ -86,9 +81,10 @@ class TestCloudStackAdapter(TestCase):
 
     def test_deploy_resource(self):
         self.assertEqual(
-            run_async(
-                self.cloudstack_adapter.deploy_resource,
-                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            asyncio.run(
+                self.cloudstack_adapter.deploy_resource(
+                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                )
             ),
             AttributeDict(
                 drone_uuid="testsite-089123",
@@ -119,9 +115,10 @@ class TestCloudStackAdapter(TestCase):
 
     def test_resource_status(self):
         self.assertEqual(
-            run_async(
-                self.cloudstack_adapter.resource_status,
-                resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+            asyncio.run(
+                self.cloudstack_adapter.resource_status(
+                    resource_attributes=AttributeDict(remote_resource_uuid="123456")
+                ),
             ),
             AttributeDict(
                 drone_uuid="testsite-089123",
@@ -134,9 +131,10 @@ class TestCloudStackAdapter(TestCase):
         )
 
     def test_stop_resource(self):
-        run_async(
-            self.cloudstack_adapter.stop_resource,
-            resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+        asyncio.run(
+            self.cloudstack_adapter.stop_resource(
+                resource_attributes=AttributeDict(remote_resource_uuid="123456")
+            ),
         )
 
         self.mock_cloudstack_api.return_value.stopVirtualMachine.assert_called_with(
@@ -144,9 +142,10 @@ class TestCloudStackAdapter(TestCase):
         )
 
     def test_terminate_resource(self):
-        run_async(
-            self.cloudstack_adapter.terminate_resource,
-            resource_attributes=AttributeDict(remote_resource_uuid="123456"),
+        asyncio.run(
+            self.cloudstack_adapter.terminate_resource(
+                resource_attributes=AttributeDict(remote_resource_uuid="123456")
+            ),
         )
 
         self.mock_cloudstack_api.return_value.destroyVirtualMachine.assert_called_with(

--- a/tests/adapters_t/sites_t/test_fakesite.py
+++ b/tests/adapters_t/sites_t/test_fakesite.py
@@ -3,12 +3,12 @@ from tardis.exceptions.tardisexceptions import TardisError
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 
-from tests.utilities.utilities import run_async
-
 from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
 from unittest import TestCase
+
+import asyncio
 
 
 class TestFakeSiteAdapter(TestCase):
@@ -42,7 +42,7 @@ class TestFakeSiteAdapter(TestCase):
         return AttributeDict(test2large=AttributeDict(jdl="submit.jdl"))
 
     def test_deploy_resource(self):
-        response = run_async(self.adapter.deploy_resource, AttributeDict())
+        response = asyncio.run(self.adapter.deploy_resource(AttributeDict()))
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
     def test_machine_meta_data(self):
@@ -65,9 +65,10 @@ class TestFakeSiteAdapter(TestCase):
         )
         self.assertEqual(
             AttributeDict(),  # no update require, resource still in Booting state
-            run_async(
-                self.adapter.resource_status,
-                resource_attributes,
+            asyncio.run(
+                self.adapter.resource_status(
+                    resource_attributes,
+                )
             ),
         )
 
@@ -77,7 +78,7 @@ class TestFakeSiteAdapter(TestCase):
 
         self.assertDictEqual(
             AttributeDict(resource_status=ResourceStatus.Running),
-            run_async(self.adapter.resource_status, resource_attributes),
+            asyncio.run(self.adapter.resource_status(resource_attributes)),
         )
 
         # test resource status of stop resources
@@ -86,7 +87,7 @@ class TestFakeSiteAdapter(TestCase):
         )
         self.assertEqual(
             AttributeDict(),
-            run_async(self.adapter.resource_status, resource_attributes),
+            asyncio.run(self.adapter.resource_status(resource_attributes)),
         )
         self.assertDictEqual(
             AttributeDict(
@@ -103,7 +104,7 @@ class TestFakeSiteAdapter(TestCase):
         )
         self.assertEqual(
             AttributeDict(),
-            run_async(self.adapter.resource_status, resource_attributes),
+            asyncio.run(self.adapter.resource_status(resource_attributes)),
         )
         self.assertDictEqual(
             AttributeDict(
@@ -120,7 +121,7 @@ class TestFakeSiteAdapter(TestCase):
             created=datetime.now(),
             resource_status=ResourceStatus.Running,
         )
-        run_async(self.adapter.stop_resource, resource_attributes)
+        asyncio.run(self.adapter.stop_resource(resource_attributes))
         self.assertEqual(resource_attributes.resource_status, ResourceStatus.Stopped)
 
     def test_terminate_resource(self):
@@ -129,7 +130,7 @@ class TestFakeSiteAdapter(TestCase):
             created=datetime.now(),
             resource_status=ResourceStatus.Running,
         )
-        run_async(self.adapter.terminate_resource, resource_attributes)
+        asyncio.run(self.adapter.terminate_resource(resource_attributes))
         self.assertEqual(resource_attributes.resource_status, ResourceStatus.Deleted)
 
     def test_exception_handling(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -161,7 +161,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_SUBMIT_OUTPUT),
+            AttributeDict(
+                stdout=CONDOR_SUBMIT_OUTPUT
+            ),  # condor_submit call in deploy_resource, 5 calls in this test
         ]
         * 5
     )
@@ -305,7 +307,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_IDLE),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_IDLE
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_idle(self):
@@ -318,7 +322,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_RUN),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_RUN
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_run(self):
@@ -331,7 +337,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_REMOVING),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_REMOVING
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_removing(self):
@@ -344,7 +352,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_COMPLETED),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_COMPLETED
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_completed(self):
@@ -357,7 +367,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_HELD),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_HELD
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_held(self):
@@ -370,7 +382,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_transfering_output(self):
@@ -383,7 +397,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_SUSPENDED),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_SUSPENDED
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_unexpanded(self):
@@ -398,7 +414,7 @@ class TestHTCondorSiteAdapter(TestCase):
         [
             CommandExecutionFailure(
                 message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-            ),
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_command_execution_error(self):
@@ -414,7 +430,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_Q_OUTPUT_DOES_NOT_EXISTS),
+            AttributeDict(
+                stdout=CONDOR_Q_OUTPUT_DOES_NOT_EXISTS
+            ),  # condor_q call in resource_status
         ]
     )
     def test_resource_status_already_deleted(self):
@@ -427,7 +445,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_SUSPEND_OUTPUT),
+            AttributeDict(
+                stdout=CONDOR_SUSPEND_OUTPUT
+            ),  # condor_suspend call in stop_resource
         ]
     )
     def test_stop_resource(self):
@@ -444,7 +464,7 @@ class TestHTCondorSiteAdapter(TestCase):
                 stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
                 stdout="",
                 stdin="",
-            ),
+            ),  # condor_suspend call in stop_resource
         ]
     )
     def test_stop_resource_failed_redo_not_found(self):
@@ -463,7 +483,7 @@ class TestHTCondorSiteAdapter(TestCase):
                 stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_RUNNING,
                 stdout="",
                 stdin="",
-            ),
+            ),  # condor_suspend call in stop_resource
         ]
     )
     def test_stop_resource_failed_redo_not_running(self):
@@ -482,7 +502,7 @@ class TestHTCondorSiteAdapter(TestCase):
                 stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
                 stdout="",
                 stdin="",
-            ),
+            ),  # condor_suspend call in stop_resource
         ]
     )
     def test_stop_resource_failed_raise(self):
@@ -495,7 +515,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_RM_OUTPUT),
+            AttributeDict(
+                stdout=CONDOR_RM_OUTPUT
+            ),  # condor_rm call in terminate_resource
         ]
     )
     def test_terminate_resource(self):
@@ -508,7 +530,9 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=CONDOR_RM_FAILED_OUTPUT),
+            AttributeDict(
+                stdout=CONDOR_RM_FAILED_OUTPUT
+            ),  # condor_rm call in terminate_resource
         ]
     )
     def test_terminate_resource_failed_redo(self):
@@ -527,7 +551,7 @@ class TestHTCondorSiteAdapter(TestCase):
                 stderr=CONDOR_RM_FAILED_OUTPUT,
                 stdout="",
                 stdin="",
-            ),
+            ),  # condor_rm call in terminate_resource
         ]
     )
     def test_terminate_resource_failed_raise(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -6,6 +6,7 @@ from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import mock_executor_run_command
 
+
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -158,7 +159,12 @@ class TestHTCondorSiteAdapter(TestCase):
             ),
         )
 
-    @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_SUBMIT_OUTPUT),
+        ]
+        * 5
+    )
     def test_deploy_resource_htcondor_obs(self):
         response = asyncio.run(
             self.adapter.deploy_resource(
@@ -297,7 +303,11 @@ class TestHTCondorSiteAdapter(TestCase):
     def test_site_name(self):
         self.assertEqual(self.adapter.site_name, "TestSite")
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_IDLE),
+        ]
+    )
     def test_resource_status_idle(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -306,7 +316,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_RUN),
+        ]
+    )
     def test_resource_status_run(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -315,7 +329,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_REMOVING)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_REMOVING),
+        ]
+    )
     def test_resource_status_removing(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -324,7 +342,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_COMPLETED),
+        ]
+    )
     def test_resource_status_completed(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -333,7 +355,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_HELD)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_HELD),
+        ]
+    )
     def test_resource_status_held(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -342,7 +368,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT),
+        ]
+    )
     def test_resource_status_transfering_output(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -351,7 +381,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUSPENDED)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_SUSPENDED),
+        ]
+    )
     def test_resource_status_unexpanded(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -361,10 +395,11 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-        ),
+        [
+            CommandExecutionFailure(
+                message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+            ),
+        ]
     )
     def test_resource_status_command_execution_error(self):
         with self.assertLogs(level=logging.WARNING):
@@ -377,7 +412,11 @@ class TestHTCondorSiteAdapter(TestCase):
                     ),
                 )
 
-    @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_DOES_NOT_EXISTS)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_Q_OUTPUT_DOES_NOT_EXISTS),
+        ]
+    )
     def test_resource_status_already_deleted(self):
         response = asyncio.run(
             self.adapter.resource_status(
@@ -386,7 +425,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
-    @mock_executor_run_command(stdout=CONDOR_SUSPEND_OUTPUT)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_SUSPEND_OUTPUT),
+        ]
+    )
     def test_stop_resource(self):
         response = asyncio.run(
             self.adapter.stop_resource(AttributeDict(remote_resource_uuid="1351043.0"))
@@ -394,14 +437,15 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertIsNone(response)
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message=CONDOR_SUSPEND_FAILED_MESSAGE,
-            exit_code=1,
-            stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
-            stdout="",
-            stdin="",
-        ),
+        [
+            CommandExecutionFailure(
+                message=CONDOR_SUSPEND_FAILED_MESSAGE,
+                exit_code=1,
+                stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
+                stdout="",
+                stdin="",
+            ),
+        ]
     )
     def test_stop_resource_failed_redo_not_found(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
@@ -412,14 +456,15 @@ class TestHTCondorSiteAdapter(TestCase):
             )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message=CONDOR_SUSPEND_FAILED_MESSAGE,
-            exit_code=1,
-            stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_RUNNING,
-            stdout="",
-            stdin="",
-        ),
+        [
+            CommandExecutionFailure(
+                message=CONDOR_SUSPEND_FAILED_MESSAGE,
+                exit_code=1,
+                stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_RUNNING,
+                stdout="",
+                stdin="",
+            ),
+        ]
     )
     def test_stop_resource_failed_redo_not_running(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
@@ -430,14 +475,15 @@ class TestHTCondorSiteAdapter(TestCase):
             )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message=CONDOR_SUSPEND_FAILED_MESSAGE,
-            exit_code=2,
-            stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
-            stdout="",
-            stdin="",
-        ),
+        [
+            CommandExecutionFailure(
+                message=CONDOR_SUSPEND_FAILED_MESSAGE,
+                exit_code=2,
+                stderr=CONDOR_SUSPEND_FAILED_OUTPUT_NOT_FOUND,
+                stdout="",
+                stdin="",
+            ),
+        ]
     )
     def test_stop_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):
@@ -447,7 +493,11 @@ class TestHTCondorSiteAdapter(TestCase):
                 ),
             )
 
-    @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_RM_OUTPUT),
+        ]
+    )
     def test_terminate_resource(self):
         response = asyncio.run(
             self.adapter.terminate_resource(
@@ -456,7 +506,11 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         self.assertIsNone(response)
 
-    @mock_executor_run_command(stdout=CONDOR_RM_FAILED_OUTPUT)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=CONDOR_RM_FAILED_OUTPUT),
+        ]
+    )
     def test_terminate_resource_failed_redo(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
             asyncio.run(
@@ -466,14 +520,15 @@ class TestHTCondorSiteAdapter(TestCase):
             )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message=CONDOR_RM_FAILED_MESSAGE,
-            exit_code=2,
-            stderr=CONDOR_RM_FAILED_OUTPUT,
-            stdout="",
-            stdin="",
-        ),
+        [
+            CommandExecutionFailure(
+                message=CONDOR_RM_FAILED_MESSAGE,
+                exit_code=2,
+                stderr=CONDOR_RM_FAILED_OUTPUT,
+                stdout="",
+                stdin="",
+            ),
+        ]
     )
     def test_terminate_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -5,11 +5,11 @@ from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import mock_executor_run_command
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
 from unittest.mock import patch
 
+import asyncio
 import logging
 
 CONDOR_SUBMIT_OUTPUT = """Submitting job(s)
@@ -160,14 +160,15 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource_htcondor_obs(self):
-        response = run_async(
-            self.adapter.deploy_resource,
-            AttributeDict(
-                drone_uuid="test-123",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1024,
-                    Disk=1024 * 1024,
+        response = asyncio.run(
+            self.adapter.deploy_resource(
+                AttributeDict(
+                    drone_uuid="test-123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1024,
+                        Disk=1024 * 1024,
+                    ),
                 ),
             ),
         )
@@ -178,16 +179,18 @@ class TestHTCondorSiteAdapter(TestCase):
             kwargs["stdin_input"],
             CONDOR_SUBMIT_JDL_CONDOR_OBS,
         )
+
         self.mock_executor.reset()
 
-        run_async(
-            self.adapter.deploy_resource,
-            AttributeDict(
-                drone_uuid="test-123",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1,
-                    Disk=1,
+        asyncio.run(
+            self.adapter.deploy_resource(
+                AttributeDict(
+                    drone_uuid="test-123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1,
+                        Disk=1,
+                    ),
                 ),
             ),
         )
@@ -205,12 +208,13 @@ class TestHTCondorSiteAdapter(TestCase):
 
         # "queue 1" deprecation
         with self.assertWarns(FutureWarning):
-            run_async(
-                self.adapter.deploy_resource,
-                AttributeDict(
-                    drone_uuid="test-123",
-                    obs_machine_meta_data_translation_mapping=AttributeDict(
-                        Cores=1, Memory=1, Disk=1
+            asyncio.run(
+                self.adapter.deploy_resource(
+                    AttributeDict(
+                        drone_uuid="test-123",
+                        obs_machine_meta_data_translation_mapping=AttributeDict(
+                            Cores=1, Memory=1, Disk=1
+                        ),
                     ),
                 ),
             )
@@ -220,14 +224,15 @@ class TestHTCondorSiteAdapter(TestCase):
             machine_type="test2large_args", site_name="TestSite"
         )
 
-        run_async(
-            self.adapter.deploy_resource,
-            AttributeDict(
-                drone_uuid="test-123",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1024,
-                    Disk=1024 * 1024,
+        asyncio.run(
+            self.adapter.deploy_resource(
+                AttributeDict(
+                    drone_uuid="test-123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1024,
+                        Disk=1024 * 1024,
+                    ),
                 ),
             ),
         )
@@ -244,14 +249,15 @@ class TestHTCondorSiteAdapter(TestCase):
         )
 
         # Test support for submit options
-        run_async(
-            self.adapter.deploy_resource,
-            AttributeDict(
-                drone_uuid="test-123",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1024,
-                    Disk=1024 * 1024,
+        asyncio.run(
+            self.adapter.deploy_resource(
+                AttributeDict(
+                    drone_uuid="test-123",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1024,
+                        Disk=1024 * 1024,
+                    ),
                 ),
             ),
         )
@@ -267,14 +273,15 @@ class TestHTCondorSiteAdapter(TestCase):
         )
         with self.assertLogs(logging.getLogger(), logging.ERROR):
             with self.assertRaises(KeyError):
-                run_async(
-                    self.adapter.deploy_resource,
-                    AttributeDict(
-                        drone_uuid="test-123",
-                        obs_machine_meta_data_translation_mapping=AttributeDict(
-                            Cores=1,
-                            Memory=1024,
-                            Disk=1024 * 1024,
+                asyncio.run(
+                    self.adapter.deploy_resource(
+                        AttributeDict(
+                            drone_uuid="test-123",
+                            obs_machine_meta_data_translation_mapping=AttributeDict(
+                                Cores=1,
+                                Memory=1024,
+                                Disk=1024 * 1024,
+                            ),
                         ),
                     ),
                 )
@@ -292,57 +299,64 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_IDLE)
     def test_resource_status_idle(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Booting)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_RUN)
     def test_resource_status_run(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_REMOVING)
     def test_resource_status_removing(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_COMPLETED)
     def test_resource_status_completed(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_HELD)
     def test_resource_status_held(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Error)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_TRANSFERING_OUTPUT)
     def test_resource_status_transfering_output(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Running)
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_SUSPENDED)
     def test_resource_status_unexpanded(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
@@ -355,25 +369,27 @@ class TestHTCondorSiteAdapter(TestCase):
     def test_resource_status_command_execution_error(self):
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(
-                    self.adapter.resource_status,
-                    AttributeDict(
-                        remote_resource_uuid="1351043.0",
+                asyncio.run(
+                    self.adapter.resource_status(
+                        AttributeDict(
+                            remote_resource_uuid="1351043.0",
+                        )
                     ),
                 )
 
     @mock_executor_run_command(stdout=CONDOR_Q_OUTPUT_DOES_NOT_EXISTS)
     def test_resource_status_already_deleted(self):
-        response = run_async(
-            self.adapter.resource_status,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.resource_status(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
     @mock_executor_run_command(stdout=CONDOR_SUSPEND_OUTPUT)
     def test_stop_resource(self):
-        response = run_async(
-            self.adapter.stop_resource, AttributeDict(remote_resource_uuid="1351043.0")
+        response = asyncio.run(
+            self.adapter.stop_resource(AttributeDict(remote_resource_uuid="1351043.0"))
         )
         self.assertIsNone(response)
 
@@ -389,9 +405,10 @@ class TestHTCondorSiteAdapter(TestCase):
     )
     def test_stop_resource_failed_redo_not_found(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            run_async(
-                self.adapter.stop_resource,
-                AttributeDict(remote_resource_uuid="1351043.0"),
+            asyncio.run(
+                self.adapter.stop_resource(
+                    AttributeDict(remote_resource_uuid="1351043.0")
+                ),
             )
 
     @mock_executor_run_command(
@@ -406,9 +423,10 @@ class TestHTCondorSiteAdapter(TestCase):
     )
     def test_stop_resource_failed_redo_not_running(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            run_async(
-                self.adapter.stop_resource,
-                AttributeDict(remote_resource_uuid="1351043.0"),
+            asyncio.run(
+                self.adapter.stop_resource(
+                    AttributeDict(remote_resource_uuid="1351043.0")
+                ),
             )
 
     @mock_executor_run_command(
@@ -423,25 +441,28 @@ class TestHTCondorSiteAdapter(TestCase):
     )
     def test_stop_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(
-                self.adapter.stop_resource,
-                AttributeDict(remote_resource_uuid="1351043.0"),
+            asyncio.run(
+                self.adapter.stop_resource(
+                    AttributeDict(remote_resource_uuid="1351043.0")
+                ),
             )
 
     @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
-        response = run_async(
-            self.adapter.terminate_resource,
-            AttributeDict(remote_resource_uuid="1351043.0"),
+        response = asyncio.run(
+            self.adapter.terminate_resource(
+                AttributeDict(remote_resource_uuid="1351043.0")
+            ),
         )
         self.assertIsNone(response)
 
     @mock_executor_run_command(stdout=CONDOR_RM_FAILED_OUTPUT)
     def test_terminate_resource_failed_redo(self):
         with self.assertRaises(TardisResourceStatusUpdateFailed):
-            run_async(
-                self.adapter.terminate_resource,
-                AttributeDict(remote_resource_uuid="1351043.0"),
+            asyncio.run(
+                self.adapter.terminate_resource(
+                    AttributeDict(remote_resource_uuid="1351043.0")
+                ),
             )
 
     @mock_executor_run_command(
@@ -456,9 +477,10 @@ class TestHTCondorSiteAdapter(TestCase):
     )
     def test_terminate_resource_failed_raise(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(
-                self.adapter.terminate_resource,
-                AttributeDict(remote_resource_uuid="1351043.0"),
+            asyncio.run(
+                self.adapter.terminate_resource(
+                    AttributeDict(remote_resource_uuid="1351043.0")
+                ),
             )
 
     def test_exception_handling(self):

--- a/tests/adapters_t/sites_t/test_kubernetes.py
+++ b/tests/adapters_t/sites_t/test_kubernetes.py
@@ -3,12 +3,11 @@ from tardis.exceptions.tardisexceptions import TardisError
 from kubernetes_asyncio.client.rest import ApiException as K8SApiException
 from tardis.utilities.attributedict import AttributeDict
 from tardis.interfaces.siteadapter import ResourceStatus
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
+import asyncio
 import logging
 from kubernetes_asyncio import client
 
@@ -94,7 +93,7 @@ class TestKubernetesStackAdapter(TestCase):
             metadata=client.V1ObjectMeta(name="testsite-089123", uid="123456"),
             spec=spec,
         )
-        kubernetes_api.create_namespaced_deployment.return_value = async_return(
+        kubernetes_api.create_namespaced_deployment = AsyncMock(
             return_value=self.create_return_value
         )
         condition_list = [
@@ -108,20 +107,16 @@ class TestKubernetesStackAdapter(TestCase):
             spec=spec,
             status=client.V1DeploymentStatus(conditions=condition_list),
         )
-        kubernetes_api.read_namespaced_deployment.return_value = async_return(
+        kubernetes_api.read_namespaced_deployment = AsyncMock(
             return_value=self.read_return_value
         )
-        kubernetes_api.replace_namespaced_deployment.return_value = async_return(
+        kubernetes_api.replace_namespaced_deployment = AsyncMock(return_value=None)
+        kubernetes_api.delete_namespaced_deployment = AsyncMock(return_value=None)
+        kubernetes_hpa.create_namespaced_horizontal_pod_autoscaler = AsyncMock(
             return_value=None
         )
-        kubernetes_api.delete_namespaced_deployment.return_value = async_return(
+        kubernetes_hpa.delete_namespaced_horizontal_pod_autoscaler = AsyncMock(
             return_value=None
-        )
-        kubernetes_hpa.create_namespaced_horizontal_pod_autoscaler.return_value = (
-            async_return(return_value=None)
-        )
-        kubernetes_hpa.delete_namespaced_horizontal_pod_autoscaler.return_value = (
-            async_return(return_value=None)
         )
         self.kubernetes_adapter = KubernetesAdapter(
             machine_type="test2large", site_name="TestSite"
@@ -135,7 +130,7 @@ class TestKubernetesStackAdapter(TestCase):
         kubernetes_api = self.mock_kubernetes_api.return_value
         self.read_return_value.spec.replicas = replicas
         self.read_return_value.status.available_replicas = available_replicas
-        kubernetes_api.read_namespaced_deployment.return_value = async_return(
+        kubernetes_api.read_namespaced_deployment = AsyncMock(
             return_value=self.read_return_value
         )
 
@@ -155,15 +150,16 @@ class TestKubernetesStackAdapter(TestCase):
     @patch("kubernetes_asyncio.client.rest.aiohttp")
     def test_deploy_resource(self, mocked_aiohttp):
         self.assertEqual(
-            run_async(
-                self.kubernetes_adapter.deploy_resource,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123",
-                    remote_resource_uuid="123456",
-                    obs_machine_meta_data_translation_mapping=AttributeDict(
-                        Cores=1, Memory=1024, Disk=1024 * 1024
+            asyncio.run(
+                self.kubernetes_adapter.deploy_resource(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123",
+                        remote_resource_uuid="123456",
+                        obs_machine_meta_data_translation_mapping=AttributeDict(
+                            Cores=1, Memory=1024, Disk=1024 * 1024
+                        ),
                     ),
-                ),
+                )
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
@@ -190,11 +186,12 @@ class TestKubernetesStackAdapter(TestCase):
     def test_resource_status(self, mocked_aiohttp):
         self.update_read_return(replicas=1, available_replicas=1)
         self.assertEqual(
-            run_async(
-                self.kubernetes_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                ),
+            asyncio.run(
+                self.kubernetes_adapter.resource_status(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    ),
+                )
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
@@ -206,11 +203,12 @@ class TestKubernetesStackAdapter(TestCase):
         )
         self.update_read_return(replicas=0, available_replicas=1)
         self.assertEqual(
-            run_async(
-                self.kubernetes_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                ),
+            asyncio.run(
+                self.kubernetes_adapter.resource_status(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    ),
+                )
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
@@ -219,11 +217,12 @@ class TestKubernetesStackAdapter(TestCase):
         )
         self.update_read_return(replicas=1, available_replicas=None)
         self.assertEqual(
-            run_async(
-                self.kubernetes_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                ),
+            asyncio.run(
+                self.kubernetes_adapter.resource_status(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    ),
+                )
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
@@ -232,11 +231,12 @@ class TestKubernetesStackAdapter(TestCase):
         )
         self.update_read_side_effect(exception=K8SApiException(status=404))
         self.assertEqual(
-            run_async(
-                self.kubernetes_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                ),
+            asyncio.run(
+                self.kubernetes_adapter.resource_status(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                    ),
+                )
             ),
             AttributeDict(
                 remote_resource_uuid="123456",
@@ -246,11 +246,12 @@ class TestKubernetesStackAdapter(TestCase):
         self.update_read_side_effect(exception=K8SApiException(status=500))
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(K8SApiException):
-                run_async(
-                    self.kubernetes_adapter.resource_status,
-                    resource_attributes=AttributeDict(
-                        drone_uuid="testsite-089123", remote_resource_uuid="123456"
-                    ),
+                asyncio.run(
+                    self.kubernetes_adapter.resource_status(
+                        resource_attributes=AttributeDict(
+                            drone_uuid="testsite-089123", remote_resource_uuid="123456"
+                        ),
+                    )
                 )
             self.update_read_side_effect(exception=None)
 
@@ -265,9 +266,10 @@ class TestKubernetesStackAdapter(TestCase):
                 )
             ]
         )
-        run_async(
-            self.kubernetes_adapter.stop_resource,
-            resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+        asyncio.run(
+            self.kubernetes_adapter.stop_resource(
+                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            )
         )
         self.mock_kubernetes_api.return_value.read_namespaced_deployment.assert_called_with(  # noqa: B950
             name="testsite-089123", namespace="default"
@@ -278,9 +280,10 @@ class TestKubernetesStackAdapter(TestCase):
 
     @patch("kubernetes_asyncio.client.rest.aiohttp")
     def test_terminate_resource(self, mocked_aiohttp):
-        run_async(
-            self.kubernetes_adapter.terminate_resource,
-            resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+        asyncio.run(
+            self.kubernetes_adapter.terminate_resource(
+                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            )
         )
         self.mock_kubernetes_api.return_value.delete_namespaced_deployment.assert_called_with(  # noqa: B950
             name="testsite-089123",
@@ -292,17 +295,19 @@ class TestKubernetesStackAdapter(TestCase):
         self.update_delete_side_effect(exception=K8SApiException(status=500))
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(K8SApiException):
-                run_async(
-                    self.kubernetes_adapter.terminate_resource,
-                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                asyncio.run(
+                    self.kubernetes_adapter.terminate_resource(
+                        resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                    )
                 )
         self.update_delete_side_effect(exception=None)
         self.update_delete_hpa_side_effect(exception=K8SApiException(status=500))
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(K8SApiException):
-                run_async(
-                    self.kubernetes_adapter.terminate_resource,
-                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                asyncio.run(
+                    self.kubernetes_adapter.terminate_resource(
+                        resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                    )
                 )
         self.update_delete_hpa_side_effect(exception=None)
 

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -220,7 +220,11 @@ class TestMoabAdapter(TestCase):
                 machine_type="test2large", site_name="TestSite"
             )
 
-    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+        ]
+    )
     def test_deploy_resource(self):
         self.assertDictEqual(
             AttributeDict(
@@ -237,7 +241,11 @@ class TestMoabAdapter(TestCase):
             "msub -j oe -m p -l walltime=02:00:00:00,mem=120gb,nodes=1:ppn=20 -v TardisDroneCores=128,TardisDroneMemory=120,TardisDroneDisk=100,TardisDroneUuid=testsite-abcdef startVM.py"  # noqa: B950
         )
 
-    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+        ]
+    )
     def test_deploy_resource_w_submit_options(self):
         self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = (
             AttributeDict(
@@ -267,7 +275,12 @@ class TestMoabAdapter(TestCase):
     def test_site_name(self):
         self.assertEqual(self.moab_adapter.site_name, "TestSite")
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+        ]
+    )
     def test_resource_status(self):
         self.assertDictEqual(
             AttributeDict(
@@ -280,7 +293,11 @@ class TestMoabAdapter(TestCase):
             ),
         )
 
-    @mock_executor_run_command(TEST_RESOURCE_STATE_TRANSLATION_RESPONSE)
+    @mock_executor_run_command(
+        # Multiplies the single-item list by the exact number of expected calls
+        [AttributeDict(stdout=TEST_RESOURCE_STATE_TRANSLATION_RESPONSE)]
+        * (2 * len(STATE_TRANSLATIONS))
+    )
     def test_resource_state_translation(self):
         self.mock_executor.reset_mock()
         for num, (_, state) in enumerate(STATE_TRANSLATIONS):
@@ -300,7 +317,12 @@ class TestMoabAdapter(TestCase):
             )
             self.mock_executor.reset_mock()
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+        ]
+    )
     def test_resource_status_update(self):
         self.assertEqual(
             self.resource_attributes["resource_status"], ResourceStatus.Booting
@@ -317,7 +339,11 @@ class TestMoabAdapter(TestCase):
             ),
         )
 
-    @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_TERMINATE_RESOURCE_RESPONSE),
+        ]
+    )
     def test_stop_resource(self):
         asyncio.run(
             self.moab_adapter.stop_resource(
@@ -328,7 +354,11 @@ class TestMoabAdapter(TestCase):
             "canceljob 4761849"
         )
 
-    @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_TERMINATE_RESOURCE_RESPONSE),
+        ]
+    )
     def test_terminate_resource(self):
         asyncio.run(
             self.moab_adapter.terminate_resource(
@@ -340,15 +370,14 @@ class TestMoabAdapter(TestCase):
         )
 
     @mock_executor_run_command(
-        "",
-        stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
-        exit_code=1,
-        raise_exception=CommandExecutionFailure(
-            message="Test",
-            stdout="",
-            stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
-            exit_code=1,
-        ),
+        [
+            CommandExecutionFailure(
+                message="Test",
+                exit_code=1,
+                stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
+                stdout="",
+            ),
+        ]
     )
     def test_terminate_dead_resource(self):
         with self.assertLogs(level=logging.WARNING):
@@ -359,11 +388,9 @@ class TestMoabAdapter(TestCase):
             )
 
     @mock_executor_run_command(
-        "",
-        exit_code=2,
-        raise_exception=CommandExecutionFailure(
-            message="Test", stdout="", stderr="", exit_code=2
-        ),
+        [
+            CommandExecutionFailure(message="Test", stdout="", stderr="", exit_code=2),
+        ]
     )
     def test_terminate_resource_error(self):
         with self.assertRaises(CommandExecutionFailure):
@@ -374,10 +401,11 @@ class TestMoabAdapter(TestCase):
             )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-        ),
+        [
+            CommandExecutionFailure(
+                message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+            ),
+        ]
     )
     def test_resource_status_update_failed(self):
         with self.assertRaises(CommandExecutionFailure):
@@ -391,7 +419,12 @@ class TestMoabAdapter(TestCase):
                 )
             )
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+        ]
+    )
     def test_resource_status_of_completed_jobs(self):
         response = asyncio.run(
             self.moab_adapter.resource_status(

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -6,7 +6,6 @@ from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import mock_executor_run_command
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
@@ -227,9 +226,10 @@ class TestMoabAdapter(TestCase):
             AttributeDict(
                 remote_resource_uuid=4761849, resource_status=ResourceStatus.Booting
             ),
-            run_async(
-                self.moab_adapter.deploy_resource,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.moab_adapter.deploy_resource(
+                    resource_attributes=self.resource_attributes,
+                )
             ),
         )
 
@@ -246,9 +246,10 @@ class TestMoabAdapter(TestCase):
             )
         )
 
-        run_async(
-            self.moab_adapter.deploy_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            self.moab_adapter.deploy_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -272,9 +273,10 @@ class TestMoabAdapter(TestCase):
             AttributeDict(
                 remote_resource_uuid=4761849, resource_status=ResourceStatus.Booting
             ),
-            run_async(
-                self.moab_adapter.resource_status,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.moab_adapter.resource_status(
+                    resource_attributes=self.resource_attributes,
+                )
             ),
         )
 
@@ -283,9 +285,10 @@ class TestMoabAdapter(TestCase):
         self.mock_executor.reset_mock()
         for num, (_, state) in enumerate(STATE_TRANSLATIONS):
             job_id = f"76242{num:02}"
-            return_resource_attributes = run_async(
-                self.moab_adapter.resource_status,
-                AttributeDict(remote_resource_uuid=job_id),
+            return_resource_attributes = asyncio.run(
+                self.moab_adapter.resource_status(
+                    AttributeDict(remote_resource_uuid=job_id),
+                )
             )
             self.assertEqual(return_resource_attributes.resource_status, state)
 
@@ -307,17 +310,19 @@ class TestMoabAdapter(TestCase):
             AttributeDict(
                 remote_resource_uuid=4761849, resource_status=ResourceStatus.Running
             ),
-            run_async(
-                self.moab_adapter.resource_status,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.moab_adapter.resource_status(
+                    resource_attributes=self.resource_attributes,
+                )
             ),
         )
 
     @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
     def test_stop_resource(self):
-        run_async(
-            self.moab_adapter.stop_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            self.moab_adapter.stop_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
         self.mock_executor.return_value.run_command.assert_called_with(
             "canceljob 4761849"
@@ -325,9 +330,10 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(TEST_TERMINATE_RESOURCE_RESPONSE)
     def test_terminate_resource(self):
-        run_async(
-            self.moab_adapter.terminate_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            self.moab_adapter.terminate_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
         self.mock_executor.return_value.run_command.assert_called_with(
             "canceljob 4761849"
@@ -346,9 +352,10 @@ class TestMoabAdapter(TestCase):
     )
     def test_terminate_dead_resource(self):
         with self.assertLogs(level=logging.WARNING):
-            run_async(
-                self.moab_adapter.terminate_resource,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.moab_adapter.terminate_resource(
+                    resource_attributes=self.resource_attributes,
+                )
             )
 
     @mock_executor_run_command(
@@ -360,9 +367,10 @@ class TestMoabAdapter(TestCase):
     )
     def test_terminate_resource_error(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(
-                self.moab_adapter.terminate_resource,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.moab_adapter.terminate_resource(
+                    resource_attributes=self.resource_attributes,
+                )
             )
 
     @mock_executor_run_command(
@@ -373,23 +381,25 @@ class TestMoabAdapter(TestCase):
     )
     def test_resource_status_update_failed(self):
         with self.assertRaises(CommandExecutionFailure):
-            run_async(
-                self.moab_adapter.resource_status,
-                AttributeDict(
-                    resource_id=1351043,
-                    remote_resource_uuid=1351043,
-                    resource_state=ResourceStatus.Booting,
-                ),
+            asyncio.run(
+                self.moab_adapter.resource_status(
+                    AttributeDict(
+                        resource_id=1351043,
+                        remote_resource_uuid=1351043,
+                        resource_state=ResourceStatus.Booting,
+                    ),
+                )
             )
 
     @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
     def test_resource_status_of_completed_jobs(self):
-        response = run_async(
-            self.moab_adapter.resource_status,
-            AttributeDict(
-                resource_id=1390065,
-                remote_resource_uuid=1351043,
-            ),
+        response = asyncio.run(
+            self.moab_adapter.resource_status(
+                AttributeDict(
+                    resource_id=1390065,
+                    remote_resource_uuid=1351043,
+                ),
+            )
         )
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -222,7 +222,9 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+            AttributeDict(
+                stdout=TEST_DEPLOY_RESOURCE_RESPONSE
+            ),  # msub call in deploy_resource
         ]
     )
     def test_deploy_resource(self):
@@ -243,7 +245,9 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+            AttributeDict(
+                stdout=TEST_DEPLOY_RESOURCE_RESPONSE
+            ),  # msub call in deploy_resource_w_submit_options
         ]
     )
     def test_deploy_resource_w_submit_options(self):
@@ -277,9 +281,11 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE
+            ),  # showq call in resource_status, called twice in resource_status
         ]
+        * 2
     )
     def test_resource_status(self):
         self.assertDictEqual(
@@ -295,8 +301,12 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         # Multiplies the single-item list by the exact number of expected calls
-        [AttributeDict(stdout=TEST_RESOURCE_STATE_TRANSLATION_RESPONSE)]
-        * (2 * len(STATE_TRANSLATIONS))
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATE_TRANSLATION_RESPONSE)
+        ]  # showq call in resource_status, called twice per resource_status call
+        * (
+            2 * len(STATE_TRANSLATIONS)
+        )  # called len(STATE_TRANSLATIONS) times in this test
     )
     def test_resource_state_translation(self):
         self.mock_executor.reset_mock()
@@ -319,9 +329,11 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING
+            ),  # showq call in resource_status, called twice in resource_status
         ]
+        * 2
     )
     def test_resource_status_update(self):
         self.assertEqual(
@@ -341,7 +353,9 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_TERMINATE_RESOURCE_RESPONSE),
+            AttributeDict(
+                stdout=TEST_TERMINATE_RESOURCE_RESPONSE
+            ),  # canceljob call in stop_resource
         ]
     )
     def test_stop_resource(self):
@@ -356,7 +370,9 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_TERMINATE_RESOURCE_RESPONSE),
+            AttributeDict(
+                stdout=TEST_TERMINATE_RESOURCE_RESPONSE
+            ),  # canceljob call in terminate_resource
         ]
     )
     def test_terminate_resource(self):
@@ -376,7 +392,7 @@ class TestMoabAdapter(TestCase):
                 exit_code=1,
                 stderr=TEST_TERMINATE_DEAD_RESOURCE_RESPONSE,
                 stdout="",
-            ),
+            ),  # canceljob call in terminate_resource
         ]
     )
     def test_terminate_dead_resource(self):
@@ -389,7 +405,9 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            CommandExecutionFailure(message="Test", stdout="", stderr="", exit_code=2),
+            CommandExecutionFailure(
+                message="Test", stdout="", stderr="", exit_code=2
+            ),  # canceljob call in terminate_resource
         ]
     )
     def test_terminate_resource_error(self):
@@ -404,7 +422,7 @@ class TestMoabAdapter(TestCase):
         [
             CommandExecutionFailure(
                 message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-            ),
+            ),  # showq call in resource_status
         ]
     )
     def test_resource_status_update_failed(self):
@@ -421,9 +439,11 @@ class TestMoabAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING
+            ),  # showq call in resource_status
         ]
+        * 2
     )
     def test_resource_status_of_completed_jobs(self):
         response = asyncio.run(

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -6,7 +6,6 @@ from tardis.exceptions.tardisexceptions import TardisTimeout
 from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.utilities.attributedict import AttributeDict
 from tardis.interfaces.siteadapter import ResourceStatus
-from tests.utilities.utilities import async_return, run_async
 
 from aiohttp import ClientConnectionError
 from aiohttp import ContentTypeError
@@ -14,7 +13,7 @@ from simple_rest_client.exceptions import AuthError
 from simple_rest_client.exceptions import ClientError
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import asyncio
 import logging
@@ -59,14 +58,12 @@ class TestOpenStackAdapter(TestCase):
         )
 
         openstack_api = self.mock_openstack_api.return_value
-        openstack_api.init_api.return_value = async_return(return_value=None)
+        openstack_api.init_api = AsyncMock(return_value=None)
 
         self.create_return_value = AttributeDict(
             server=AttributeDict(name="testsite-089123")
         )
-        openstack_api.servers.create.return_value = async_return(
-            return_value=self.create_return_value
-        )
+        openstack_api.servers.create = AsyncMock(return_value=self.create_return_value)
 
         self.get_return_value = AttributeDict(
             server=AttributeDict(
@@ -77,19 +74,13 @@ class TestOpenStackAdapter(TestCase):
                 updated="2023-07-31T12:46:50Z",
             )
         )
-        openstack_api.servers.get.return_value = async_return(
-            return_value=self.get_return_value
-        )
+        openstack_api.servers.get = AsyncMock(return_value=self.get_return_value)
 
-        openstack_api.servers.run_action.return_value = async_return(return_value=None)
+        openstack_api.servers.run_action = AsyncMock(return_value=None)
 
-        openstack_api.servers.force_delete.return_value = async_return(
-            return_value=None
-        )
+        openstack_api.servers.force_delete = AsyncMock(return_value=None)
 
-        self.mock_openstack_api.return_value.init_api.return_value = async_return(
-            return_value=True
-        )
+        self.mock_openstack_api.return_value.init_api = AsyncMock(return_value=True)
         self.openstack_adapter = OpenStackAdapter(
             machine_type="test2large", site_name="TestSite"
         )
@@ -117,9 +108,10 @@ class TestOpenStackAdapter(TestCase):
 
     def test_deploy_resource(self):
         self.assertEqual(
-            run_async(
-                self.openstack_adapter.deploy_resource,
-                resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+            asyncio.run(
+                self.openstack_adapter.deploy_resource(
+                    resource_attributes=AttributeDict(drone_uuid="testsite-089123"),
+                )
             ),
             AttributeDict(drone_uuid="testsite-089123"),
         )
@@ -147,12 +139,13 @@ class TestOpenStackAdapter(TestCase):
 
     def test_resource_status(self):
         self.assertEqual(
-            run_async(
-                self.openstack_adapter.resource_status,
-                resource_attributes=AttributeDict(
-                    drone_uuid="testsite-089123",
-                    remote_resource_uuid="029312-1231-123123",
-                    resource_status=ResourceStatus.Booting,
+            asyncio.run(
+                self.openstack_adapter.resource_status(
+                    resource_attributes=AttributeDict(
+                        drone_uuid="testsite-089123",
+                        remote_resource_uuid="029312-1231-123123",
+                        resource_status=ResourceStatus.Booting,
+                    )
                 ),
             ),
             AttributeDict(
@@ -167,11 +160,12 @@ class TestOpenStackAdapter(TestCase):
         )
 
     def test_stop_resource(self):
-        run_async(
-            self.openstack_adapter.stop_resource,
-            resource_attributes=AttributeDict(
-                remote_resource_uuid="029312-1231-123123"
-            ),
+        asyncio.run(
+            self.openstack_adapter.stop_resource(
+                resource_attributes=AttributeDict(
+                    remote_resource_uuid="029312-1231-123123"
+                )
+            )
         )
         params = {"os-stop": None}
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
@@ -180,11 +174,12 @@ class TestOpenStackAdapter(TestCase):
         )
 
     def test_terminate_resource(self):
-        run_async(
-            self.openstack_adapter.terminate_resource,
-            resource_attributes=AttributeDict(
-                remote_resource_uuid="029312-1231-123123"
-            ),
+        asyncio.run(
+            self.openstack_adapter.terminate_resource(
+                resource_attributes=AttributeDict(
+                    remote_resource_uuid="029312-1231-123123"
+                )
+            )
         )
 
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -148,9 +148,8 @@ class TestSlurmAdapter(TestCase):
     @mock_executor_run_command(
         [
             AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
-            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
-            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
-        ]
+        ]  # sbatch call in deploy_resource, called 3 times in test
+        * 3
     )
     def test_deploy_resource(self):
         resource_attributes = AttributeDict(
@@ -197,7 +196,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+            AttributeDict(
+                stdout=TEST_DEPLOY_RESOURCE_RESPONSE
+            ),  # sbatch call in deploy_resource
         ]
     )
     def test_deploy_resource_w_submit_options(self):
@@ -239,7 +240,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE
+            ),  # squeue call in resource_status
         ]
     )
     def test_resource_status(self):
@@ -260,7 +263,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE
+            ),  # squeue call in resource_status
         ]
     )
     def test_resource_status_w_options(self):
@@ -290,7 +295,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+            AttributeDict(
+                stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING
+            ),  # squeue call in resource_status
         ]
     )
     def test_update_resource_status(self):
@@ -315,7 +322,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         # Return 24 times (the number of states in state_translations dictionary)
-        [AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_ALL_STATES)]
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_ALL_STATES)
+        ]  # squeue call in resource_status
         * 24
     )
     def test_resource_state_translation(self):
@@ -365,7 +374,7 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=""),
+            AttributeDict(stdout=""),  # squeue call in resource_status
         ]
     )
     def test_resource_status_of_completed_jobs_w_empty_reply(self):
@@ -386,13 +395,13 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout=""),
+            AttributeDict(stdout=""),  # squeue call in resource_status
             CommandExecutionFailure(
                 message="Run command squeue --job=1351043 via SSHExecutor failed",
                 stdout="",
                 stderr="slurm_load_jobs error: Invalid job id specified",
                 exit_code=1,
-            ),
+            ),  # squeue call in resource_status (2nd call in test)
         ]
     )
     def test_resource_status_of_completed_jobs_w_raised_exception(self):
@@ -444,7 +453,7 @@ class TestSlurmAdapter(TestCase):
         [
             CommandExecutionFailure(
                 message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-            ),
+            ),  # squeue call in resource_status
         ]
     )
     def test_resource_status_update_failed(self):
@@ -462,7 +471,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout="", stderr="", exit_code=0),
+            AttributeDict(
+                stdout="", stderr="", exit_code=0
+            ),  # scancel call in stop_resource
         ]
     )
     def test_stop_resource(self):
@@ -478,7 +489,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout="", stderr="", exit_code=0),
+            AttributeDict(
+                stdout="", stderr="", exit_code=0
+            ),  # scancel call in terminate_resource
         ]
     )
     def test_terminate_resource(self):
@@ -494,7 +507,9 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(
         [
-            AttributeDict(stdout="", stderr="", exit_code=0),
+            AttributeDict(
+                stdout="", stderr="", exit_code=0
+            ),  # scancel call in terminate_resource
         ]
     )
     def test_terminate_resource_w_options(self):

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -5,7 +5,7 @@ from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
-from tests.utilities.utilities import mock_executor_run_command, run_async
+from tests.utilities.utilities import mock_executor_run_command
 
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -93,7 +93,10 @@ class TestSlurmAdapter(TestCase):
         self.test_site_config.StatusUpdate = 10
         self.test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         self.test_site_config.executor = self.mock_executor.return_value
-        self.test_site_config.bulk_delay = 0.01
+        # set to smallest positive float
+        # prevents BulkCall from blocking indefinitely on _get_bulk() when
+        # the event loop is closed before the semaphore is released by asyncio.run
+        self.test_site_config.bulk_delay = 0.01  # sys.float_info.min
 
         self.slurm_adapter = SlurmAdapter(
             machine_type="test2large", site_name="TestSite"
@@ -158,7 +161,7 @@ class TestSlurmAdapter(TestCase):
             AttributeDict(
                 remote_resource_uuid=1390065, resource_status=ResourceStatus.Booting
             ),
-            run_async(self.slurm_adapter.deploy_resource, resource_attributes),
+            asyncio.run(self.slurm_adapter.deploy_resource(resource_attributes)),
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -169,7 +172,7 @@ class TestSlurmAdapter(TestCase):
 
         self.test_site_config.MachineMetaData.test2large.Memory = 2.5
 
-        run_async(self.slurm_adapter.deploy_resource, resource_attributes)
+        asyncio.run(self.slurm_adapter.deploy_resource(resource_attributes))
 
         self.mock_executor.return_value.run_command.assert_called_with(
             "sbatch -p normal -N 1 -n 20 -t 60 --mem=2560mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2560,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
@@ -179,7 +182,7 @@ class TestSlurmAdapter(TestCase):
 
         self.test_site_config.MachineMetaData.test2large.Memory = 2.546372129
 
-        run_async(self.slurm_adapter.deploy_resource, resource_attributes)
+        asyncio.run(self.slurm_adapter.deploy_resource(resource_attributes))
 
         self.mock_executor.return_value.run_command.assert_called_with(
             "sbatch -p normal -N 1 -n 20 -t 60 --mem=2607mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2607,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
@@ -193,18 +196,19 @@ class TestSlurmAdapter(TestCase):
 
         slurm_adapter = SlurmAdapter(machine_type="test2large", site_name="TestSite")
 
-        run_async(
-            slurm_adapter.deploy_resource,
-            resource_attributes=AttributeDict(
-                machine_type="test2large",
-                site_name="TestSite",
-                obs_machine_meta_data_translation_mapping=AttributeDict(
-                    Cores=1,
-                    Memory=1000,
-                    Disk=1000,
+        asyncio.run(
+            slurm_adapter.deploy_resource(
+                resource_attributes=AttributeDict(
+                    machine_type="test2large",
+                    site_name="TestSite",
+                    obs_machine_meta_data_translation_mapping=AttributeDict(
+                        Cores=1,
+                        Memory=1000,
+                        Disk=1000,
+                    ),
+                    drone_uuid="testsite-1390065",
                 ),
-                drone_uuid="testsite-1390065",
-            ),
+            )
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -228,9 +232,10 @@ class TestSlurmAdapter(TestCase):
             AttributeDict(
                 resource_status=ResourceStatus.Booting, remote_resource_uuid=1390065
             ),
-            run_async(
-                self.slurm_adapter.resource_status,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.slurm_adapter.resource_status(
+                    resource_attributes=self.resource_attributes,
+                ),
             ),
         )
 
@@ -253,9 +258,10 @@ class TestSlurmAdapter(TestCase):
             AttributeDict(
                 resource_status=ResourceStatus.Booting, remote_resource_uuid=1390065
             ),
-            run_async(
-                slurm_adapter.resource_status,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                slurm_adapter.resource_status(
+                    resource_attributes=self.resource_attributes,
+                ),
             ),
         )
 
@@ -273,9 +279,10 @@ class TestSlurmAdapter(TestCase):
             AttributeDict(
                 resource_status=ResourceStatus.Running, remote_resource_uuid=1390065
             ),
-            run_async(
-                self.slurm_adapter.resource_status,
-                resource_attributes=self.resource_attributes,
+            asyncio.run(
+                self.slurm_adapter.resource_status(
+                    resource_attributes=self.resource_attributes,
+                ),
             ),
         )
 
@@ -314,9 +321,10 @@ class TestSlurmAdapter(TestCase):
 
         for id, value in enumerate(state_translations.values()):
             job_id = int(f"{id + 1000}000")
-            returned_resource_attributes = run_async(
-                self.slurm_adapter.resource_status,
-                AttributeDict(remote_resource_uuid=job_id),
+            returned_resource_attributes = asyncio.run(
+                self.slurm_adapter.resource_status(
+                    AttributeDict(remote_resource_uuid=job_id),
+                )
             )
             self.assertEqual(returned_resource_attributes.resource_status, value)
 
@@ -330,12 +338,13 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command("")
     def test_resource_status_of_completed_jobs_w_empty_reply(self):
-        response = run_async(
-            self.slurm_adapter.resource_status,
-            AttributeDict(
-                resource_id="1390065",
-                remote_resource_uuid="1351043",
-            ),
+        response = asyncio.run(
+            self.slurm_adapter.resource_status(
+                AttributeDict(
+                    resource_id="1390065",
+                    remote_resource_uuid="1351043",
+                ),
+            )
         )
 
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
@@ -354,12 +363,13 @@ class TestSlurmAdapter(TestCase):
         ),
     )
     def test_resource_status_of_completed_jobs_w_raised_exception(self):
-        response = run_async(
-            self.slurm_adapter.resource_status,
-            AttributeDict(
-                resource_id="1390065",
-                remote_resource_uuid="1351043",
-            ),
+        response = asyncio.run(
+            self.slurm_adapter.resource_status(
+                AttributeDict(
+                    resource_id="1390065",
+                    remote_resource_uuid="1351043",
+                ),
+            )
         )
 
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
@@ -386,9 +396,12 @@ class TestSlurmAdapter(TestCase):
             ),
         ]
 
+        async def run_gather():
+            return await asyncio.gather(*tasks)
+
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(asyncio.gather, *tasks)
+                asyncio.run(run_gather())
 
         self.mock_executor.return_value.run_command.assert_called_with(
             'squeue -o "%A|%N|%T" -h -t all --job=1351043,1351044'
@@ -403,9 +416,10 @@ class TestSlurmAdapter(TestCase):
     def test_resource_status_update_failed(self):
         with self.assertLogs(level=logging.WARNING):
             with self.assertRaises(CommandExecutionFailure):
-                run_async(
-                    self.slurm_adapter.resource_status,
-                    AttributeDict(remote_resource_uuid="1390065"),
+                asyncio.run(
+                    self.slurm_adapter.resource_status(
+                        AttributeDict(remote_resource_uuid="1390065"),
+                    )
                 )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -414,9 +428,10 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(stdout="", stderr="", exit_code=0)
     def test_stop_resource(self):
-        run_async(
-            self.slurm_adapter.stop_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            self.slurm_adapter.stop_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -425,9 +440,10 @@ class TestSlurmAdapter(TestCase):
 
     @mock_executor_run_command(stdout="", stderr="", exit_code=0)
     def test_terminate_resource(self):
-        run_async(
-            self.slurm_adapter.terminate_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            self.slurm_adapter.terminate_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(
@@ -445,9 +461,10 @@ class TestSlurmAdapter(TestCase):
 
         slurm_adapter = SlurmAdapter(machine_type="test2large", site_name="TestSite")
 
-        run_async(
-            slurm_adapter.terminate_resource,
-            resource_attributes=self.resource_attributes,
+        asyncio.run(
+            slurm_adapter.terminate_resource(
+                resource_attributes=self.resource_attributes,
+            )
         )
 
         self.mock_executor.return_value.run_command.assert_called_with(

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -7,6 +7,7 @@ from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import mock_executor_run_command
 
+
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -144,7 +145,13 @@ class TestSlurmAdapter(TestCase):
                 machine_type="test2large", site_name="TestSite"
             )
 
-    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+        ]
+    )
     def test_deploy_resource(self):
         resource_attributes = AttributeDict(
             machine_type="test2large",
@@ -188,7 +195,11 @@ class TestSlurmAdapter(TestCase):
             "sbatch -p normal -N 1 -n 20 -t 60 --mem=2607mb --export=SLURM_Walltime=60,TardisDroneCores=20,TardisDroneMemory=2607,TardisDroneDisk=102400,TardisDroneUuid=testsite-1390065 pilot.sh"  # noqa: B950
         )
 
-    @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_DEPLOY_RESOURCE_RESPONSE),
+        ]
+    )
     def test_deploy_resource_w_submit_options(self):
         self.test_site_config.MachineTypeConfiguration.test2large.SubmitOptions = (
             AttributeDict(long=AttributeDict(gres="tmp:1G"))
@@ -226,7 +237,11 @@ class TestSlurmAdapter(TestCase):
     def test_site_name(self):
         self.assertEqual(self.slurm_adapter.site_name, "TestSite")
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+        ]
+    )
     def test_resource_status(self):
         self.assertDictEqual(
             AttributeDict(
@@ -243,7 +258,11 @@ class TestSlurmAdapter(TestCase):
             'squeue -o "%A|%N|%T" -h -t all --job=1390065'
         )
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE),
+        ]
+    )
     def test_resource_status_w_options(self):
         self.test_site_config.MachineTypeConfiguration.test2large.StatusOptions = (
             AttributeDict(
@@ -269,7 +288,11 @@ class TestSlurmAdapter(TestCase):
             'squeue -p cm4_tiny --cluster=cm4 -o "%A|%N|%T" -h -t all --job=1390065'
         )
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_RUNNING)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_RUNNING),
+        ]
+    )
     def test_update_resource_status(self):
         self.assertEqual(
             self.resource_attributes["resource_status"], ResourceStatus.Booting
@@ -290,7 +313,11 @@ class TestSlurmAdapter(TestCase):
             'squeue -o "%A|%N|%T" -h -t all --job=1390065'
         )
 
-    @mock_executor_run_command(TEST_RESOURCE_STATUS_RESPONSE_ALL_STATES)
+    @mock_executor_run_command(
+        # Return 24 times (the number of states in state_translations dictionary)
+        [AttributeDict(stdout=TEST_RESOURCE_STATUS_RESPONSE_ALL_STATES)]
+        * 24
+    )
     def test_resource_state_translation(self):
         state_translations = {
             "BOOT_FAIL": ResourceStatus.Error,
@@ -336,7 +363,11 @@ class TestSlurmAdapter(TestCase):
 
             self.mock_executor.reset_mock()
 
-    @mock_executor_run_command("")
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout=""),
+        ]
+    )
     def test_resource_status_of_completed_jobs_w_empty_reply(self):
         response = asyncio.run(
             self.slurm_adapter.resource_status(
@@ -354,13 +385,15 @@ class TestSlurmAdapter(TestCase):
         )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message="Run command squeue --job=1351043 via SSHExecutor failed",
-            stdout="",
-            stderr="slurm_load_jobs error: Invalid job id specified",
-            exit_code=1,
-        ),
+        [
+            AttributeDict(stdout=""),
+            CommandExecutionFailure(
+                message="Run command squeue --job=1351043 via SSHExecutor failed",
+                stdout="",
+                stderr="slurm_load_jobs error: Invalid job id specified",
+                exit_code=1,
+            ),
+        ]
     )
     def test_resource_status_of_completed_jobs_w_raised_exception(self):
         response = asyncio.run(
@@ -408,10 +441,11 @@ class TestSlurmAdapter(TestCase):
         )
 
     @mock_executor_run_command(
-        stdout="",
-        raise_exception=CommandExecutionFailure(
-            message="Failed", stdout="Failed", stderr="Failed", exit_code=2
-        ),
+        [
+            CommandExecutionFailure(
+                message="Failed", stdout="Failed", stderr="Failed", exit_code=2
+            ),
+        ]
     )
     def test_resource_status_update_failed(self):
         with self.assertLogs(level=logging.WARNING):
@@ -426,7 +460,11 @@ class TestSlurmAdapter(TestCase):
             'squeue -o "%A|%N|%T" -h -t all --job=1390065'
         )
 
-    @mock_executor_run_command(stdout="", stderr="", exit_code=0)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout="", stderr="", exit_code=0),
+        ]
+    )
     def test_stop_resource(self):
         asyncio.run(
             self.slurm_adapter.stop_resource(
@@ -438,7 +476,11 @@ class TestSlurmAdapter(TestCase):
             "scancel 1390065"
         )
 
-    @mock_executor_run_command(stdout="", stderr="", exit_code=0)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout="", stderr="", exit_code=0),
+        ]
+    )
     def test_terminate_resource(self):
         asyncio.run(
             self.slurm_adapter.terminate_resource(
@@ -450,7 +492,11 @@ class TestSlurmAdapter(TestCase):
             "scancel 1390065"
         )
 
-    @mock_executor_run_command(stdout="", stderr="", exit_code=0)
+    @mock_executor_run_command(
+        [
+            AttributeDict(stdout="", stderr="", exit_code=0),
+        ]
+    )
     def test_terminate_resource_w_options(self):
         self.test_site_config.MachineTypeConfiguration.test2large.TerminateOptions = (
             AttributeDict(

--- a/tests/agents_t/test_batchsystemagent.py
+++ b/tests/agents_t/test_batchsystemagent.py
@@ -1,11 +1,11 @@
-from tests.utilities.utilities import run_async
-from tests.utilities.utilities import async_return
 from tardis.agents.batchsystemagent import BatchSystemAgent
 from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
 from tardis.utilities.attributedict import AttributeDict
 
 from unittest import TestCase
-from unittest.mock import create_autospec, PropertyMock
+from unittest.mock import create_autospec, AsyncMock, PropertyMock
+
+import asyncio
 
 
 class TestBatchSystemAgent(TestCase):
@@ -14,33 +14,33 @@ class TestBatchSystemAgent(TestCase):
         self.batch_system_agent = BatchSystemAgent(self.batch_system_adapter)
 
     def test_disintegrate_machine(self):
-        self.batch_system_adapter.disintegrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.disintegrate_machine, drone_uuid="test")
+        self.batch_system_adapter.disintegrate_machine = AsyncMock()
+        asyncio.run(self.batch_system_agent.disintegrate_machine(drone_uuid="test"))
         self.batch_system_adapter.disintegrate_machine.assert_called_with("test")
 
     def test_drain_machine(self):
-        self.batch_system_adapter.drain_machine.side_effect = async_return
-        run_async(self.batch_system_agent.drain_machine, drone_uuid="test")
+        self.batch_system_adapter.drain_machine = AsyncMock()
+        asyncio.run(self.batch_system_agent.drain_machine(drone_uuid="test"))
         self.batch_system_adapter.drain_machine.assert_called_with("test")
 
     def test_integrate_machine(self):
-        self.batch_system_adapter.integrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.integrate_machine, drone_uuid="test")
+        self.batch_system_adapter.integrate_machine = AsyncMock()
+        asyncio.run(self.batch_system_agent.integrate_machine(drone_uuid="test"))
         self.batch_system_adapter.integrate_machine.assert_called_with("test")
 
     def test_get_allocation(self):
-        self.batch_system_adapter.get_allocation.side_effect = async_return
-        run_async(self.batch_system_agent.get_allocation, drone_uuid="test")
+        self.batch_system_adapter.get_allocation = AsyncMock()
+        asyncio.run(self.batch_system_agent.get_allocation(drone_uuid="test"))
         self.batch_system_adapter.get_allocation.assert_called_with("test")
 
     def test_get_machine_status(self):
-        self.batch_system_adapter.get_machine_status.side_effect = async_return
-        run_async(self.batch_system_agent.get_machine_status, drone_uuid="test")
+        self.batch_system_adapter.get_machine_status = AsyncMock()
+        asyncio.run(self.batch_system_agent.get_machine_status(drone_uuid="test"))
         self.batch_system_adapter.get_machine_status.assert_called_with("test")
 
     def test_get_utilisation(self):
-        self.batch_system_adapter.get_utilisation.side_effect = async_return
-        run_async(self.batch_system_agent.get_utilisation, drone_uuid="test")
+        self.batch_system_adapter.get_utilisation = AsyncMock()
+        asyncio.run(self.batch_system_agent.get_utilisation(drone_uuid="test"))
         self.batch_system_adapter.get_utilisation.assert_called_with("test")
 
     def test_machine_meta_data_translation_mapping(self):

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -1,11 +1,10 @@
-from tests.utilities.utilities import run_async
-from tests.utilities.utilities import async_return
 from tardis.agents.siteagent import SiteAgent
 from tardis.interfaces.siteadapter import SiteAdapter
 
 from unittest import TestCase
-from unittest.mock import create_autospec
-from unittest.mock import PropertyMock
+from unittest.mock import create_autospec, PropertyMock, AsyncMock
+
+import asyncio
 
 
 class TestSiteAgent(TestCase):
@@ -14,8 +13,8 @@ class TestSiteAgent(TestCase):
         self.site_agent = SiteAgent(self.site_adapter)
 
     def test_deploy_resource(self):
-        self.site_adapter.deploy_resource.side_effect = async_return
-        run_async(self.site_agent.deploy_resource, resource_attributes="test")
+        self.site_adapter.deploy_resource = AsyncMock()
+        asyncio.run(self.site_agent.deploy_resource(resource_attributes="test"))
         self.site_adapter.deploy_resource.assert_called_with(resource_attributes="test")
 
     def test_drone_uuid(self):
@@ -53,8 +52,8 @@ class TestSiteAgent(TestCase):
         self.assertEqual(self.site_agent.machine_type, "Test123")
 
     def test_resource_status(self):
-        self.site_adapter.resource_status.side_effect = async_return
-        run_async(self.site_agent.resource_status, resource_attributes="test")
+        self.site_adapter.resource_status = AsyncMock()
+        asyncio.run(self.site_agent.resource_status(resource_attributes="test"))
         self.site_adapter.resource_status.assert_called_with(resource_attributes="test")
 
     def test_site_name(self):
@@ -62,13 +61,13 @@ class TestSiteAgent(TestCase):
         self.assertEqual(self.site_agent.site_name, "Test123")
 
     def test_stop_resource(self):
-        self.site_adapter.stop_resource.side_effect = async_return
-        run_async(self.site_agent.stop_resource, resource_attributes="test")
+        self.site_adapter.stop_resource = AsyncMock()
+        asyncio.run(self.site_agent.stop_resource(resource_attributes="test"))
         self.site_adapter.stop_resource.assert_called_with(resource_attributes="test")
 
     def test_terminate_resource(self):
-        self.site_adapter.terminate_resource.side_effect = async_return
-        run_async(self.site_agent.terminate_resource, resource_attributes="test")
+        self.site_adapter.terminate_resource = AsyncMock()
+        asyncio.run(self.site_agent.terminate_resource(resource_attributes="test"))
         self.site_adapter.terminate_resource.assert_called_with(
             resource_attributes="test"
         )

--- a/tests/interfaces_t/test_batchsystemadapter.py
+++ b/tests/interfaces_t/test_batchsystemadapter.py
@@ -1,9 +1,9 @@
 from tardis.interfaces.batchsystemadapter import BatchSystemAdapter
 
-from tests.utilities.utilities import run_async
-
 from unittest import TestCase
 from unittest.mock import patch
+
+import asyncio
 
 
 class TestBatchSystemAdapter(TestCase):
@@ -13,27 +13,27 @@ class TestBatchSystemAdapter(TestCase):
 
     def test_disintegrate_machine(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.disintegrate_machine, "test-123")
+            asyncio.run(self.batch_system_adapter.disintegrate_machine("test-123"))
 
     def test_drain_machine(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.drain_machine, "test-123")
+            asyncio.run(self.batch_system_adapter.drain_machine("test-123"))
 
     def test_integrate_machine(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.integrate_machine, "test-123")
+            asyncio.run(self.batch_system_adapter.integrate_machine("test-123"))
 
     def test_get_allocation(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.get_allocation, "test-123")
+            asyncio.run(self.batch_system_adapter.get_allocation("test-123"))
 
     def test_get_machine_status(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.get_machine_status, "test-123")
+            asyncio.run(self.batch_system_adapter.get_machine_status("test-123"))
 
     def test_get_utilisation(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.batch_system_adapter.get_utilisation, "test-123")
+            asyncio.run(self.batch_system_adapter.get_utilisation("test-123"))
 
     def test_machine_meta_data_translation_mapping(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/interfaces_t/test_siteadapter.py
+++ b/tests/interfaces_t/test_siteadapter.py
@@ -1,13 +1,12 @@
 from tardis.interfaces.siteadapter import SiteAdapter
 from tardis.utilities.attributedict import AttributeDict
 
-from tests.utilities.utilities import run_async
-
 from cobald.utility.primitives import infinity as inf
 from unittest import TestCase
 from unittest.mock import patch
 from pydantic.error_wrappers import ValidationError
 
+import asyncio
 import logging
 
 
@@ -47,7 +46,7 @@ class TestSiteAdapter(TestCase):
 
     def test_deploy_resource(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.site_adapter.deploy_resource, dict())
+            asyncio.run(self.site_adapter.deploy_resource(dict()))
 
     def test_drone_environment(self):
         self.site_adapter._machine_type = "TestMachineType"
@@ -205,7 +204,7 @@ class TestSiteAdapter(TestCase):
 
     def test_resource_status(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.site_adapter.resource_status, dict())
+            asyncio.run(self.site_adapter.resource_status(dict()))
 
     def test_site_configuration(self):
         self.assertEqual(
@@ -271,8 +270,8 @@ class TestSiteAdapter(TestCase):
 
     def test_stop_resource(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.site_adapter.stop_resource, dict())
+            asyncio.run(self.site_adapter.stop_resource(dict()))
 
     def test_terminate_resource(self):
         with self.assertRaises(NotImplementedError):
-            run_async(self.site_adapter.terminate_resource, dict())
+            asyncio.run(self.site_adapter.terminate_resource(dict()))

--- a/tests/plugins_t/test_auditor.py
+++ b/tests/plugins_t/test_auditor.py
@@ -18,10 +18,9 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch
 
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
-
 from unittest.mock import AsyncMock
+
+import asyncio
 
 
 class TestAuditor(TestCase):
@@ -94,8 +93,8 @@ class TestAuditor(TestCase):
         self.mock_address = self.mock_builder.address.return_value
         self.mock_timeout = self.mock_address.timeout.return_value
         self.client = self.mock_timeout.build.return_value
-        self.client.add.return_value = async_return()
-        self.client.update.return_value = async_return()
+        self.client.add = AsyncMock()
+        self.client.update = AsyncMock()
 
         self.config = config
         self.plugin = Auditor()
@@ -168,19 +167,21 @@ class TestAuditor(TestCase):
             self.client_cert_path, self.client_key_path, self.ca_cert_path
         )
 
-        run_async(
-            self.plugin.notify,
-            state=AvailableState(),
-            resource_attributes=self.test_param,
+        asyncio.run(
+            self.plugin.notify(
+                state=AvailableState(),
+                resource_attributes=self.test_param,
+            )
         )
 
         self.client.add.assert_called_once()
         self.client.update.assert_not_called()
 
-        run_async(
-            self.plugin.notify,
-            state=DownState(),
-            resource_attributes=self.test_param,
+        asyncio.run(
+            self.plugin.notify(
+                state=DownState(),
+                resource_attributes=self.test_param,
+            )
         )
 
         self.assertEqual(self.client.add.call_count, 1)
@@ -197,10 +198,11 @@ class TestAuditor(TestCase):
             DrainingState(),
             DisintegrateState(),
         ]:
-            run_async(
-                self.plugin.notify,
-                state=state,
-                resource_attributes=self.test_param,
+            asyncio.run(
+                self.plugin.notify(
+                    state=state,
+                    resource_attributes=self.test_param,
+                )
             )
             self.assertEqual(self.client.add.call_count, 1)
             self.assertEqual(self.client.update.call_count, 1)
@@ -210,10 +212,11 @@ class TestAuditor(TestCase):
             "Reqwest Error: HTTP status client error (404 Not Found) "
             "for url (http://127.0.0.1:8000/update)"
         )
-        run_async(
-            self.plugin.notify,
-            state=DownState(),
-            resource_attributes=self.test_param,
+        asyncio.run(
+            self.plugin.notify(
+                state=DownState(),
+                resource_attributes=self.test_param,
+            )
         )
 
         self.client.update.side_effect = RuntimeError(
@@ -221,26 +224,29 @@ class TestAuditor(TestCase):
             "for url (http://127.0.0.1:8000/update)"
         )
         with self.assertRaises(RuntimeError):
-            run_async(
-                self.plugin.notify,
-                state=DownState(),
-                resource_attributes=self.test_param,
+            asyncio.run(
+                self.plugin.notify(
+                    state=DownState(),
+                    resource_attributes=self.test_param,
+                )
             )
 
         self.client.update.side_effect = RuntimeError("Does not match RegEx")
         with self.assertRaises(RuntimeError):
-            run_async(
-                self.plugin.notify,
-                state=DownState(),
-                resource_attributes=self.test_param,
+            asyncio.run(
+                self.plugin.notify(
+                    state=DownState(),
+                    resource_attributes=self.test_param,
+                )
             )
 
         self.client.update.side_effect = ValueError("Other exception")
         with self.assertRaises(ValueError):
-            run_async(
-                self.plugin.notify,
-                state=DownState(),
-                resource_attributes=self.test_param,
+            asyncio.run(
+                self.plugin.notify(
+                    state=DownState(),
+                    resource_attributes=self.test_param,
+                )
             )
 
         self.client.update.side_effect = None

--- a/tests/plugins_t/test_elasticsearchmonitoring.py
+++ b/tests/plugins_t/test_elasticsearchmonitoring.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch
 
-from tests.utilities.utilities import run_async
+import asyncio
 
 
 class TestElasticsearchMonitoring(TestCase):
@@ -67,8 +67,8 @@ class TestElasticsearchMonitoring(TestCase):
             "hits": {"total": {"value": 2}}
         }
 
-        run_async(
-            self.plugin.notify, state=CleanupState(), resource_attributes=test_param
+        asyncio.run(
+            self.plugin.notify(state=CleanupState(), resource_attributes=test_param)
         )
 
         self.mock_elasticsearch.return_value.search.assert_called_with(
@@ -103,8 +103,8 @@ class TestElasticsearchMonitoring(TestCase):
             "hits": {"total": {"value": 2}}
         }
 
-        run_async(
-            self.plugin.notify, state=CleanupState(), resource_attributes=test_param
+        asyncio.run(
+            self.plugin.notify(state=CleanupState(), resource_attributes=test_param)
         )
 
         self.mock_elasticsearch.return_value.search.assert_called_with(

--- a/tests/plugins_t/test_prometheusmonitoring.py
+++ b/tests/plugins_t/test_prometheusmonitoring.py
@@ -8,7 +8,9 @@ from unittest import TestCase
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from tests.utilities.utilities import get_free_port, run_async
+from tests.utilities.utilities import get_free_port
+
+import asyncio
 
 
 class TestPrometheusMonitoring(TestCase):
@@ -36,38 +38,38 @@ class TestPrometheusMonitoring(TestCase):
     def test_notify(self):
         test_state = RequestState()
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("6", ResourceStatus.Booting)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("6", ResourceStatus.Booting))
         )
         self.assert_gauges([1, 0, 0, 0, 0])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("6", ResourceStatus.Running)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("6", ResourceStatus.Running))
         )
         self.assert_gauges([0, 1, 0, 0, 0])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("6", ResourceStatus.Stopped)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("6", ResourceStatus.Stopped))
         )
         self.assert_gauges([0, 0, 1, 0, 0])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("6", ResourceStatus.Deleted)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("6", ResourceStatus.Deleted))
         )
         self.assert_gauges([0, 0, 0, 1, 0])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("7", ResourceStatus.Error)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("7", ResourceStatus.Error))
         )
         self.assert_gauges([0, 0, 0, 1, 1])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("9", ResourceStatus.Booting)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("9", ResourceStatus.Booting))
         )
         self.assert_gauges([1, 0, 0, 1, 1])
 
-        run_async(
-            self.plugin.notify, test_state, get_test_param("8", ResourceStatus.Error)
+        asyncio.run(
+            self.plugin.notify(test_state, get_test_param("8", ResourceStatus.Error))
         )
         self.assert_gauges([1, 0, 0, 1, 2])
 

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -9,12 +9,12 @@ from tardis.plugins.sqliteregistry import (
     convert_datetime,
 )
 from tardis.utilities.attributedict import AttributeDict
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
 from unittest.mock import patch
 from unittest.mock import Mock
 
+import asyncio
 import datetime
 import os
 import sqlite3
@@ -202,20 +202,22 @@ class TestSqliteRegistry(TestCase):
     def test_get_resource_state(self):
         self.registry.add_site(self.test_site_name)
         self.registry.add_machine_types(self.test_site_name, self.test_machine_type)
-        run_async(self.registry.notify, RequestState(), self.test_resource_attributes)
+        asyncio.run(self.registry.notify(RequestState(), self.test_resource_attributes))
 
         self.assertEqual(
-            run_async(
-                self.registry.get_resource_state,
-                drone_uuid=self.test_resource_attributes["drone_uuid"],
+            asyncio.run(
+                self.registry.get_resource_state(
+                    drone_uuid=self.test_resource_attributes["drone_uuid"],
+                )
             ),
             [{"state": "RequestState"}],
         )
 
         self.assertEqual(
-            run_async(
-                self.registry.get_resource_state,
-                drone_uuid="does_not_exists",
+            asyncio.run(
+                self.registry.get_resource_state(
+                    drone_uuid="does_not_exists",
+                )
             ),
             [],
         )
@@ -224,7 +226,7 @@ class TestSqliteRegistry(TestCase):
     def test_get_resources(self):
         self.registry.add_site(self.test_site_name)
         self.registry.add_machine_types(self.test_site_name, self.test_machine_type)
-        run_async(self.registry.notify, RequestState(), self.test_resource_attributes)
+        asyncio.run(self.registry.notify(RequestState(), self.test_resource_attributes))
 
         self.assertListEqual(
             self.registry.get_resources(
@@ -250,26 +252,27 @@ class TestSqliteRegistry(TestCase):
         self.registry.add_site(self.test_site_name)
         self.registry.add_machine_types(self.test_site_name, self.test_machine_type)
 
-        run_async(self.registry.notify, RequestState(), self.test_resource_attributes)
+        asyncio.run(self.registry.notify(RequestState(), self.test_resource_attributes))
 
         self.assertEqual([self.test_notify_result], fetch_all())
 
         with self.assertRaises(sqlite3.IntegrityError) as ie:
-            run_async(
-                self.registry.notify, RequestState(), self.test_resource_attributes
+            asyncio.run(
+                self.registry.notify(RequestState(), self.test_resource_attributes)
             )
         self.assertTrue("unique" in str(ie.exception).lower())
 
-        run_async(
-            self.registry.notify,
-            BootingState(),
-            self.test_updated_resource_attributes,
+        asyncio.run(
+            self.registry.notify(
+                BootingState(),
+                self.test_updated_resource_attributes,
+            )
         )
 
         self.assertEqual([self.test_updated_notify_result], fetch_all())
 
-        run_async(
-            self.registry.notify, DownState(), self.test_updated_resource_attributes
+        asyncio.run(
+            self.registry.notify(DownState(), self.test_updated_resource_attributes)
         )
 
         self.assertListEqual([], fetch_all())
@@ -295,12 +298,12 @@ class TestSqliteRegistry(TestCase):
         bind_parameters = {"state": "RequestState"}
         bind_parameters.update(self.test_resource_attributes)
 
-        run_async(self.registry.insert_resource, bind_parameters)
+        asyncio.run(self.registry.insert_resource(bind_parameters))
 
         self.assertListEqual([self.test_notify_result], fetch_all())
 
         with self.assertRaises(sqlite3.IntegrityError) as ie:
-            run_async(self.registry.insert_resource, bind_parameters)
+            asyncio.run(self.registry.insert_resource(bind_parameters))
         self.assertTrue("unique" in str(ie.exception).lower())
 
         self.assertListEqual([self.test_notify_result], fetch_all())
@@ -311,7 +314,7 @@ class TestSqliteRegistry(TestCase):
         bind_parameters["drone_uuid"] = f"{self.other_test_site_name}-045285abef1"
         bind_parameters["site_name"] = self.other_test_site_name
 
-        run_async(self.registry.insert_resource, bind_parameters)
+        asyncio.run(self.registry.insert_resource(bind_parameters))
 
         other_test_notify_result = (
             self.test_resource_attributes["remote_resource_uuid"],

--- a/tests/plugins_t/test_telegrafmonitoring.py
+++ b/tests/plugins_t/test_telegrafmonitoring.py
@@ -4,12 +4,10 @@ from tardis.utilities.attributedict import AttributeDict
 
 from datetime import datetime
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 from unittest.mock import patch
 
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
-
+import asyncio
 import platform
 
 
@@ -39,8 +37,8 @@ class TestTelegrafMonitoring(TestCase):
         self.config.Plugins.TelegrafMonitoring.metric = "tardis_data"
 
         telegraf_client = self.mock_aiotelegraf.Client.return_value
-        telegraf_client.connect.return_value = async_return()
-        telegraf_client.close.return_value = async_return()
+        telegraf_client.connect = AsyncMock()
+        telegraf_client.close = AsyncMock()
 
         self.plugin = TelegrafMonitoring()
 
@@ -64,7 +62,7 @@ class TestTelegrafMonitoring(TestCase):
             machine_type=test_param.machine_type,
             drone_uuid=test_param.drone_uuid,
         )
-        run_async(self.plugin.notify, test_state, test_param)
+        asyncio.run(self.plugin.notify(test_state, test_param))
         self.mock_aiotelegraf.Client.assert_called_with(
             host="telegraf.test",
             port=1234,
@@ -84,7 +82,7 @@ class TestTelegrafMonitoring(TestCase):
             "tardis_machine_name": "my_test_node",
         }
         self.plugin = TelegrafMonitoring()
-        run_async(self.plugin.notify, test_state, test_param)
+        asyncio.run(self.plugin.notify(test_state, test_param))
 
         self.mock_aiotelegraf.Client.assert_called_with(
             host="telegraf.test",

--- a/tests/resources_t/test_drone.py
+++ b/tests/resources_t/test_drone.py
@@ -1,9 +1,3 @@
-from tests.utilities.utilities import (
-    async_return,
-    run_async,
-    set_awaitable_return_value,
-)
-
 from tardis.interfaces.plugin import Plugin
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.interfaces.state import State
@@ -14,7 +8,9 @@ from tardis.utilities.attributedict import AttributeDict
 
 from logging import DEBUG
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncio
 
 
 class TestDrone(TestCase):
@@ -41,7 +37,7 @@ class TestDrone(TestCase):
         self.mock_site_agent.drone_minimum_lifetime = None
         self.mock_site_agent.drone_heartbeat_interval = 60
         self.mock_plugin = MagicMock(spec=Plugin)()
-        self.mock_plugin.notify.return_value = async_return()
+        self.mock_plugin.notify = AsyncMock()
         self.drone = Drone(
             site_agent=self.mock_site_agent,
             batch_system_agent=self.mock_batch_system_agent,
@@ -65,24 +61,24 @@ class TestDrone(TestCase):
         self.assertEqual(self.drone._database, sql_registry)
 
     def test_database_state(self):
-        self.assertIsNone(run_async(self.drone.database_state))
+        self.assertIsNone(asyncio.run(self.drone.database_state()))
 
         sql_registry = MagicMock(spec=SqliteRegistry)
         self.drone.register_plugins(sql_registry)
         self.drone.__dict__.pop("_database")  # reset cached_property's cache
-        set_awaitable_return_value(
-            sql_registry.get_resource_state, [{"state": "DrainState"}]
+        sql_registry.get_resource_state = AsyncMock(
+            return_value=[{"state": "DrainState"}]
         )
 
-        self.assertIsInstance(run_async(self.drone.database_state), DrainState)
+        self.assertIsInstance(asyncio.run(self.drone.database_state()), DrainState)
 
         # testing IndexError
-        set_awaitable_return_value(sql_registry.get_resource_state, [])
-        self.assertIsNone(run_async(self.drone.database_state))
+        sql_registry.get_resource_state = AsyncMock(return_value=[])
+        self.assertIsNone(asyncio.run(self.drone.database_state()))
 
         # testing AttributeError
         del self.drone.resource_attributes.drone_uuid
-        self.assertIsNone(run_async(self.drone.database_state))
+        self.assertIsNone(asyncio.run(self.drone.database_state()))
 
     def test_demand(self):
         self.assertEqual(self.drone.demand, 8)
@@ -127,7 +123,7 @@ class TestDrone(TestCase):
 
         mocked_request_state.return_value.run.side_effect = EndOfLoop
         with self.assertRaises(EndOfLoop):
-            run_async(self.drone.run)
+            asyncio.run(self.drone.run())
 
         # Actual test code
         self.assertIsInstance(self.drone.state, RequestState)
@@ -135,11 +131,10 @@ class TestDrone(TestCase):
             self.drone.resource_attributes.resource_status, ResourceStatus.Booting
         )
 
-    @patch("tardis.resources.drone.asyncio.sleep")
+    @patch("tardis.resources.drone.asyncio.sleep", new_callable=AsyncMock)
     def test_run(self, mocked_asyncio_sleep):
-        mocked_asyncio_sleep.side_effect = async_return
         mocked_down_state = MagicMock(spec=DownState)
-        mocked_down_state.run.return_value = async_return()
+        mocked_down_state.run = AsyncMock()
 
         async def mocked_run(drone):
             await drone.set_state(mocked_down_state)
@@ -147,11 +142,11 @@ class TestDrone(TestCase):
         mocked_state = MagicMock(spec=State)
         mocked_state.run.side_effect = mocked_run
 
-        run_async(self.drone.set_state, mocked_state)
+        asyncio.run(self.drone.set_state(mocked_state))
         self.drone.demand = 8
         self.mock_site_agent.drone_heartbeat_interval = 10
         with self.assertLogs(level=DEBUG):
-            run_async(self.drone.run)
+            asyncio.run(self.drone.run())
 
         # duration skipped via asyncio.sleep
         # use the `sum` to avoid `asyncio.sleep(0)` context switches to skew the result
@@ -178,12 +173,12 @@ class TestDrone(TestCase):
     def test_set_state(self):
         self.drone.register_plugins(self.mock_plugin)
         old_update_time_stamp = self.drone.resource_attributes.updated
-        run_async(self.drone.set_state, self.drone._state)
+        asyncio.run(self.drone.set_state(self.drone._state))
         self.mock_plugin.notify.assert_not_called()
         self.assertEqual(self.drone.resource_attributes.updated, old_update_time_stamp)
 
         new_state = DownState()
-        run_async(self.drone.set_state, new_state)
+        asyncio.run(self.drone.set_state(new_state))
         self.mock_plugin.notify.assert_called_with(
             new_state, self.drone.resource_attributes
         )
@@ -199,7 +194,7 @@ class TestDrone(TestCase):
         self.drone.register_plugins(self.mock_plugin)
         self.assertEqual(self.drone._plugins, [self.mock_plugin])
 
-        run_async(self.drone.notify_plugins)
+        asyncio.run(self.drone.notify_plugins())
         self.mock_plugin.notify.assert_called_with(
             self.drone.state, self.drone.resource_attributes
         )

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -18,13 +18,11 @@ from tardis.resources.dronestates import ShuttingDownState
 from tardis.resources.dronestates import CleanupState
 from tardis.resources.dronestates import DownState
 from tardis.utilities.attributedict import AttributeDict
-from tests.utilities.utilities import async_return
-from tests.utilities.utilities import run_async
 
 from functools import partial
 from datetime import datetime, timedelta
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import asyncio
 import logging
@@ -57,48 +55,32 @@ class TestDroneStates(TestCase):
         self.drone._supply = 8.0
         self.drone.minimum_lifetime = 3600
         self.drone.set_state.side_effect = partial(mock_set_state, self.drone)
-        self.drone.site_agent.deploy_resource.return_value = async_return(
+        self.drone.site_agent.deploy_resource = AsyncMock(return_value=AttributeDict())
+        self.drone.site_agent.resource_status = AsyncMock(return_value=AttributeDict())
+        self.drone.site_agent.stop_resource = AsyncMock(return_value=AttributeDict())
+        self.drone.site_agent.terminate_resource = AsyncMock(
             return_value=AttributeDict()
         )
-        self.drone.site_agent.resource_status.return_value = async_return(
-            return_value=AttributeDict()
-        )
-        self.drone.site_agent.stop_resource.return_value = async_return(
-            return_value=AttributeDict()
-        )
-        self.drone.site_agent.terminate_resource.return_value = async_return(
-            return_value=AttributeDict()
-        )
-        self.drone.batch_system_agent.integrate_machine.return_value = async_return(
+        self.drone.batch_system_agent.integrate_machine = AsyncMock(return_value=None)
+        self.drone.batch_system_agent.disintegrate_machine = AsyncMock(
             return_value=None
         )
-        self.drone.batch_system_agent.disintegrate_machine.return_value = async_return(
-            return_value=None
-        )
-        self.drone.batch_system_agent.drain_machine.return_value = async_return(
-            return_value=None
-        )
-        self.drone.batch_system_agent.get_machine_status.return_value = async_return(
-            return_value=None
-        )
-        self.drone.batch_system_agent.get_allocation.return_value = async_return(
-            return_value=None
-        )
-        self.drone.batch_system_agent.get_utilisation.return_value = async_return(
-            return_value=None
-        )
+        self.drone.batch_system_agent.drain_machine = AsyncMock(return_value=None)
+        self.drone.batch_system_agent.get_machine_status = AsyncMock(return_value=None)
+        self.drone.batch_system_agent.get_allocation = AsyncMock(return_value=None)
+        self.drone.batch_system_agent.get_utilisation = AsyncMock(return_value=None)
 
     def run_the_matrix(self, matrix, initial_state):
         for resource_status, machine_status, new_state in matrix:
-            self.drone.site_agent.resource_status.return_value = async_return(
+            self.drone.site_agent.resource_status = AsyncMock(
                 return_value=AttributeDict(resource_status=resource_status)
             )
-            self.drone.batch_system_agent.get_machine_status.return_value = (
-                async_return(return_value=machine_status)
+            self.drone.batch_system_agent.get_machine_status = AsyncMock(
+                return_value=machine_status
             )
             self.drone.state.return_value = initial_state
             with self.assertLogs(None, level="DEBUG"):
-                run_async(self.drone.state.return_value.run, self.drone)
+                asyncio.run(self.drone.state.return_value.run(self.drone))
             self.assertIsInstance(self.drone.state, new_state)
 
     def run_side_effects(
@@ -107,14 +89,14 @@ class TestDroneStates(TestCase):
         for exception in exceptions:
             self.drone.state.return_value = initial_state
             api_call_to_test.side_effect = exception()
-            run_async(self.drone.state.return_value.run, self.drone)
+            asyncio.run(self.drone.state.return_value.run(self.drone))
             self.assertIsInstance(self.drone.state, final_state)
 
         api_call_to_test.side_effect = None
 
     def test_request_state(self):
         self.drone.state.return_value = RequestState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, BootingState)
 
         self.run_side_effects(
@@ -164,13 +146,13 @@ class TestDroneStates(TestCase):
         # Test draining procedure if cobald sets drone demand to zero
         self.drone.demand = 0.0
         self.drone.state.return_value = BootingState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, CleanupState)
         self.assertEqual(self.drone._supply, 0.0)
 
     def test_integrate_state(self):
         self.drone.state.return_value = IntegrateState
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, IntegratingState)
         self.drone.batch_system_agent.integrate_machine.assert_called_with(
             drone_uuid="test-923ABF"
@@ -195,7 +177,7 @@ class TestDroneStates(TestCase):
         self.run_the_matrix(matrix, initial_state=IntegratingState)
 
     def test_available_state(self):
-        self.drone.database_state.return_value = async_return()
+        self.drone.database_state = AsyncMock()
 
         matrix = [
             (ResourceStatus.Running, MachineStatus.Available, AvailableState),
@@ -214,7 +196,7 @@ class TestDroneStates(TestCase):
         # Test draining procedure if cobald sets drone demand to zero
         self.drone.demand = 0.0
         self.drone.state.return_value = AvailableState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, DrainState)
         self.assertEqual(self.drone._supply, 0.0)
 
@@ -222,18 +204,18 @@ class TestDroneStates(TestCase):
         self.drone.demand = 8.0
         self.drone.minimum_lifetime = 1
         self.drone.state.return_value = AvailableState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, DrainState)
 
         # Test remote draining procedure via REST service and database
-        self.drone.database_state.return_value = async_return(return_value=DrainState)
+        self.drone.database_state = AsyncMock(return_value=DrainState)
         self.drone.state.return_value = AvailableState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, DrainState)
 
     def test_drain_state(self):
         self.drone.state.return_value = DrainState
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, DrainingState)
         self.drone.batch_system_agent.drain_machine.assert_called_with(
             drone_uuid="test-923ABF"
@@ -254,7 +236,7 @@ class TestDroneStates(TestCase):
 
     def test_disintegrate_state(self):
         self.drone.state.return_value = DisintegrateState
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertIsInstance(self.drone.state, ShutDownState)
         self.drone.batch_system_agent.disintegrate_machine.assert_called_with(
             drone_uuid="test-923ABF"
@@ -286,7 +268,7 @@ class TestDroneStates(TestCase):
         )
 
         self.mock_drone.reset()
-        self.drone.site_agent.resource_status.return_value = async_return(
+        self.drone.site_agent.resource_status = AsyncMock(
             return_value=AttributeDict(resource_status=ResourceStatus.Running)
         )
         with self.assertLogs(level=logging.WARNING):
@@ -358,5 +340,5 @@ class TestDroneStates(TestCase):
 
     def test_down_state(self):
         self.drone.state.return_value = DownState()
-        run_async(self.drone.state.return_value.run, self.drone)
+        asyncio.run(self.drone.state.return_value.run(self.drone))
         self.assertEqual(self.drone.demand, 0.0)

--- a/tests/rest_t/app_t/test_crutd.py
+++ b/tests/rest_t/app_t/test_crutd.py
@@ -1,9 +1,10 @@
 from tardis.rest.app import crud
 from tardis.plugins.sqliteregistry import SqliteRegistry
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
 from unittest.mock import MagicMock
+
+import asyncio
 
 
 class TestCRUD(TestCase):
@@ -25,10 +26,11 @@ class TestCRUD(TestCase):
 
         self.assertEqual(
             [],
-            run_async(
-                crud.get_resource_state,
-                sql_registry=self.sql_registry_mock,
-                drone_uuid="test-noexists-01234567ab",
+            asyncio.run(
+                crud.get_resource_state(
+                    sql_registry=self.sql_registry_mock,
+                    drone_uuid="test-noexists-01234567ab",
+                )
             ),
         )
 
@@ -45,10 +47,11 @@ class TestCRUD(TestCase):
 
         self.assertEqual(
             [{"drone_uuid": "test-01234567ab", "state": "AvailableState"}],
-            run_async(
-                crud.get_resource_state,
-                sql_registry=self.sql_registry_mock,
-                drone_uuid="test-available-01234567ab",
+            asyncio.run(
+                crud.get_resource_state(
+                    sql_registry=self.sql_registry_mock,
+                    drone_uuid="test-available-01234567ab",
+                )
             ),
         )
 
@@ -90,9 +93,10 @@ class TestCRUD(TestCase):
 
         self.assertEqual(
             full_expected_resources,
-            run_async(
-                crud.get_resources,
-                sql_registry=self.sql_registry_mock,
+            asyncio.run(
+                crud.get_resources(
+                    sql_registry=self.sql_registry_mock,
+                ),
             ),
         )
 

--- a/tests/rest_t/routers_t/base_test_case_routers.py
+++ b/tests/rest_t/routers_t/base_test_case_routers.py
@@ -1,11 +1,12 @@
 from tardis.rest.app.security import get_user
 from tardis.utilities.attributedict import AttributeDict
-from tests.utilities.utilities import run_async
 
 from httpx import AsyncClient, ASGITransport
 
 from unittest import TestCase
 from unittest.mock import patch
+
+import asyncio
 
 
 class TestCaseRouters(TestCase):
@@ -62,12 +63,12 @@ class TestCaseRouters(TestCase):
         return self.config.Services.restapi.get_user.return_value.scopes
 
     def tearDown(self) -> None:
-        run_async(self.client.aclose)
+        asyncio.run(self.client.aclose())
 
     def login(self, user: dict = None):
         self.clear_lru_cache()
-        response = run_async(
-            self.client.post, "/user/login", json=user or self.test_user
+        response = asyncio.run(
+            self.client.post("/user/login", json=user or self.test_user)
         )
         self.assertEqual(response.status_code, 200)
 

--- a/tests/rest_t/routers_t/test_resources.py
+++ b/tests/rest_t/routers_t/test_resources.py
@@ -1,6 +1,7 @@
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 from tests.rest_t.routers_t.base_test_case_routers import TestCaseRouters
-from tests.utilities.utilities import async_return, run_async
+
+import asyncio
 
 
 class TestResources(TestCaseRouters):
@@ -13,13 +14,14 @@ class TestResources(TestCaseRouters):
 
     def test_get_resource_state(self):
         self.clear_lru_cache()
-        self.mock_crud.get_resource_state.return_value = async_return(
+        self.mock_crud.get_resource_state = AsyncMock(
             return_value=[{"drone_uuid": "test-0123456789", "state": "AvailableState"}]
         )
 
-        response = run_async(
-            self.client.get,
-            "/resources/test-0123456789/state",
+        response = asyncio.run(
+            self.client.get(
+                "/resources/test-0123456789/state",
+            )
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -27,12 +29,12 @@ class TestResources(TestCaseRouters):
             {"drone_uuid": "test-0123456789", "state": "AvailableState"},
         )
 
-        self.mock_crud.get_resource_state.return_value = async_return(return_value=[])
-        response = run_async(self.client.get, "/resources/test-1234567890/state")
+        self.mock_crud.get_resource_state = AsyncMock(return_value=[])
+        response = asyncio.run(self.client.get("/resources/test-1234567890/state"))
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {"detail": "Drone not found"})
 
-        response = run_async(self.client.get, "/resources/test-invalid/state")
+        response = asyncio.run(self.client.get("/resources/test-invalid/state"))
         self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.json(),
@@ -48,17 +50,14 @@ class TestResources(TestCaseRouters):
             },
         )
 
-        response = run_async(
-            self.client.get,
-            "/resources/state",
-        )
+        response = asyncio.run(self.client.get("/resources/state"))
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {"detail": "Not Found"})
 
         # missing scope
         self.set_scopes(["resources:patch"])
         self.login()
-        response = run_async(self.client.get, "/resources/test-0123456789/state")
+        response = asyncio.run(self.client.get("/resources/test-0123456789/state"))
         self.assertEqual(response.status_code, 403)
 
     def test_get_resources(self):
@@ -83,11 +82,9 @@ class TestResources(TestCaseRouters):
                 "updated": "2021-10-08T12:42:30.648325",
             },
         ]
-        self.mock_crud.get_resources.return_value = async_return(
-            return_value=full_expected_resources
-        )
+        self.mock_crud.get_resources = AsyncMock(return_value=full_expected_resources)
 
-        response = run_async(self.client.get, "/resources/")
+        response = asyncio.run(self.client.get("/resources/"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -97,14 +94,14 @@ class TestResources(TestCaseRouters):
         # missing scope
         self.set_scopes(["resources:patch"])
         self.login()
-        response = run_async(self.client.get, "/resources/")
+        response = asyncio.run(self.client.get("/resources/"))
         self.assertEqual(response.status_code, 403)
 
     def test_drain_drone(self):
         self.clear_lru_cache()
-        self.mock_crud.set_state_to_draining.return_value = async_return()
+        self.mock_crud.set_state_to_draining = AsyncMock()
 
-        response = run_async(self.client.patch, "/resources/test-0125bc9fd8/drain")
+        response = asyncio.run(self.client.patch("/resources/test-0125bc9fd8/drain"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"msg": "Drone set to DrainState"})
 
@@ -116,5 +113,5 @@ class TestResources(TestCaseRouters):
         # missing scope
         self.set_scopes(["resources:get"])
         self.login()
-        response = run_async(self.client.patch, "/resources/test-0125bc9fd8/drain")
+        response = asyncio.run(self.client.patch("/resources/test-0125bc9fd8/drain"))
         self.assertEqual(response.status_code, 403)

--- a/tests/rest_t/routers_t/test_types.py
+++ b/tests/rest_t/routers_t/test_types.py
@@ -1,5 +1,8 @@
 from tests.rest_t.routers_t.base_test_case_routers import TestCaseRouters
-from tests.utilities.utilities import async_return, run_async
+
+from unittest.mock import AsyncMock
+
+import asyncio
 
 
 def is_list_str(resp):
@@ -14,28 +17,28 @@ class TestTypes(TestCaseRouters):
 
     def test_types(self):
         self.clear_lru_cache()
-        self.mock_types.get_available_states.return_value = async_return(
+        self.mock_types.get_available_states = AsyncMock(
             return_value=[{"state": "state"}, {"state": "state2"}]
         )
-        self.mock_types.get_available_sites.return_value = async_return(
+        self.mock_types.get_available_sites = AsyncMock(
             return_value=[{"site": "site"}, {"site": "site2"}]
         )
-        self.mock_types.get_available_machine_types.return_value = async_return(
+        self.mock_types.get_available_machine_types = AsyncMock(
             return_value=[{"machine_type": "type"}, {"machine_type": "type2"}]
         )
 
         self.clear_lru_cache()
-        response = run_async(self.client.get, "/types/states")
+        response = asyncio.run(self.client.get("/types/states"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["state", "state2"])
 
         self.clear_lru_cache()
-        response = run_async(self.client.get, "/types/sites")
+        response = asyncio.run(self.client.get("/types/sites"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["site", "site2"])
 
         self.clear_lru_cache()
-        response = run_async(self.client.get, "/types/machine_types")
+        response = asyncio.run(self.client.get("/types/machine_types"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["type", "type2"])
 
@@ -43,5 +46,5 @@ class TestTypes(TestCaseRouters):
         self.clear_lru_cache()
         self.set_scopes(["resources:patch"])
         self.login()
-        response = run_async(self.client.get, "/types/states")
+        response = asyncio.run(self.client.get("/types/states"))
         self.assertEqual(response.status_code, 403)

--- a/tests/rest_t/routers_t/test_user.py
+++ b/tests/rest_t/routers_t/test_user.py
@@ -1,5 +1,6 @@
 from tests.rest_t.routers_t.base_test_case_routers import TestCaseRouters
-from tests.utilities.utilities import run_async
+
+import asyncio
 
 
 class TestUser(TestCaseRouters):
@@ -8,7 +9,7 @@ class TestUser(TestCaseRouters):
     def test_login(self):
         # No body and headers
         self.clear_lru_cache()
-        response = run_async(self.client.post, "/user/login")
+        response = asyncio.run(self.client.post("/user/login"))
         self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.json(),
@@ -25,7 +26,7 @@ class TestUser(TestCaseRouters):
 
         # Empty body
         self.clear_lru_cache()
-        response = run_async(self.client.post, "/user/login", data="{}")
+        response = asyncio.run(self.client.post("/user/login", data="{}"))
         self.assertEqual(response.status_code, 422)
         self.assertEqual(
             response.json(),
@@ -46,7 +47,7 @@ class TestUser(TestCaseRouters):
         )
 
         self.clear_lru_cache()
-        response = run_async(self.client.post, "/user/login", json=self.test_user)
+        response = asyncio.run(self.client.post("/user/login", json=self.test_user))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -59,7 +60,7 @@ class TestUser(TestCaseRouters):
         # missing scopes
         self.clear_lru_cache()
         self.set_scopes(["resources:get"])
-        response = run_async(self.client.post, "/user/login", json=self.test_user)
+        response = asyncio.run(self.client.post("/user/login", json=self.test_user))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -70,21 +71,21 @@ class TestUser(TestCaseRouters):
 
         self.clear_lru_cache()
         self.config.Services.restapi.get_user.side_effect = lambda user_name: None
-        response = run_async(self.client.post, "/user/login", json=self.test_user)
+        response = asyncio.run(self.client.post("/user/login", json=self.test_user))
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json(), {"detail": "Incorrect username or password"})
         self.config.Services.restapi.get_user.side_effect = None
 
         self.clear_lru_cache()
         self.test_user["password"] = "wrong"
-        response = run_async(self.client.post, "/user/login", json=self.test_user)
+        response = asyncio.run(self.client.post("/user/login", json=self.test_user))
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json(), {"detail": "Incorrect username or password"})
 
     def test_logout(self):
         # Not logged in yet
         self.clear_lru_cache()
-        response = run_async(self.client.post, "/user/logout")
+        response = asyncio.run(self.client.post("/user/logout"))
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
@@ -93,17 +94,17 @@ class TestUser(TestCaseRouters):
 
         # correct login
         self.login()
-        response = run_async(self.client.post, "/user/logout")
+        response = asyncio.run(self.client.post("/user/logout"))
         self.assertEqual(response.status_code, 200)
 
         # prevent second logout
-        response = run_async(self.client.post, "/user/logout")
+        response = asyncio.run(self.client.post("/user/logout"))
         self.assertEqual(response.status_code, 401)
 
     def test_refresh(self):
         # Not logged in yet
         self.clear_lru_cache()
-        response = run_async(self.client.post, "/user/refresh")
+        response = asyncio.run(self.client.post("/user/refresh"))
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(), {"detail": "Missing cookie refresh_token_cookie"}
@@ -111,26 +112,26 @@ class TestUser(TestCaseRouters):
 
         # correct login
         self.login()
-        response = run_async(self.client.post, "/user/refresh")
+        response = asyncio.run(self.client.post("/user/refresh"))
         self.assertEqual(response.status_code, 200)
 
         # invalid access token but valid refresh token
         self.clear_lru_cache()
         self.client.cookies["access_token_cookie"] = "invalid"
-        response = run_async(self.client.post, "/user/refresh")
+        response = asyncio.run(self.client.post("/user/refresh"))
         self.assertEqual(response.status_code, 200)
 
     def test_user_me(self):
         # Not logged in yet
         self.clear_lru_cache()
-        response = run_async(self.client.get, "/user/me")
+        response = asyncio.run(self.client.get("/user/me"))
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(), {"detail": "Missing cookie access_token_cookie"}
         )
 
         self.login()
-        response = run_async(self.client.get, "/user/me")
+        response = asyncio.run(self.client.get("/user/me"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -140,7 +141,7 @@ class TestUser(TestCaseRouters):
         # missing scope
         self.set_scopes(["resources:get"])
         self.login()
-        response = run_async(self.client.get, "/user/me")
+        response = asyncio.run(self.client.get("/user/me"))
         self.assertEqual(response.status_code, 403)
 
     def test_get_token_scopes(self):
@@ -152,6 +153,6 @@ class TestUser(TestCaseRouters):
                 "scopes": ["resources:get"],
             }
         )
-        response = run_async(self.client.get, "/user/token_scopes")
+        response = asyncio.run(self.client.get("/user/token_scopes"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["resources:get"])

--- a/tests/rest_t/test_service.py
+++ b/tests/rest_t/test_service.py
@@ -1,8 +1,9 @@
 from tardis.rest.service import RestService
-from tests.utilities.utilities import async_return, run_async
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
+
+import asyncio
 
 
 class TestRestService(TestCase):
@@ -11,14 +12,14 @@ class TestRestService(TestCase):
 
     @patch("tardis.rest.service.Server")
     def test_run(self, mocked_server):
-        mocked_server().serve.return_value = async_return()
+        mocked_server().serve = AsyncMock()
 
         mocked_server.reset_mock()
 
         # Mocking the server means that all its attributes are set, including
         # the "I got killed by SIGINT" flag, which triggers its shutdown heuristic.
         with self.assertRaises(KeyboardInterrupt):
-            run_async(self.rest_service.run)
+            asyncio.run(self.rest_service.run())
         mocked_server.assert_called_with(config=self.rest_service._config)
 
     def test_get_user(self):

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -2,15 +2,7 @@ from tardis.utilities.attributedict import AttributeDict
 
 from unittest.mock import AsyncMock
 from typing import Union
-import asyncio
 import socket
-
-
-def async_return(*args, return_value=None, **kwargs):
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    f = loop.create_future()
-    f.set_result(return_value)
-    return f
 
 
 def get_free_port(ip: str):  # from https://gist.github.com/dbrgn/3979133
@@ -40,7 +32,7 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
     def decorator(func):
         def wrapper(self):
             executor = self.mock_executor.return_value
-            executor.run_command.return_value = async_return(
+            executor.run_command = AsyncMock(
                 return_value=AttributeDict(
                     stdout=stdout, stderr=stderr, exit_code=exit_code
                 )
@@ -52,18 +44,3 @@ def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=No
         return wrapper
 
     return decorator
-
-
-def run_async(coroutine, *args, **kwargs):
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    return loop.run_until_complete(coroutine(*args, **kwargs))
-
-
-def set_awaitable_return_value(mocked_coroutine, return_value):
-    # isinstance does not work due to inheritance
-    # iswaitable, iscoroutine not because RuntimeWarning (not awaited)
-    # comparing type(...) did not solve the problem as well.
-    if not mocked_coroutine.__class__.__name__ == "MagicMock":
-        mocked_coroutine.return_value = return_value
-    else:  # pass test on Python 3.6 and 3.7
-        mocked_coroutine.return_value = async_return(return_value=return_value)

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -13,7 +13,7 @@ def get_free_port(ip: str):  # from https://gist.github.com/dbrgn/3979133
     return port
 
 
-def mock_executor_run_command_new(
+def mock_executor_run_command(
     mock_call_side_effects: list[Union[AttributeDict, Exception]],
 ):
     def decorator(func):
@@ -22,24 +22,6 @@ def mock_executor_run_command_new(
             executor.run_command = AsyncMock(side_effect=mock_call_side_effects)
             func(self)
             executor.run_command = AsyncMock()
-
-        return wrapper
-
-    return decorator
-
-
-def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):
-    def decorator(func):
-        def wrapper(self):
-            executor = self.mock_executor.return_value
-            executor.run_command = AsyncMock(
-                return_value=AttributeDict(
-                    stdout=stdout, stderr=stderr, exit_code=exit_code
-                )
-            )
-            executor.run_command.side_effect = raise_exception
-            func(self)
-            executor.run_command.side_effect = None
 
         return wrapper
 

--- a/tests/utilities_t/executors_t/test_shellexecutor.py
+++ b/tests/utilities_t/executors_t/test_shellexecutor.py
@@ -1,9 +1,9 @@
-from tests.utilities.utilities import run_async
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.utilities.executors.shellexecutor import ShellExecutor
 
 from unittest import TestCase
 
+import asyncio
 import yaml
 
 
@@ -12,27 +12,27 @@ class TestAsyncRunCommand(TestCase):
         self.executor = ShellExecutor()
 
     def test_run_command(self):
-        self.assertEqual(run_async(self.executor.run_command, "exit 0").exit_code, 0)
+        self.assertEqual(asyncio.run(self.executor.run_command("exit 0")).exit_code, 0)
         self.assertEqual(
-            run_async(self.executor.run_command, "exit 255").exit_code, 255
+            asyncio.run(self.executor.run_command("exit 255")).exit_code, 255
         )
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, "exit 254")
+            asyncio.run(self.executor.run_command("exit 254"))
         self.assertEqual(cf.exception.exit_code, 254)
 
         self.assertEqual(
-            run_async(self.executor.run_command, 'echo "Test"').stdout, "Test"
+            asyncio.run(self.executor.run_command('echo "Test"')).stdout, "Test"
         )
 
         self.assertEqual(
-            run_async(self.executor.run_command, 'echo "Test" >>/dev/stderr').stderr,
+            asyncio.run(self.executor.run_command('echo "Test" >>/dev/stderr')).stderr,
             "Test",
         )
 
         self.assertEqual(
-            run_async(
-                self.executor.run_command, "read test; echo $test", stdin_input="Test"
+            asyncio.run(
+                self.executor.run_command("read test; echo $test", stdin_input="Test")
             ).stdout,
             "Test",
         )
@@ -41,15 +41,18 @@ class TestAsyncRunCommand(TestCase):
         executor = yaml.safe_load("""
                       !ShellExecutor
         """)
-        self.assertEqual(run_async(executor.run_command, "exit 0").exit_code, 0)
-        self.assertEqual(run_async(executor.run_command, "exit 255").exit_code, 255)
+        self.assertEqual(asyncio.run(executor.run_command("exit 0")).exit_code, 0)
+        self.assertEqual(asyncio.run(executor.run_command("exit 255")).exit_code, 255)
 
         with self.assertRaises(CommandExecutionFailure) as cf:
-            run_async(self.executor.run_command, "exit 254")
+            asyncio.run(self.executor.run_command("exit 254"))
         self.assertEqual(cf.exception.exit_code, 254)
 
-        self.assertEqual(run_async(executor.run_command, 'echo "Test"').stdout, "Test")
+        self.assertEqual(
+            asyncio.run(executor.run_command('echo "Test"')).stdout, "Test"
+        )
 
         self.assertEqual(
-            run_async(executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test"
+            asyncio.run(executor.run_command('echo "Test" >>/dev/stderr')).stderr,
+            "Test",
         )

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -1,4 +1,3 @@
-from tests.utilities.utilities import async_return, run_async
 from tardis.utilities.attributedict import AttributeDict
 from tardis.utilities.executors.sshexecutor import (
     SSHExecutor,
@@ -15,7 +14,7 @@ from tardis.exceptions.tardisexceptions import TardisAuthError
 from asyncssh import ChannelOpenError, ConnectionLost, DisconnectError, ProcessError
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import asyncio
 import yaml
@@ -77,13 +76,15 @@ class TestSSHExecutorUtilities(TestCase):
     def test_max_sessions(self):
         with self.subTest(sessions="default"):
             self.assertEqual(
-                DEFAULT_MAX_SESSIONS, run_async(probe_max_session, MockConnection())
+                DEFAULT_MAX_SESSIONS, asyncio.run(probe_max_session(MockConnection()))
             )
         for expected in (1, 9, 11, 20, 100):
             with self.subTest(sessions=expected):
                 self.assertEqual(
                     expected,
-                    run_async(probe_max_session, MockConnection(max_sessions=expected)),
+                    asyncio.run(
+                        probe_max_session(MockConnection(max_sessions=expected))
+                    ),
                 )
 
 
@@ -102,16 +103,17 @@ class TestMFASSHClient(TestCase):
         self.mfa_ssh_client = MFASSHClient(mfa_config=mfa_config)
 
     def test_kbdint_auth_requested(self):
-        self.assertEqual(run_async(self.mfa_ssh_client.kbdint_auth_requested), "")
+        self.assertEqual(asyncio.run(self.mfa_ssh_client.kbdint_auth_requested()), "")
 
     def test_kbdint_challenge_received(self):
         def test_responses(prompts, num_of_expected_responses):
-            responses = run_async(
-                self.mfa_ssh_client.kbdint_challenge_received,
-                name="test",
-                instructions="no",
-                lang="en",
-                prompts=prompts,
+            responses = asyncio.run(
+                self.mfa_ssh_client.kbdint_challenge_received(
+                    name="test",
+                    instructions="no",
+                    lang="en",
+                    prompts=prompts,
+                )
             )
 
             self.assertEqual(len(responses), num_of_expected_responses)
@@ -131,12 +133,13 @@ class TestMFASSHClient(TestCase):
 
         with self.assertRaises(TardisAuthError) as tae:
             with self.assertLogs(level=logging.ERROR):
-                run_async(
-                    self.mfa_ssh_client.kbdint_challenge_received,
-                    name="test",
-                    instructions="no",
-                    lang="en",
-                    prompts=prompts_to_fail,
+                asyncio.run(
+                    self.mfa_ssh_client.kbdint_challenge_received(
+                        name="test",
+                        instructions="no",
+                        lang="en",
+                        prompts=prompts_to_fail,
+                    )
                 )
         self.assertIn(
             "Keyboard interactive authentication failed: Unexpected Prompt",
@@ -164,19 +167,17 @@ class TestSSHExecutor(TestCase):
 
     def setUp(self) -> None:
         self.response = AttributeDict(stderr="", exit_status=0)
-        self.mock_asyncssh.connect.return_value = async_return(
-            return_value=MockConnection()
-        )
+        self.mock_asyncssh.connect = AsyncMock(return_value=MockConnection())
         self.test_asyncssh_params = AttributeDict(
             host="test_host", username="test", client_keys=["TestKey"]
         )
         self.executor = SSHExecutor(**self.test_asyncssh_params)
         self.mock_asyncssh.reset_mock()
 
-    @patch("tardis.utilities.executors.sshexecutor.asyncio.sleep", async_return)
+    @patch("tardis.utilities.executors.sshexecutor.asyncio.sleep", AsyncMock())
     def test_establish_connection(self):
         self.assertIsInstance(
-            run_async(self.executor._establish_connection), MockConnection
+            asyncio.run(self.executor._establish_connection()), MockConnection
         )
 
         self.mock_asyncssh.connect.assert_called_with(**self.test_asyncssh_params)
@@ -193,7 +194,7 @@ class TestSSHExecutor(TestCase):
             self.mock_asyncssh.connect.side_effect = exception
 
             with self.assertRaises(type(exception)):
-                run_async(self.executor._establish_connection)
+                asyncio.run(self.executor._establish_connection())
 
             self.assertEqual(self.mock_asyncssh.connect.call_count, 10)
 
@@ -205,12 +206,12 @@ class TestSSHExecutor(TestCase):
                 return connection
 
         self.assertIsNone(self.executor._connection_state)
-        run_async(force_connection)
+        asyncio.run(force_connection())
         self.assertIsInstance(
             self.executor._connection_state.connection, MockConnection
         )
         current_ssh_connection = self.executor._connection_state
-        run_async(force_connection)
+        asyncio.run(force_connection())
         # make sure the connection is not needlessly replaced
         self.assertEqual(self.executor._connection_state, current_ssh_connection)
 
@@ -241,7 +242,7 @@ class TestSSHExecutor(TestCase):
             "tardis.utilities.executors.sshexecutor.probe_max_session",
             mocked_probe_max_session,
         ):
-            run_async(run_race_condition)
+            asyncio.run(run_race_condition())
 
     def test_lock(self):
         self.assertIsInstance(self.executor.lock, asyncio.Lock)
@@ -262,15 +263,17 @@ class TestSSHExecutor(TestCase):
             return queued
 
         for sessions in (1, 8, 10, 12, 20):
+            # Reset connection state: so a new Semaphore is bound to the new loop
+            self.executor._connection_state = None
             with self.subTest(sessions=sessions):
                 self.assertEqual(
                     sessions > DEFAULT_MAX_SESSIONS,
-                    run_async(is_queued, sessions),
+                    asyncio.run(is_queued(sessions)),
                 )
 
     def test_run_command(self):
         self.assertEqual(
-            run_async(self.executor.run_command, command="Test").stdout,
+            asyncio.run(self.executor.run_command(command="Test")).stdout,
             "command=Test, stdin=None",
         )
         self.mock_asyncssh.connect.assert_called_with(
@@ -278,8 +281,11 @@ class TestSSHExecutor(TestCase):
         )
         self.mock_asyncssh.reset_mock()
 
-        response = run_async(
-            self.executor.run_command, command="Test", stdin_input="Test"
+        # Clear state because we are entering a new asyncio.run loop
+        self.executor._connection_state = None
+
+        response = asyncio.run(
+            self.executor.run_command(command="Test", stdin_input="Test")
         )
 
         self.assertEqual(response.stdout, "command=Test, stdin=Test")
@@ -288,13 +294,16 @@ class TestSSHExecutor(TestCase):
 
         self.assertEqual(response.exit_code, 0)
 
+        # Clear state because we are entering a new asyncio.run loop
+        self.executor._connection_state = None
+
         with self.assertRaises(ExecutorFailure) as cef:
-            run_async(self.executor.run_command, command="lost_connection")
+            asyncio.run(self.executor.run_command(command="lost_connection"))
         self.assertEqual(cef.exception.executor, self.executor)
 
         raising_executor = SSHExecutor(**self.test_asyncssh_params)
 
-        self.mock_asyncssh.connect.return_value = async_return(
+        self.mock_asyncssh.connect = AsyncMock(
             return_value=MockConnection(
                 exception=ProcessError(
                     env="Test",
@@ -309,19 +318,29 @@ class TestSSHExecutor(TestCase):
             )
         )
 
+        # Clear state because we are entering a new asyncio.run loop
+        self.executor._connection_state = None
+
         with self.assertRaises(CommandExecutionFailure):
-            run_async(raising_executor.run_command, command="Test", stdin_input="Test")
+            asyncio.run(
+                raising_executor.run_command(command="Test", stdin_input="Test")
+            )
 
         raising_executor = SSHExecutor(**self.test_asyncssh_params)
 
-        self.mock_asyncssh.connect.return_value = async_return(
+        self.mock_asyncssh.connect = AsyncMock(
             return_value=MockConnection(
                 exception=ChannelOpenError(reason="test_reason", code=255)
             )
         )
 
+        # Clear state because we are entering a new asyncio.run loop
+        self.executor._connection_state = None
+
         with self.assertRaises(ExecutorFailure):
-            run_async(raising_executor.run_command, command="Test", stdin_input="Test")
+            asyncio.run(
+                raising_executor.run_command(command="Test", stdin_input="Test")
+            )
 
     def test_run_command_retry(self):
         """Test that a failed command is retried and may succeed"""
@@ -331,39 +350,39 @@ class TestSSHExecutor(TestCase):
         )
         # acceptable failure number
         self.mock_asyncssh.connect.side_effect = [
-            async_return(return_value=broken_connection),
-            async_return(return_value=MockConnection()),
+            broken_connection,
+            MockConnection(),
         ]
         reconnected_executor = SSHExecutor(
             on_disconnect_retry=1, **self.test_asyncssh_params
         )
 
-        response = run_async(
-            reconnected_executor.run_command, command="Test", stdin_input="Test"
+        response = asyncio.run(
+            reconnected_executor.run_command(command="Test", stdin_input="Test")
         )
         self.assertEqual(response.stdout, "command=Test, stdin=Test")
         self.assertEqual(response.exit_code, 0)
 
         # too many failures
         self.mock_asyncssh.connect.side_effect = [
-            async_return(return_value=broken_connection),
-            async_return(return_value=broken_connection),
-            async_return(return_value=MockConnection()),
+            broken_connection,
+            broken_connection,
+            MockConnection(),
         ]
         disconnected_executor = SSHExecutor(
             on_disconnect_retry=1, **self.test_asyncssh_params
         )
 
         with self.assertRaises(ExecutorFailure):
-            run_async(
-                disconnected_executor.run_command, command="Test", stdin_input="Test"
+            asyncio.run(
+                disconnected_executor.run_command(command="Test", stdin_input="Test")
             )
 
     def test_construction_by_yaml(self):
         def test_yaml_construction(test_executor, *args, **kwargs):
             self.assertEqual(
-                run_async(
-                    test_executor.run_command, command="Test", stdin_input="Test"
+                asyncio.run(
+                    test_executor.run_command(command="Test", stdin_input="Test")
                 ).stdout,
                 "command=Test, stdin=Test",
             )
@@ -426,9 +445,7 @@ class TestDupingSSHExecutor(TestCase):
 
     def setUp(self) -> None:
         self.response = AttributeDict(stderr="", exit_status=0)
-        self.mock_asyncssh.connect.return_value = async_return(
-            return_value=MockConnection()
-        )
+        self.mock_asyncssh.connect = AsyncMock(return_value=MockConnection())
         self.test_asyncssh_params = AttributeDict(
             host="test_host", username="test", client_keys=["TestKey"]
         )
@@ -443,8 +460,8 @@ class TestDupingSSHExecutor(TestCase):
             self.assertEqual(response.stderr, "TestError")
             self.assertEqual(response.exit_code, 0)
 
-        response = run_async(
-            self.executor.run_command, command="Test", stdin_input="TestStdInput"
+        response = asyncio.run(
+            self.executor.run_command(command="Test", stdin_input="TestStdInput")
         )
 
         test_wrapper_and_response(wrapper="/bin/bash", response=response)
@@ -453,8 +470,8 @@ class TestDupingSSHExecutor(TestCase):
             wrapper="test_wrapper", **self.test_asyncssh_params
         )
 
-        response = run_async(
-            self.executor.run_command, command="Test", stdin_input="TestStdInput"
+        response = asyncio.run(
+            self.executor.run_command(command="Test", stdin_input="TestStdInput")
         )
 
         test_wrapper_and_response(wrapper="test_wrapper", response=response)
@@ -463,10 +480,11 @@ class TestDupingSSHExecutor(TestCase):
         def test_yaml_construction(test_executor, wrapper, *args, **kwargs):
             command = "Test"
             self.assertEqual(
-                run_async(
-                    test_executor.run_command,
-                    command=command,
-                    stdin_input="TestStdInput",
+                asyncio.run(
+                    test_executor.run_command(
+                        command=command,
+                        stdin_input="TestStdInput",
+                    )
                 ).stdout,
                 f"command={wrapper}, stdin={command}\nTestStdInput\n",
             )

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -111,8 +111,8 @@ class TestAsyncBulkCall(TestCase):
         asyncio.run(start_and_abandon())
 
         # Verify that the item is sitting stale inside the loop resources queue
-        self.assertIsNotNone(execution._loop_resources)
-        self.assertFalse(execution._loop_resources.queue.empty())
+        self.assertIsNotNone(execution._loop_synchronization)
+        self.assertFalse(execution._loop_synchronization.queue.empty())
 
         # Move to a new event loop execution block
         async def verify_clean_slate():

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -6,8 +6,6 @@ from unittest import TestCase
 
 from tardis.utilities.asyncbulkcall import AsyncBulkCall
 
-from tests.utilities.utilities import run_async
-
 
 class CallCounter:
     def __init__(self, start=0):
@@ -37,7 +35,7 @@ class TestAsyncBulkCall(TestCase):
         for size in (1, 10, 100, 1000, 2, 3, 5, 7, 97, 2129):
             with self.subTest(size=size):
                 execution = AsyncBulkCall(CallCounter(), size=size, delay=0.1)
-                result = run_async(self.execute, execution, count=size * 3 + 5)
+                result = asyncio.run(self.execute(execution, count=size * 3 + 5))
                 self.assertEqual(result, [(i, i // size) for i in range(size * 3 + 5)])
 
     def test_bulk_delay(self):
@@ -46,7 +44,7 @@ class TestAsyncBulkCall(TestCase):
         # check that delay forces a bulk if the size is too large to be reached
         execution = AsyncBulkCall(CallCounter(), size=2**32, delay=bulk_delay)
         before = time.monotonic()
-        result = run_async(self.execute, execution, count=test_size)
+        result = asyncio.run(self.execute(execution, count=test_size))
         after = time.monotonic()
         # PyPy can have a huge overhead before the JIT has warmed up
         grace = 5 if python_implementation() != "PyPy" else 25
@@ -58,12 +56,12 @@ class TestAsyncBulkCall(TestCase):
         # sys.float_info.min is not the smallest float possible,
         # but it should be insignificant in all math
         execution = AsyncBulkCall(CallCounter(), size=2**32, delay=sys.float_info.min)
-        result = run_async(self.execute, execution, count=2048)
+        result = asyncio.run(self.execute(execution, count=2048))
         self.assertEqual(result, [(i, i) for i in range(2048)])
 
     def test_restart(self):
         """Test that calls work after pausing"""
-        run_async(self.check_restart)
+        asyncio.run(self.check_restart())
 
     async def check_restart(self):
         bunch_size = 4
@@ -96,3 +94,83 @@ class TestAsyncBulkCall(TestCase):
                         delay=1.0,
                         concurrent=wrong_concurrency,
                     )
+
+    def test_abandoned_queue_cancellation_on_loop_swap(self):
+        """
+        Test that pending tasks left over from an old loop are safely cleared
+        upon a loop swap.
+        """
+        execution = AsyncBulkCall(CallCounter(), size=100, delay=0.01)
+
+        async def start_and_abandon():
+            loop = asyncio.get_running_loop()
+            fake_future = loop.create_future()
+            # This triggers initialization of self._loop_resources on the first loop
+            execution._queue.put_nowait((999, fake_future))
+
+        asyncio.run(start_and_abandon())
+
+        # Verify that the item is sitting stale inside the loop resources queue
+        self.assertIsNotNone(execution._loop_resources)
+        self.assertFalse(execution._loop_resources.queue.empty())
+
+        # Move to a new event loop execution block
+        async def verify_clean_slate():
+            task = asyncio.ensure_future(execution(123))
+            return await task
+
+        before = time.monotonic()
+        result = asyncio.run(verify_clean_slate())
+        after = time.monotonic()
+
+        # The execution should be near-instant (well under 0.1s) and warning-free
+        self.assertLess(after - before, 0.1)
+        self.assertEqual(result, (123, 0))
+
+    def test_concurrency_limit_enforced_and_released(self):
+        """
+        Test that the concurrency limit works precisely and doesn't freeze due
+        to an uncalled release.
+        """
+
+        async def slow_command(*tasks):
+            await asyncio.sleep(
+                0.05
+            )  # block execution briefly to stack concurrent bulks
+            return [t for t in tasks]
+
+        # Max 2 concurrent execution batches allowed at a time
+        execution = AsyncBulkCall(slow_command, size=1, delay=0.1, concurrent=2)
+
+        async def run_test():
+            # Send 3 concurrent items. With size=1, they form 3 separate batches.
+            # Batch 1 and 2 fill up the concurrency slots (limit=2).
+            # Batch 3 will wait until either Batch 1 or 2 finishes and releases
+            # its semaphore slot.
+            tasks = [asyncio.ensure_future(execution(i)) for i in range(3)]
+            return await asyncio.gather(*tasks)
+
+        # If the semaphore release fix works, this returns cleanly.
+        # If the fix fails, this would hang indefinitely on the 3rd item.
+        result = asyncio.run(run_test())
+        self.assertEqual(result, [0, 1, 2])
+
+    def test_multi_loop_reinitialization(self):
+        """
+        Test that re-using an AsyncBulkCall instance across separate
+        `asyncio.run` statements does not hang.
+        """
+        execution = AsyncBulkCall(CallCounter(), size=5, delay=0.1)
+
+        # Run 1: First event loop lifecycle
+        result_1 = asyncio.run(self.execute(execution, count=5))
+        self.assertEqual(result_1, [(i, 0) for i in range(5)])
+
+        # Run 2: New event loop lifecycle.
+        # This will trigger the dynamic loop check and successfully reset the
+        # loop-bound objects
+        result_2 = asyncio.run(self.execute(execution, count=5))
+
+        # CallCounter is persistent on the execution instance, so calls are
+        # incremented to 1
+        self.assertEqual(result_2, [(i, 1) for i in range(5)])

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -112,7 +112,8 @@ class TestAsyncBulkCall(TestCase):
             abandoned_loop = asyncio.get_running_loop()
             fake_future = abandoned_loop.create_future()
 
-            # Dynamically initialize the loop synchronization reference just like __call__ does
+            # Dynamically initialize the loop synchronization reference just
+            # like __call__ does
             if abandoned_loop not in execution._loop_synchronization:
                 execution._loop_synchronization[abandoned_loop] = (
                     LoopSynchronization.create(execution._concurrency)
@@ -188,3 +189,71 @@ class TestAsyncBulkCall(TestCase):
         # CallCounter is persistent on the execution instance, so calls are
         # incremented to 1
         self.assertEqual(result_2, [(i, 1) for i in range(5)])
+
+    def test_final_guard_handles_late_enqueues(self):
+        """
+        Verifies that the final guard in _bulk_dispatch successfully respawns
+        a worker if a new item is queued during the teardown phase.
+        """
+        asyncio.run(self.check_final_guard_handles_late_enqueues())
+
+    async def check_final_guard_handles_late_enqueues(self):
+        # Using size=1 means every call immediately satisfies a complete bulk
+        execution = AsyncBulkCall(CallCounter(), size=1, delay=0.01)
+        current_loop = asyncio.get_running_loop()
+
+        # Pre-initialize loop-bound synchronization resources so we can grab the
+        # queue reference
+        if current_loop not in execution._loop_synchronization:
+            execution._loop_synchronization[current_loop] = LoopSynchronization.create(
+                execution._concurrency
+            )
+        synchronized_resources = execution._loop_synchronization[current_loop]
+
+        # Kick off an initial call to wake up the worker loop
+        task1_future = asyncio.create_task(execution("task_1"))
+
+        # Yield control to let _bulk_dispatch spin up, process task_1,
+        # and sit on the `await asyncio.sleep(0)` right before it checks the
+        # while loop condition again.
+        await asyncio.sleep(0)
+
+        # Manually inject a second task directly into the queue.
+        # This bypasses execution()'s worker-spawn checks, perfectly mimicking
+        # the race condition where an item lands in the queue right as the
+        # worker is shutting down.
+        result_future = current_loop.create_future()
+        synchronized_resources.queue.put_nowait(("task_2", result_future))
+
+        # Trick the while loop!
+        # We mock empty() to return True once so the main loop thinks it's done
+        # and exits.
+        # Subsequent calls will use the real method so the final guard sees the item.
+        original_empty = synchronized_resources.queue.empty
+        empty_called = False
+
+        def mock_empty():
+            nonlocal empty_called
+            if not empty_called:
+                empty_called = True
+                return True  # Force the while loop to exit
+            return original_empty()
+
+        synchronized_resources.queue.empty = mock_empty
+
+        # Await the late-arriving future with a brief timeout.
+        # If the final guard works, it notices the queue isn't empty, revives
+        # the dispatch loop, and resolves.
+        # If the final guard is missing or broken, this hangs forever and hits
+        # the timeout.
+        try:
+            await asyncio.wait_for(result_future, timeout=0.2)
+            self.assertTrue(result_future.done())
+            self.assertEqual(result_future.result(), ("task_2", 1))
+        except asyncio.TimeoutError:
+            self.fail(
+                "Task 2 was stranded in the queue! The final guard failed to respawn the worker."  # noqa B950
+            )
+
+        # Clean up the initial tracking future
+        await task1_future

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -257,3 +257,43 @@ class TestAsyncBulkCall(TestCase):
 
         # Clean up the initial tracking future
         await task1_future
+
+
+class TestLoopSynchronizationFactory(TestCase):
+    def test_create_inside_event_loop(self):
+        """
+        Verifies that create() successfully initializes LoopSynchronization
+        when an event loop is running.
+        """
+
+        async def run_test():
+            concurrency_limit = 5
+
+            # Call the factory method inside the running loop context
+            instance = LoopSynchronization.create(concurrency_limit)
+
+            # Assert correct types are initialized
+            self.assertIsInstance(instance, LoopSynchronization)
+            self.assertIsInstance(instance.queue, asyncio.Queue)
+            self.assertIsInstance(instance.semaphore, asyncio.BoundedSemaphore)
+
+            # Verify the semaphore's internal value matches our concurrency parameter
+            # Note: _value is an implementation detail of asyncio.BoundedSemaphore
+            self.assertEqual(instance.semaphore._value, concurrency_limit)
+
+        # asyncio.run handles setting up and tearing down a fresh event loop
+        asyncio.run(run_test())
+
+    def test_create_outside_event_loop_raises_error(self):
+        """
+        Verifies that create() raises a RuntimeError with the expected
+        explanatory message when called outside an active event loop.
+        """
+        # Ensure no event loop is running during this call
+        with self.assertRaises(RuntimeError) as context:
+            LoopSynchronization.create(concurrency=3)
+
+        self.assertIn(
+            "LoopSynchronization must be initialized within a running event loop.",
+            str(context.exception),
+        )

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -255,7 +255,6 @@ class TestAsyncBulkCall(TestCase):
                 "Task 2 was stranded in the queue! The final guard failed to respawn the worker."  # noqa B950
             )
 
-        # Clean up the initial tracking future
         await task1_future
 
 

--- a/tests/utilities_t/test_asyncbulkcall.py
+++ b/tests/utilities_t/test_asyncbulkcall.py
@@ -4,7 +4,7 @@ import sys
 from platform import python_implementation
 from unittest import TestCase
 
-from tardis.utilities.asyncbulkcall import AsyncBulkCall
+from tardis.utilities.asyncbulkcall import AsyncBulkCall, LoopSynchronization
 
 
 class CallCounter:
@@ -67,13 +67,16 @@ class TestAsyncBulkCall(TestCase):
         bunch_size = 4
         # use large delay to only trigger on size
         execution = AsyncBulkCall(CallCounter(), size=bunch_size // 2, delay=256)
+        current_loop = asyncio.get_running_loop()
         for repeat in range(6):
             result = await self.execute(execution, bunch_size)
             self.assertEqual(
                 result, [(i, i // 2 + repeat * 2) for i in range(bunch_size)]
             )
             await asyncio.sleep(0.01)  # pause to allow for cleanup
-            assert execution._dispatch_task is None
+
+            # Update: Check that the loop key has been removed from the weak dict
+            self.assertNotIn(current_loop, execution._dispatch_tasks)
 
     def test_sanity_checks(self):
         """Test against illegal settings"""
@@ -102,17 +105,28 @@ class TestAsyncBulkCall(TestCase):
         """
         execution = AsyncBulkCall(CallCounter(), size=100, delay=0.01)
 
+        abandoned_loop = None
+
         async def start_and_abandon():
-            loop = asyncio.get_running_loop()
-            fake_future = loop.create_future()
-            # This triggers initialization of self._loop_resources on the first loop
-            execution._queue.put_nowait((999, fake_future))
+            nonlocal abandoned_loop
+            abandoned_loop = asyncio.get_running_loop()
+            fake_future = abandoned_loop.create_future()
+
+            # Dynamically initialize the loop synchronization reference just like __call__ does
+            if abandoned_loop not in execution._loop_synchronization:
+                execution._loop_synchronization[abandoned_loop] = (
+                    LoopSynchronization.create(execution._concurrency)
+                )
+
+            execution._loop_synchronization[abandoned_loop].queue.put_nowait(
+                (999, fake_future)
+            )
 
         asyncio.run(start_and_abandon())
 
-        # Verify that the item is sitting stale inside the loop resources queue
-        self.assertIsNotNone(execution._loop_synchronization)
-        self.assertFalse(execution._loop_synchronization.queue.empty())
+        # Verify that the item is sitting stale inside the specific old loop's queue
+        self.assertIn(abandoned_loop, execution._loop_synchronization)
+        self.assertFalse(execution._loop_synchronization[abandoned_loop].queue.empty())
 
         # Move to a new event loop execution block
         async def verify_clean_slate():

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -1,8 +1,6 @@
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.utilities.asynccachemap import AsyncCacheMap
 
-from tests.utilities.utilities import run_async
-
 from json.decoder import JSONDecodeError
 from datetime import datetime
 from datetime import timedelta
@@ -10,6 +8,7 @@ from functools import partial
 from types import MappingProxyType
 from unittest import TestCase
 
+import asyncio
 import logging
 
 
@@ -36,7 +35,7 @@ class TestAsyncCacheMap(TestCase):
         return self.test_data
 
     def update_status(self):
-        run_async(self.async_cache_map.update_status)
+        asyncio.run(self.async_cache_map.update_status())
 
     def test_update_async_cache_map(self):
         self.update_status()
@@ -58,17 +57,17 @@ class TestAsyncCacheMap(TestCase):
 
     def test_json_failing_update(self):
         with self.assertLogs(level=logging.WARNING):
-            run_async(self.json_failing_async_cache_map.update_status)
+            asyncio.run(self.json_failing_async_cache_map.update_status())
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 
     def test_command_failing_update(self):
         with self.assertLogs(level=logging.WARNING):
-            run_async(self.json_failing_async_cache_map.update_status)
+            asyncio.run(self.json_failing_async_cache_map.update_status())
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
 
     def test_last_update(self):
         self.assertEqual(self.async_cache_map.last_update, datetime.fromtimestamp(0))
-        run_async(self.async_cache_map.update_status)
+        asyncio.run(self.async_cache_map.update_status())
         self.assertTrue(
             datetime.now() - self.async_cache_map.last_update < timedelta(seconds=1)
         )
@@ -83,7 +82,7 @@ class TestAsyncCacheMap(TestCase):
         self.assertFalse(self.async_cache_map != test_cache_map)
 
     def test_read_only_cache_returns_mappingproxy(self):
-        run_async(self.async_cache_map.update_status)  # populate data
+        asyncio.run(self.async_cache_map.update_status())  # populate data
         ro_cache = self.async_cache_map.read_only_cache
         self.assertIsInstance(ro_cache, MappingProxyType)
         self.assertEqual(dict(ro_cache), self.async_cache_map._data)

--- a/tests/utilities_t/test_pipeline.py
+++ b/tests/utilities_t/test_pipeline.py
@@ -1,8 +1,9 @@
 from tardis.utilities.pipeline import PipelineProcessor
 from tardis.utilities.pipeline import StopProcessing
-from tests.utilities.utilities import run_async
 
 from unittest import TestCase
+
+import asyncio
 
 
 class TestPipelineProcessor(TestCase):
@@ -16,10 +17,11 @@ class TestPipelineProcessor(TestCase):
 
     def test_pipeline_processor(self):
         self.assertEqual(
-            run_async(
-                self.pipeline_processor.run_pipeline,
-                pipeline_input=10,
-                drone="drone_place_holder",
+            asyncio.run(
+                self.pipeline_processor.run_pipeline(
+                    pipeline_input=10,
+                    drone="drone_place_holder",
+                )
             ),
             1,
         )
@@ -32,10 +34,11 @@ class TestPipelineProcessor(TestCase):
 
         self.pipeline_processor.add_to_pipeline(test_add)
         self.assertEqual(
-            run_async(
-                self.pipeline_processor.run_pipeline,
-                pipeline_input=10,
-                drone="drone_place_holder",
+            asyncio.run(
+                self.pipeline_processor.run_pipeline(
+                    pipeline_input=10,
+                    drone="drone_place_holder",
+                )
             ),
             2,
         )
@@ -48,10 +51,11 @@ class TestPipelineProcessor(TestCase):
 
         pipeline_processor = PipelineProcessor([test_stop_processing])
         self.assertEqual(
-            run_async(
-                pipeline_processor.run_pipeline,
-                pipeline_input=10,
-                drone="drone_place_holder",
+            asyncio.run(
+                pipeline_processor.run_pipeline(
+                    pipeline_input=10,
+                    drone="drone_place_holder",
+                )
             ),
             99,
         )


### PR DESCRIPTION
This PR refactors the asynchronous test utilities to use standard, non-deprecated patterns. Legacy custom async helpers have been removed.

- [x] Replace `run_async` by `asyncio.run`
- [x] Replace `async_return` by `AsyncMock`
- [x] Replace `set_awaitable_return` by `AsyncMock`
- [x] Improve AsyncBullCall to handle event loop replacements correctly (e.g. in uniitests)
- [x] Replace mock_executor_run_command by an improved variant, that can return multiple arbitary values
- [x] ~~Fix codeql version to be used~~ Already fixed by #416 