### PR TITLE
Fix pipelines

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,9 +31,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/tardis/utilities/attributedict.py
+++ b/tardis/utilities/attributedict.py
@@ -15,7 +15,9 @@ class AttributeDict(dict):
             return self[item]
         except KeyError:
             raise AttributeError(
-                f"{item} is not a valid attribute. Dict contains {str(self)}."
+                f"{item} is not a valid attribute. Dict contains {str(self)}.",
+                name=item,
+                obj=self,
             ) from None
 
     def __setattr__(self, key, value):
@@ -26,7 +28,9 @@ class AttributeDict(dict):
             del self[item]
         except KeyError:
             raise AttributeError(
-                f"{item} is not a valid attribute. Dict contains {str(self)}."
+                f"{item} is not a valid attribute. Dict contains {str(self)}.",
+                name=item,
+                obj=self,
             ) from None
 
     def __or__(self, other):

--- a/tests/rest_t/hash_credentials_t/test_hash_credentials.py
+++ b/tests/rest_t/hash_credentials_t/test_hash_credentials.py
@@ -16,9 +16,11 @@ class TestHashCredentials(TestCase):
         result = self.runner.invoke(self.app)
         self.assertNotEqual(result.exit_code, 0)
         try:
-            self.assertIn("Missing argument 'PASSWORD'.", result.stderr)
+            output = result.stderr
         except ValueError:
-            self.assertIn("Missing argument 'PASSWORD'.", result.stdout)
+            output = result.stdout
+        self.assertIn("Missing argument", output)
+        self.assertIn("password", output.lower())
 
         result = self.runner.invoke(self.app, "test_password")
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Things fixed:

- codeql: explicit state that building step is not needed for python code [source](https://github.com/github/codeql-action/blob/main/README.md)
- Adapt to latest `typer` version by checking for lower case "passwort"
- set "name" arg in `AttributeError` to call [ae.name](https://github.com/MatterMiners/tardis/blob/15c2c76121437fb05e0ff033b60e1467a51407f2/tardis/plugins/auditor.py#L73)