### PR TITLE
Group dependabot in minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       - "MatterMiners/review"
     cooldown:
       default-days: 7
+    groups:
+      gha minor:
+        update-types:
+          - "minor"
+      gha patches:
+        update-types:
+          - "patch"


### PR DESCRIPTION
Following the excellent work of @maxfischer2781, we adopt minor and patch update grouping for dependabot for TARDIS as well.  